### PR TITLE
fix: correct GHCR image namespace in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ permissions:
   packages: write
 
 env:
-  IMAGE: ghcr.io/jesta/thumper
+  IMAGE: ghcr.io/jestasecurity/thumper
 
 jobs:
   release:


### PR DESCRIPTION
## Summary
- Fixes #48
- Changes `ghcr.io/jesta/thumper` → `ghcr.io/jestasecurity/thumper` to match the repo owner

🤖 Generated with [Claude Code](https://claude.com/claude-code)