### PR TITLE
fix: show feedback when clipboard copy fails

### DIFF
--- a/ui/src/components/ui.tsx
+++ b/ui/src/components/ui.tsx
@@ -66,19 +66,23 @@ export function EndpointBadge({ status }: { status: EndpointStatus }) {
 
 /** Monospace block with a copy button - used for the install command. */
 export function CopyField({ value }: { value: string }) {
-  const [copied, setCopied] = useState(false);
+  const [label, setLabel] = useState("Copy");
   return (
     <div className="copyfield">
       <code>{value}</code>
       <button
         className="btn"
         onClick={() => {
-          navigator.clipboard?.writeText(value);
-          setCopied(true);
-          setTimeout(() => setCopied(false), 1200);
+          if (navigator.clipboard) {
+            navigator.clipboard.writeText(value);
+            setLabel("✓ Copied");
+          } else {
+            setLabel("Copy failed, try manually");
+          }
+          setTimeout(() => setLabel("Copy"), 1200);
         }}
       >
-        {copied ? "✓ Copied" : "Copy"}
+        {label}
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary
- Fixes #51
- Shows "Copy failed, try manually" when `navigator.clipboard` is unavailable instead of silently pretending the copy succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)