### PR TITLE
Fix trigger reviving failed deployments (#34)

### DIFF
--- a/server/thumper/api/routes.py
+++ b/server/thumper/api/routes.py
@@ -606,7 +606,9 @@ async def trigger(request: Request, background: BackgroundTasks,
         timestamp=data.get("timestamp") or iso_now(),
         triggered_by=data.get("triggered_by"),
     )
-    store.set_deployment_state(db, deployment.id, "planted")
+    # Only a pending deployment becomes planted. A failed one stays failed.
+    if deployment.state == "pending":
+        store.set_deployment_state(db, deployment.id, "planted")
     store.mark_deployment_triggered(db, deployment.id)
 
     background.add_task(deliver_alert, {

--- a/tests/test_trigger_delivery.py
+++ b/tests/test_trigger_delivery.py
@@ -5,9 +5,9 @@ from thumper.db import Deployment
 from thumper.services.signing import sign
 
 
-def _insert_deployment(db, *, did, secret, path):
+def _insert_deployment(db, *, did, secret, path, state="planted"):
     db.add(Deployment(id=did, tripwire_id="tw_1", endpoint_id="ep_1", path=path,
-                      content="bait-body", hmac_secret=secret, state="planted",
+                      content="bait-body", hmac_secret=secret, state=state,
                       created_at="2026-01-01T00:00:00Z"))
     db.commit()
 
@@ -45,3 +45,34 @@ def test_trigger_bad_signature_schedules_nothing(client_db, monkeypatch):
 
     assert resp.status_code == 401
     assert calls == []
+
+
+def test_trigger_does_not_revive_failed_deployment(client_db, monkeypatch):
+    tc, db = client_db
+    secret = "s3cr3t"
+    _insert_deployment(db, did="dep_1", secret=secret, path="/x", state="failed")
+    monkeypatch.setattr(routes, "deliver_alert", lambda event: None)
+
+    body = b"deployment_id=dep_1\nprocess=cat\n"
+    resp = tc.post("/api/trigger", content=body,
+                   headers={"X-Thumper-Signature": sign(secret, body)})
+
+    assert resp.status_code == 200
+    db.expire_all()
+    # a failed deployment must not be silently marked healthy by a trigger event
+    assert db.query(Deployment).filter(Deployment.id == "dep_1").first().state == "failed"
+
+
+def test_trigger_promotes_pending_to_planted(client_db, monkeypatch):
+    tc, db = client_db
+    secret = "s3cr3t"
+    _insert_deployment(db, did="dep_1", secret=secret, path="/x", state="pending")
+    monkeypatch.setattr(routes, "deliver_alert", lambda event: None)
+
+    body = b"deployment_id=dep_1\nprocess=cat\n"
+    resp = tc.post("/api/trigger", content=body,
+                   headers={"X-Thumper-Signature": sign(secret, body)})
+
+    assert resp.status_code == 200
+    db.expire_all()
+    assert db.query(Deployment).filter(Deployment.id == "dep_1").first().state == "planted"


### PR DESCRIPTION
Fixes #34.

The `/trigger` handler set state to `planted` on every event, silently
overwriting a `failed` deployment. Now promotes `pending` → `planted`
only; any other state is left untouched.