### PR TITLE
feat: add Helm chart for Kubernetes deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,22 @@ uvicorn thumper.main:app --reload --app-dir server     # → http://localhost:80
 cd ui && npm install && npm run dev                     # → http://localhost:5173
 ```
 </details>
+
+<details>
+<summary>Deploy on Kubernetes (Helm)</summary>
+
+A Helm chart lives in [`deploy/helm/thumper`](deploy/helm/thumper). Build and push the image from the `Dockerfile` first, then:
+
+```bash
+helm install thumper ./deploy/helm/thumper \
+  --set image.repository=ghcr.io/jestasecurity/thumper \
+  --set secrets.enrollToken=$(openssl rand -hex 24) \
+  --set secrets.installToken=$(openssl rand -hex 24) \
+  --set config.baseUrl=https://thumper.example.com
+```
+
+Defaults to SQLite on a PVC (single replica). Set `externalDatabase.url` for Postgres/MySQL. See [`values.yaml`](deploy/helm/thumper/values.yaml) for all options.
+</details>
 </p>
 
 <h2>Architecture</h2>

--- a/deploy/helm/thumper/.helmignore
+++ b/deploy/helm/thumper/.helmignore
@@ -1,0 +1,9 @@
+# Patterns to ignore when building Helm packages.
+.DS_Store
+.git/
+.gitignore
+*.tmproj
+*.bak
+*.tgz
+.idea/
+.vscode/

--- a/deploy/helm/thumper/Chart.yaml
+++ b/deploy/helm/thumper/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: thumper
+description: |
+  Thumper — a tripwire/canary-token honeypot platform. A single FastAPI monolith
+  (server + bundled React UI + plugins + agent installer) deployed as one container.
+type: application
+# Chart version — bump on chart changes.
+version: 0.1.0
+# Application version — tracks the thumper image release (pyproject.toml).
+appVersion: "0.1.0"
+home: https://github.com/jestasecurity/thumper
+sources:
+  - https://github.com/jestasecurity/thumper
+keywords:
+  - security
+  - honeypot
+  - tripwire
+  - canary
+maintainers:
+  - name: Jesta Security

--- a/deploy/helm/thumper/templates/_helpers.tpl
+++ b/deploy/helm/thumper/templates/_helpers.tpl
@@ -1,0 +1,90 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "thumper.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "thumper.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart name and version as used by the chart label.
+*/}}
+{{- define "thumper.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "thumper.labels" -}}
+helm.sh/chart: {{ include "thumper.chart" . }}
+{{ include "thumper.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "thumper.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "thumper.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+ServiceAccount name to use.
+*/}}
+{{- define "thumper.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "thumper.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Fully-qualified container image reference.
+*/}}
+{{- define "thumper.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end }}
+
+{{/*
+Name of the Secret holding tokens + THUMPER_DB (existing or chart-managed).
+*/}}
+{{- define "thumper.secretName" -}}
+{{- if .Values.secrets.existingSecret }}
+{{- .Values.secrets.existingSecret }}
+{{- else }}
+{{- include "thumper.fullname" . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Effective THUMPER_DB value: external URL if provided, else SQLite on the PVC.
+*/}}
+{{- define "thumper.databaseUrl" -}}
+{{- if .Values.externalDatabase.url }}
+{{- .Values.externalDatabase.url }}
+{{- else }}
+{{- printf "sqlite:///%s/thumper.db" (trimSuffix "/" .Values.persistence.mountPath) }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/thumper/templates/configmap.yaml
+++ b/deploy/helm/thumper/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "thumper.fullname" . }}
+  labels:
+    {{- include "thumper.labels" . | nindent 4 }}
+data:
+  THUMPER_BASE_URL: {{ .Values.config.baseUrl | quote }}
+  THUMPER_DASHBOARD_REFRESH: {{ .Values.config.dashboardRefresh | quote }}

--- a/deploy/helm/thumper/templates/deployment.yaml
+++ b/deploy/helm/thumper/templates/deployment.yaml
@@ -1,0 +1,107 @@
+{{- $usePersistence := and .Values.persistence.enabled (not .Values.externalDatabase.url) -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "thumper.fullname" . }}
+  labels:
+    {{- include "thumper.labels" . | nindent 4 }}
+spec:
+  # SQLite on a ReadWriteOnce volume cannot be shared; keep replicas at 1 unless
+  # using an external database.
+  replicas: {{ .Values.replicaCount }}
+  # Recreate (not RollingUpdate): the RWO PVC can't attach to old + new pods at once.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "thumper.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "thumper.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        # Roll pods when the config/secret content changes.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if not .Values.secrets.existingSecret }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "thumper.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: thumper
+          image: {{ include "thumper.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "thumper.fullname" . }}
+            - secretRef:
+                name: {{ include "thumper.secretName" . }}
+          {{- with .Values.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if $usePersistence }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+          {{- end }}
+      {{- if $usePersistence }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "thumper.fullname" .) }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/thumper/templates/ingress.yaml
+++ b/deploy/helm/thumper/templates/ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "thumper.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "thumper.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/thumper/templates/pvc.yaml
+++ b/deploy/helm/thumper/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (not .Values.externalDatabase.url) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "thumper.fullname" . }}
+  labels:
+    {{- include "thumper.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/thumper/templates/secret.yaml
+++ b/deploy/helm/thumper/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if not .Values.secrets.existingSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "thumper.fullname" . }}
+  labels:
+    {{- include "thumper.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  THUMPER_ENROLL_TOKEN: {{ .Values.secrets.enrollToken | quote }}
+  THUMPER_INSTALL_TOKEN: {{ .Values.secrets.installToken | quote }}
+  THUMPER_DB: {{ include "thumper.databaseUrl" . | quote }}
+{{- end }}

--- a/deploy/helm/thumper/templates/service.yaml
+++ b/deploy/helm/thumper/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "thumper.fullname" . }}
+  labels:
+    {{- include "thumper.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "thumper.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/thumper/templates/serviceaccount.yaml
+++ b/deploy/helm/thumper/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "thumper.serviceAccountName" . }}
+  labels:
+    {{- include "thumper.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/thumper/templates/tests/test-connection.yaml
+++ b/deploy/helm/thumper/templates/tests/test-connection.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "thumper.fullname" . }}-test-connection
+  labels:
+    {{- include "thumper.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: healthz
+      image: curlimages/curl:8.10.1
+      command: ["curl"]
+      args:
+        - "--fail"
+        - "--silent"
+        - "--show-error"
+        - "http://{{ include "thumper.fullname" . }}:{{ .Values.service.port }}/healthz"

--- a/deploy/helm/thumper/values.yaml
+++ b/deploy/helm/thumper/values.yaml
@@ -1,0 +1,136 @@
+# Default values for the thumper chart.
+# This is a YAML-formatted file. Values are documented inline.
+
+# -- Number of replicas. KEEP AT 1 with the default SQLite-on-PVC database:
+# the volume is ReadWriteOnce and SQLite (WAL mode) cannot be shared across
+# pods. Only raise this when using an external database (externalDatabase.url).
+replicaCount: 1
+
+image:
+  # -- Container image repository. You must build & push the image from the
+  # repo Dockerfile (e.g. `docker build -t ghcr.io/jestasecurity/thumper:0.1.0 .`).
+  repository: ghcr.io/jestasecurity/thumper
+  # -- Image tag. Defaults to the chart's appVersion when left empty.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+# -- Secrets for pulling the image from a private registry.
+imagePullSecrets: []
+
+# -- Override the chart name / fullname.
+nameOverride: ""
+fullnameOverride: ""
+
+# Non-secret application configuration (rendered into a ConfigMap).
+config:
+  # -- Public URL agents use to reach this server's /api/trigger callback.
+  # MUST be reachable from managed endpoints in production (set to your ingress
+  # host, e.g. https://thumper.example.com). THUMPER_BASE_URL.
+  baseUrl: "http://localhost:8000"
+  # -- Dashboard auto-refresh interval in seconds (0 disables). THUMPER_DASHBOARD_REFRESH.
+  dashboardRefresh: 60
+
+# Sensitive configuration (rendered into a Secret unless existingSecret is set).
+secrets:
+  # -- Shared enrollment token agents present to POST /api/enroll. REQUIRED in
+  # production — leaving this empty (or "dev-enroll-token") is insecure and the
+  # NOTES output will warn about it. THUMPER_ENROLL_TOKEN.
+  enrollToken: ""
+  # -- Admin token gating the installer endpoint (GET /api/install.sh). REQUIRED
+  # in production. THUMPER_INSTALL_TOKEN.
+  installToken: ""
+  # -- Use a pre-existing Secret instead of one managed by this chart. When set,
+  # the chart's Secret is not created and the values above are ignored. The
+  # referenced Secret must provide keys THUMPER_ENROLL_TOKEN, THUMPER_INSTALL_TOKEN
+  # and THUMPER_DB.
+  existingSecret: ""
+
+# External database. Leave url empty to use the bundled SQLite-on-PVC database.
+externalDatabase:
+  # -- Full SQLAlchemy database URL. When set, the PVC is not used and replicas
+  # may be scaled. Examples:
+  #   postgresql+psycopg://user:pass@host:5432/thumper
+  #   mysql+pymysql://user:pass@host:3306/thumper
+  # Stored in the chart Secret because it may embed credentials. THUMPER_DB.
+  url: ""
+
+# Persistent volume for the SQLite database (db + -wal + -shm files).
+persistence:
+  # -- Enable a PersistentVolumeClaim for SQLite. Set false when using
+  # externalDatabase.url.
+  enabled: true
+  # -- Reuse an existing PVC instead of creating one.
+  existingClaim: ""
+  size: 5Gi
+  # -- StorageClass. Empty uses the cluster default.
+  storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+  # -- Directory the database lives in (THUMPER_DB becomes
+  # sqlite:///<mountPath>/thumper.db).
+  mountPath: /data
+
+service:
+  type: ClusterIP
+  # -- Service port. Maps to the container's 8000.
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: thumper.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  # -- TLS config, e.g. [{ secretName: thumper-tls, hosts: [thumper.example.com] }]
+  tls: []
+
+serviceAccount:
+  # -- Create a dedicated ServiceAccount.
+  create: true
+  # -- Name to use. Generated from the fullname when empty.
+  name: ""
+  annotations: {}
+
+# -- Pod resource requests/limits.
+resources: {}
+  # limits:
+  #   cpu: 500m
+  #   memory: 512Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 256Mi
+
+# -- Liveness/readiness probe tuning (both hit GET /healthz on port 8000).
+probes:
+  liveness:
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    timeoutSeconds: 3
+    failureThreshold: 3
+  readiness:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3
+
+# -- Pod-level security context.
+podSecurityContext: {}
+  # fsGroup: 1000
+
+# -- Container-level security context.
+securityContext: {}
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# -- Extra environment variables (list of name/value or name/valueFrom maps).
+extraEnv: []
+
+podAnnotations: {}
+podLabels: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
## Summary
- Adds a Helm chart at `deploy/helm/thumper`.
- Deploys the monolith image. Port 8000. `/healthz` probes.
- Migrations run on startup. No init job needed.
- SQLite on a PVC by default. Single replica.
- Set `externalDatabase.url` for Postgres/MySQL. PVC drops, can scale.
- Templates: Deployment, Service, Ingress (off), Secret, ConfigMap, PVC, ServiceAccount.
- Tokens go in a Secret. `NOTES.txt` warns on insecure defaults.

## Test
- `helm lint` passes.
- Rendered SQLite, external-DB, existingSecret, and ingress paths.
- Live install on kind: pod Ready, migrations ran, `/healthz` returned 200, `helm test` passed.

Closes #8