### PR TITLE
fix: update broken Shai-Hulud news link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   </p>
   <p>
   <a href="docs/architecture.md"><strong>Get started »</strong></a>
-  <br />
+  |
   <a href="https://jesta.ai/thumper">Wesbite</a>
 </p>
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
   The tokens authenticate to nothing. A <b><em>read</em></b> is the signal.
   </p>
   <p>
-  <a href="docs/architecture.md"><strong>Get started »</strong></a>
-  |
   <a href="https://jesta.ai/thumper">Wesbite</a>
+  |
+  <a href="docs/architecture.md"><strong>Get started »</strong></a>
 </p>
 <p align="center">
    <img src="https://img.shields.io/badge/release-v0.1.0-yellow.svg" alt="PRs welcome" />

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   </p>
   <h1>Thumper</h1>
   <p align="center">
-  Plant fake-but-realistic credentials where the <a href="https://www.cisa.gov/news-events/alerts">Shai-Hulud</a>
+  Plant fake-but-realistic credentials where the <a href="https://www.securityweek.com/?s=shai+hulud">Shai-Hulud</a>
   npm supply-chain worm scans - and get alerted the instant one is read.
   <br />
   The tokens authenticate to nothing. A <b><em>read</em></b> is the signal.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
   </p>
   <p>
   <a href="docs/architecture.md"><strong>Get started »</strong></a>
+  <br />
+  <a href="https://jesta.ai/thumper">Wesbite</a>
 </p>
 <p align="center">
    <img src="https://img.shields.io/badge/release-v0.1.0-yellow.svg" alt="PRs welcome" />


### PR DESCRIPTION
## Summary
- Fixes #45
- Updates the Shai-Hulud reference link in the README from a generic CISA alerts page to a SecurityWeek search that surfaces relevant coverage

## Test plan
- [ ] Verify the new link resolves and returns Shai-Hulud results

🤖 Generated with [Claude Code](https://claude.com/claude-code)