### PR TITLE
Restore Thumper gif to README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 <div align="center">
+  <p>
+    <a href="https://jesta.ai">
+      <img width="150" src="ui/public/thumper_gif.gif" alt="Thumper" />
+    </a>
+  </p>
   <h1>Thumper</h1>
   <p align="center">
   Plant fake-but-realistic credentials where the <a href="https://www.securityweek.com/?s=shai+hulud">Shai-Hulud</a>

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <div align="center">
-  <p>
+  <p align="center">
     <a href="https://jesta.ai">
       <img width="150" src="ui/public/thumper_gif.gif" alt="Thumper" />
     </a>
   </p>
-  <h1>Thumper</h1>
+  <h1 align="center">Thumper</h1>
   <p align="center">
   Plant fake-but-realistic credentials where the <a href="https://www.securityweek.com/?s=shai+hulud">Shai-Hulud</a>
   npm supply-chain worm scans - and get alerted the instant one is read.


### PR DESCRIPTION
Re-adds the header logo block that #47 removed. The gif file
(`ui/public/thumper_gif.gif`) was never deleted — only the README
markup referencing it — so this just restores the original `<img>` block
at the top of the README.