### PR TITLE
Mark non-production integrations as Coming Soon

### DIFF
--- a/ui/src/pages/Integrations.tsx
+++ b/ui/src/pages/Integrations.tsx
@@ -46,6 +46,7 @@ export default function Integrations() {
   const deploy = manifests.filter((m) => m.kind === "deploy");
   const alert = manifests.filter((m) => m.kind === "alert");
   const stateOf = (name: string) => integrations.find((i) => i.plugin === name);
+  const COMING_SOON = new Set(["mdm", "ssh", "splunk"]);
 
   function StatusBadge({ st }: { st?: Integration }) {
     if (!st?.configured) {
@@ -86,12 +87,13 @@ export default function Integrations() {
         </div>
         {plugins.map((m) => {
           const st = stateOf(m.name);
+          const soon = COMING_SOON.has(m.name);
           return (
-            <div className="integration-row" key={m.name}>
+            <div className={`integration-row ${soon ? "disabled" : ""}`} key={m.name} title={soon ? "Coming soon" : ""}>
               <div>
                 <div className="row" style={{ gap: 8 }}>
                   <strong>{m.display_name}</strong>
-                  <StatusBadge st={st} />
+                  {soon ? <span className="soon">soon</span> : <StatusBadge st={st} />}
                 </div>
                 <div className="muted" style={{ marginTop: 4 }}>
                   {m.description}

--- a/ui/src/styles/app.css
+++ b/ui/src/styles/app.css
@@ -374,6 +374,7 @@ input[type="checkbox"]:focus-visible {
 .step-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--accent); font-weight: 700; margin-bottom: 10px; }
 .integration-row { display: flex; justify-content: space-between; align-items: center; padding: 14px 0; border-bottom: 1px solid var(--border); }
 .integration-row:last-child { border-bottom: none; }
+.integration-row.disabled { opacity: 0.5; pointer-events: none; }
 
 /* ── Settings grid ──────────────────────────────────────────── */
 .settings-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px 24px; padding: 8px 0; }


### PR DESCRIPTION
## Summary
- MDM (Jamf), SSH, and Splunk integrations are marked as "Coming Soon" in the Integrations UI
- Reuses the existing `.soon` badge and `.disabled` pattern from CreateTripwire
- Grayed out with `pointer-events: none` so users can't configure them

Closes #19