### PR TITLE
Alert management: resolve alerts (Open → Resolved)

### DIFF
--- a/server/thumper/api/routes.py
+++ b/server/thumper/api/routes.py
@@ -303,6 +303,12 @@ def list_alerts(status: str | None = Query(default=None, pattern="^(open|resolve
     return [_alert_out(alert) for alert in store.list_alerts(db, status=status)]
 
 
+@router.post("/alerts/resolve-all")
+def resolve_all_alerts(db: Session = Depends(get_db)):
+    """Bulk-resolve every open alert in one round trip."""
+    return {"resolved": store.resolve_all_alerts(db)}
+
+
 @router.post("/alerts/resolve")
 def resolve_deployment_alerts(body: ResolveAlertsIn, db: Session = Depends(get_db)):
     """Bulk-resolve every open alert for a deployment."""
@@ -311,9 +317,10 @@ def resolve_deployment_alerts(body: ResolveAlertsIn, db: Session = Depends(get_d
 
 @router.post("/alerts/{aid}/resolve", response_model=AlertOut)
 def resolve_alert(aid: str, db: Session = Depends(get_db)):
-    if not store.resolve_alert(db, aid):
+    alert = store.resolve_alert(db, aid)
+    if alert is None:
         raise HTTPException(404, "alert not found")
-    return _alert_out(store.get_alert(db, aid))
+    return _alert_out(alert)
 
 
 @router.get("/alerts/{aid}/deliveries", response_model=list[DeliveryOut])

--- a/server/thumper/api/routes.py
+++ b/server/thumper/api/routes.py
@@ -31,6 +31,7 @@ from ..models import (
     IntegrationTestResult,
     InstallCommandOut,
     InstallSpecOut,
+    ResolveAlertsIn,
     TokenPreviewIn,
     TokenPreviewOut,
     TripwireDetailOut,
@@ -124,6 +125,8 @@ def _alert_out(alert) -> AlertOut:
         accessed_path=alert.accessed_path, process=alert.process, pid=alert.pid,
         os_user=alert.os_user, event_type=alert.event_type,
         timestamp=alert.timestamp, triggered_by=alert.triggered_by,
+        status="resolved" if alert.resolved_at else "open",
+        resolved_at=alert.resolved_at,
     )
 
 
@@ -295,8 +298,22 @@ def unassign_tripwire(eid: str, tid: str, db: Session = Depends(get_db)):
 
 # ── alerts ───────────────────────────────────────────────────────────────────
 @router.get("/alerts", response_model=list[AlertOut])
-def list_alerts(db: Session = Depends(get_db)):
-    return [_alert_out(alert) for alert in store.list_alerts(db)]
+def list_alerts(status: str | None = Query(default=None, pattern="^(open|resolved)$"),
+                db: Session = Depends(get_db)):
+    return [_alert_out(alert) for alert in store.list_alerts(db, status=status)]
+
+
+@router.post("/alerts/resolve")
+def resolve_deployment_alerts(body: ResolveAlertsIn, db: Session = Depends(get_db)):
+    """Bulk-resolve every open alert for a deployment."""
+    return {"resolved": store.resolve_deployment_alerts(db, body.deployment_id)}
+
+
+@router.post("/alerts/{aid}/resolve", response_model=AlertOut)
+def resolve_alert(aid: str, db: Session = Depends(get_db)):
+    if not store.resolve_alert(db, aid):
+        raise HTTPException(404, "alert not found")
+    return _alert_out(store.get_alert(db, aid))
 
 
 @router.get("/alerts/{aid}/deliveries", response_model=list[DeliveryOut])

--- a/server/thumper/db.py
+++ b/server/thumper/db.py
@@ -82,6 +82,9 @@ class Alert(Base):
     __table_args__ = (
         Index("ix_alert_deployment", "deployment_id"),
         Index("ix_alert_tripwire", "tripwire_id"),
+        # Every active-count query filters resolved_at IS NULL; index it so those
+        # don't table-scan as alert history grows.
+        Index("ix_alert_resolved_at", "resolved_at"),
     )
 
 

--- a/server/thumper/db.py
+++ b/server/thumper/db.py
@@ -77,6 +77,8 @@ class Alert(Base):
     event_type = Column(String(255))
     timestamp = Column(String(255), nullable=False)
     triggered_by = Column(String(255))
+    # NULL = open (unresolved). Set to an ISO timestamp when a user resolves it.
+    resolved_at = Column(String(255))
     __table_args__ = (
         Index("ix_alert_deployment", "deployment_id"),
         Index("ix_alert_tripwire", "tripwire_id"),

--- a/server/thumper/migrations/versions/alert_resolved_at_v1.py
+++ b/server/thumper/migrations/versions/alert_resolved_at_v1.py
@@ -1,0 +1,29 @@
+"""Add alerts.resolved_at for alert lifecycle (Open → Resolved).
+
+NULL means the alert is open (unresolved); a timestamp means a user resolved it.
+Existing rows migrate to NULL, i.e. all currently-open - matching prior behavior
+where every fired alert counted as an active trigger.
+
+Revision ID: alert_resolved_at_v1
+Revises: deploy_fk_cascade_v1
+Create Date: 2026-06-17
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "alert_resolved_at_v1"
+down_revision: Union[str, None] = "deploy_fk_cascade_v1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("alerts") as b:
+        b.add_column(sa.Column("resolved_at", sa.String(length=255), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("alerts") as b:
+        b.drop_column("resolved_at")

--- a/server/thumper/migrations/versions/alert_resolved_at_v1.py
+++ b/server/thumper/migrations/versions/alert_resolved_at_v1.py
@@ -22,8 +22,11 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     with op.batch_alter_table("alerts") as b:
         b.add_column(sa.Column("resolved_at", sa.String(length=255), nullable=True))
+    # Active-count queries all filter resolved_at IS NULL - index it.
+    op.create_index("ix_alert_resolved_at", "alerts", ["resolved_at"])
 
 
 def downgrade() -> None:
+    op.drop_index("ix_alert_resolved_at", table_name="alerts")
     with op.batch_alter_table("alerts") as b:
         b.drop_column("resolved_at")

--- a/server/thumper/models.py
+++ b/server/thumper/models.py
@@ -105,6 +105,12 @@ class AlertOut(BaseModel):
     event_type: Optional[str] = None
     timestamp: str
     triggered_by: Optional[str] = None
+    status: str                              # "open" | "resolved"
+    resolved_at: Optional[str] = None
+
+
+class ResolveAlertsIn(BaseModel):
+    deployment_id: str
 
 
 class DeliveryOut(BaseModel):

--- a/server/thumper/store.py
+++ b/server/thumper/store.py
@@ -211,10 +211,9 @@ def resolve_deployment_alerts(db: Session, did: str) -> int:
     return n
 
 
-# The "triggered" rollups below count only OPEN (unresolved) alerts, so the red
-# "triggered" badges across the UI clear in lockstep with the dashboard's active
-# count once an operator resolves them. `count_alerts_since` is deliberately not
-# filtered - it's a 24h volume metric, not an active-state indicator.
+# The alert rollups below all count only OPEN (unresolved) alerts, so every
+# "triggered" badge and the 24h count across the UI clear in lockstep with the
+# dashboard's active count once an operator resolves them.
 def count_alerts_for_tripwire(db: Session, tripwire_id: str) -> int:
     return db.query(Alert).filter(
         Alert.tripwire_id == tripwire_id, Alert.resolved_at.is_(None)).count()
@@ -231,7 +230,9 @@ def count_alerts_for_deployment(db: Session, deployment_id: str) -> int:
 
 
 def count_alerts_since(db: Session, cutoff_iso: str) -> int:
-    return db.query(Alert).filter(Alert.timestamp >= cutoff_iso).count()
+    """Open alerts fired since the cutoff. Resolving one drops it from the count."""
+    return db.query(Alert).filter(
+        Alert.timestamp >= cutoff_iso, Alert.resolved_at.is_(None)).count()
 
 
 def count_distinct_alert_deployments(db: Session) -> int:

--- a/server/thumper/store.py
+++ b/server/thumper/store.py
@@ -175,8 +175,40 @@ def create_alert(db: Session, *, deployment_id: str, tripwire_id: str,
     return row
 
 
-def list_alerts(db: Session) -> list[Alert]:
-    return db.query(Alert).order_by(Alert.timestamp.desc()).all()
+def list_alerts(db: Session, status: Optional[str] = None) -> list[Alert]:
+    """All alerts, newest first. `status` optionally filters to "open"
+    (unresolved) or "resolved"; anything else returns all."""
+    q = db.query(Alert)
+    if status == "open":
+        q = q.filter(Alert.resolved_at.is_(None))
+    elif status == "resolved":
+        q = q.filter(Alert.resolved_at.isnot(None))
+    return q.order_by(Alert.timestamp.desc()).all()
+
+
+def get_alert(db: Session, aid: str) -> Optional[Alert]:
+    return db.query(Alert).filter(Alert.id == aid).first()
+
+
+def resolve_alert(db: Session, aid: str) -> bool:
+    """Mark one alert resolved. Idempotent; returns False if the id is unknown."""
+    alert = db.query(Alert).filter(Alert.id == aid).first()
+    if alert is None:
+        return False
+    if alert.resolved_at is None:
+        alert.resolved_at = iso_now()
+        db.commit()
+    return True
+
+
+def resolve_deployment_alerts(db: Session, did: str) -> int:
+    """Resolve every open alert for a deployment. Returns how many were newly
+    resolved (already-resolved alerts are left untouched and not counted)."""
+    n = db.query(Alert).filter(
+        Alert.deployment_id == did, Alert.resolved_at.is_(None),
+    ).update({Alert.resolved_at: iso_now()})
+    db.commit()
+    return n
 
 
 def count_alerts_for_tripwire(db: Session, tripwire_id: str) -> int:
@@ -196,7 +228,10 @@ def count_alerts_since(db: Session, cutoff_iso: str) -> int:
 
 
 def count_distinct_alert_deployments(db: Session) -> int:
-    return db.query(func.count(distinct(Alert.deployment_id))).scalar() or 0
+    """Deployments with at least one OPEN alert - i.e. still-active triggers.
+    Resolving a deployment's alerts removes it from this count."""
+    return db.query(func.count(distinct(Alert.deployment_id))).filter(
+        Alert.resolved_at.is_(None)).scalar() or 0
 
 
 # ── batched counts (avoid N+1 in list endpoints) ─────────────────────────────

--- a/server/thumper/store.py
+++ b/server/thumper/store.py
@@ -177,12 +177,15 @@ def create_alert(db: Session, *, deployment_id: str, tripwire_id: str,
 
 def list_alerts(db: Session, status: Optional[str] = None) -> list[Alert]:
     """All alerts, newest first. `status` optionally filters to "open"
-    (unresolved) or "resolved"; anything else returns all."""
+    (unresolved) or "resolved". An unrecognized value is a caller bug, not a
+    silent "return everything" - so it raises."""
     q = db.query(Alert)
     if status == "open":
         q = q.filter(Alert.resolved_at.is_(None))
     elif status == "resolved":
         q = q.filter(Alert.resolved_at.isnot(None))
+    elif status is not None:
+        raise ValueError(f"invalid alert status filter: {status!r}")
     return q.order_by(Alert.timestamp.desc()).all()
 
 
@@ -190,15 +193,16 @@ def get_alert(db: Session, aid: str) -> Optional[Alert]:
     return db.query(Alert).filter(Alert.id == aid).first()
 
 
-def resolve_alert(db: Session, aid: str) -> bool:
-    """Mark one alert resolved. Idempotent; returns False if the id is unknown."""
+def resolve_alert(db: Session, aid: str) -> Optional[Alert]:
+    """Mark one alert resolved and return it. Idempotent; returns None if the id
+    is unknown (so the caller has the row without a second query)."""
     alert = db.query(Alert).filter(Alert.id == aid).first()
     if alert is None:
-        return False
+        return None
     if alert.resolved_at is None:
         alert.resolved_at = iso_now()
         db.commit()
-    return True
+    return alert
 
 
 def resolve_deployment_alerts(db: Session, did: str) -> int:
@@ -207,6 +211,14 @@ def resolve_deployment_alerts(db: Session, did: str) -> int:
     n = db.query(Alert).filter(
         Alert.deployment_id == did, Alert.resolved_at.is_(None),
     ).update({Alert.resolved_at: iso_now()})
+    db.commit()
+    return n
+
+
+def resolve_all_alerts(db: Session) -> int:
+    """Resolve every open alert in one statement. Returns the count resolved."""
+    n = db.query(Alert).filter(Alert.resolved_at.is_(None)) \
+        .update({Alert.resolved_at: iso_now()})
     db.commit()
     return n
 

--- a/server/thumper/store.py
+++ b/server/thumper/store.py
@@ -211,16 +211,23 @@ def resolve_deployment_alerts(db: Session, did: str) -> int:
     return n
 
 
+# The "triggered" rollups below count only OPEN (unresolved) alerts, so the red
+# "triggered" badges across the UI clear in lockstep with the dashboard's active
+# count once an operator resolves them. `count_alerts_since` is deliberately not
+# filtered - it's a 24h volume metric, not an active-state indicator.
 def count_alerts_for_tripwire(db: Session, tripwire_id: str) -> int:
-    return db.query(Alert).filter(Alert.tripwire_id == tripwire_id).count()
+    return db.query(Alert).filter(
+        Alert.tripwire_id == tripwire_id, Alert.resolved_at.is_(None)).count()
 
 
 def count_alerts_for_endpoint(db: Session, endpoint_id: str) -> int:
-    return db.query(Alert).filter(Alert.endpoint_id == endpoint_id).count()
+    return db.query(Alert).filter(
+        Alert.endpoint_id == endpoint_id, Alert.resolved_at.is_(None)).count()
 
 
 def count_alerts_for_deployment(db: Session, deployment_id: str) -> int:
-    return db.query(Alert).filter(Alert.deployment_id == deployment_id).count()
+    return db.query(Alert).filter(
+        Alert.deployment_id == deployment_id, Alert.resolved_at.is_(None)).count()
 
 
 def count_alerts_since(db: Session, cutoff_iso: str) -> int:
@@ -249,13 +256,13 @@ def deployment_counts_by_endpoint(db: Session) -> dict[str, int]:
 
 def alert_counts_by_tripwire(db: Session) -> dict[str, int]:
     rows = db.query(Alert.tripwire_id, func.count(Alert.id)) \
-        .group_by(Alert.tripwire_id).all()
+        .filter(Alert.resolved_at.is_(None)).group_by(Alert.tripwire_id).all()
     return {tid: n for tid, n in rows}
 
 
 def alert_counts_by_endpoint(db: Session) -> dict[str, int]:
     rows = db.query(Alert.endpoint_id, func.count(Alert.id)) \
-        .group_by(Alert.endpoint_id).all()
+        .filter(Alert.resolved_at.is_(None)).group_by(Alert.endpoint_id).all()
     return {eid: n for eid, n in rows}
 
 

--- a/tests/test_alert_management.py
+++ b/tests/test_alert_management.py
@@ -117,3 +117,51 @@ def test_stats_active_triggers_reflects_open(client_db):
     assert tc.get("/api/stats").json()["active_triggers"] == 2
     tc.post("/api/alerts/resolve", json={"deployment_id": "dp_1"})
     assert tc.get("/api/stats").json()["active_triggers"] == 1
+
+
+# ── trigger counts everywhere reflect OPEN alerts only ───────────────────────
+
+def test_endpoint_trigger_count_is_open_only(client_db):
+    _, db = client_db
+    a = _mk(db, did="dp_1", eid="ep_1"); _mk(db, did="dp_2", eid="ep_1")
+    assert store.count_alerts_for_endpoint(db, "ep_1") == 2
+    store.resolve_alert(db, a.id)
+    assert store.count_alerts_for_endpoint(db, "ep_1") == 1
+
+
+def test_tripwire_trigger_count_is_open_only(client_db):
+    _, db = client_db
+    a = _mk(db, did="dp_1", tid="tw_1"); _mk(db, did="dp_2", tid="tw_1")
+    assert store.count_alerts_for_tripwire(db, "tw_1") == 2
+    store.resolve_alert(db, a.id)
+    assert store.count_alerts_for_tripwire(db, "tw_1") == 1
+
+
+def test_deployment_trigger_count_is_open_only(client_db):
+    _, db = client_db
+    a = _mk(db, did="dp_1"); _mk(db, did="dp_1")
+    assert store.count_alerts_for_deployment(db, "dp_1") == 2
+    store.resolve_alert(db, a.id)
+    assert store.count_alerts_for_deployment(db, "dp_1") == 1
+
+
+def test_batched_counts_are_open_only(client_db):
+    _, db = client_db
+    a = _mk(db, did="dp_1", eid="ep_1", tid="tw_1")
+    _mk(db, did="dp_2", eid="ep_1", tid="tw_1")
+    store.resolve_alert(db, a.id)
+    assert store.alert_counts_by_endpoint(db)["ep_1"] == 1
+    assert store.alert_counts_by_tripwire(db)["tw_1"] == 1
+
+
+def test_endpoints_api_trigger_count_decays(client_db):
+    tc, db = client_db
+    from thumper.db import Endpoint
+    db.add(Endpoint(id="ep_1", hostname="h", platform="linux", machine_id="m1",
+                    agent_token="t", enrolled_at="2026-01-01T00:00:00Z",
+                    last_seen="2026-01-01T00:00:00Z"))
+    db.commit()
+    _mk(db, did="dp_1", eid="ep_1")
+    assert tc.get("/api/endpoints").json()[0]["triggered_count"] == 1
+    tc.post("/api/alerts/resolve", json={"deployment_id": "dp_1"})
+    assert tc.get("/api/endpoints").json()[0]["triggered_count"] == 0

--- a/tests/test_alert_management.py
+++ b/tests/test_alert_management.py
@@ -41,17 +41,40 @@ def test_new_alert_is_open(client_db):
     assert a.resolved_at is None
 
 
-def test_resolve_alert_sets_timestamp(client_db):
+def test_resolve_alert_sets_timestamp_and_returns_row(client_db):
     _, db = client_db
     a = _mk(db, did="dp_1")
-    assert store.resolve_alert(db, a.id) is True
-    db.refresh(a)
-    assert a.resolved_at is not None
+    resolved = store.resolve_alert(db, a.id)
+    assert resolved is not None and resolved.id == a.id
+    assert resolved.resolved_at is not None
 
 
-def test_resolve_unknown_alert_returns_false(client_db):
+def test_resolve_unknown_alert_returns_none(client_db):
     _, db = client_db
-    assert store.resolve_alert(db, "nope") is False
+    assert store.resolve_alert(db, "nope") is None
+
+
+def test_list_alerts_invalid_status_raises(client_db):
+    _, db = client_db
+    with pytest.raises(ValueError):
+        store.list_alerts(db, status="typo")
+
+
+def test_resolve_all_alerts_store(client_db):
+    _, db = client_db
+    _mk(db, did="dp_1"); _mk(db, did="dp_2"); _mk(db, did="dp_3")
+    assert store.resolve_all_alerts(db) == 3
+    assert store.resolve_all_alerts(db) == 0  # nothing left open
+    assert store.list_alerts(db, status="open") == []
+
+
+def test_resolve_all_endpoint(client_db):
+    tc, db = client_db
+    _mk(db, did="dp_1"); _mk(db, did="dp_2")
+    resp = tc.post("/api/alerts/resolve-all")
+    assert resp.status_code == 200
+    assert resp.json() == {"resolved": 2}
+    assert tc.get("/api/stats").json()["active_triggers"] == 0
 
 
 def test_bulk_resolve_for_deployment(client_db):

--- a/tests/test_alert_management.py
+++ b/tests/test_alert_management.py
@@ -1,0 +1,119 @@
+"""Alert lifecycle: manual resolve (Open → Resolved), per-alert + bulk."""
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from thumper import store
+from thumper.db import Base, get_db
+from thumper.main import app
+
+
+@pytest.fixture
+def client_db():
+    engine = create_engine("sqlite://", echo=False,
+                           connect_args={"check_same_thread": False},
+                           poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    db = sessionmaker(bind=engine)()
+    app.dependency_overrides[get_db] = lambda: db
+    yield TestClient(app), db
+    del app.dependency_overrides[get_db]
+    db.close()
+
+
+def _mk(db, *, did, tid="tw_1", eid="ep_1"):
+    return store.create_alert(
+        db, deployment_id=did, tripwire_id=tid, endpoint_id=eid,
+        tripwire_name="AWS creds", endpoint_hostname="host-1", token_type="aws",
+        accessed_path="~/.aws/credentials", process="cat", pid=1, os_user="root",
+        event_type="openat", timestamp="2026-06-17T10:00:00Z", triggered_by="cat")
+
+
+# ── store ────────────────────────────────────────────────────────────────────
+
+def test_new_alert_is_open(client_db):
+    _, db = client_db
+    a = _mk(db, did="dp_1")
+    assert a.resolved_at is None
+
+
+def test_resolve_alert_sets_timestamp(client_db):
+    _, db = client_db
+    a = _mk(db, did="dp_1")
+    assert store.resolve_alert(db, a.id) is True
+    db.refresh(a)
+    assert a.resolved_at is not None
+
+
+def test_resolve_unknown_alert_returns_false(client_db):
+    _, db = client_db
+    assert store.resolve_alert(db, "nope") is False
+
+
+def test_bulk_resolve_for_deployment(client_db):
+    _, db = client_db
+    _mk(db, did="dp_1"); _mk(db, did="dp_1"); _mk(db, did="dp_2")
+    assert store.resolve_deployment_alerts(db, "dp_1") == 2
+    # a second call resolves nothing new
+    assert store.resolve_deployment_alerts(db, "dp_1") == 0
+    assert store.count_alerts_for_deployment(db, "dp_2") == 1
+
+
+def test_active_triggers_counts_open_deployments_only(client_db):
+    _, db = client_db
+    _mk(db, did="dp_1"); _mk(db, did="dp_2")
+    assert store.count_distinct_alert_deployments(db) == 2
+    store.resolve_deployment_alerts(db, "dp_1")
+    assert store.count_distinct_alert_deployments(db) == 1
+
+
+def test_list_alerts_status_filter(client_db):
+    _, db = client_db
+    a = _mk(db, did="dp_1"); _mk(db, did="dp_2")
+    store.resolve_alert(db, a.id)
+    assert len(store.list_alerts(db)) == 2
+    assert len(store.list_alerts(db, status="open")) == 1
+    assert len(store.list_alerts(db, status="resolved")) == 1
+
+
+# ── API ──────────────────────────────────────────────────────────────────────
+
+def test_alert_out_exposes_status(client_db):
+    tc, db = client_db
+    _mk(db, did="dp_1")
+    body = tc.get("/api/alerts").json()
+    assert body[0]["status"] == "open"
+    assert body[0]["resolved_at"] is None
+
+
+def test_resolve_alert_endpoint(client_db):
+    tc, db = client_db
+    a = _mk(db, did="dp_1")
+    resp = tc.post(f"/api/alerts/{a.id}/resolve")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "resolved"
+    assert resp.json()["resolved_at"] is not None
+
+
+def test_resolve_unknown_alert_endpoint_404(client_db):
+    tc, _ = client_db
+    assert tc.post("/api/alerts/nope/resolve").status_code == 404
+
+
+def test_bulk_resolve_endpoint(client_db):
+    tc, db = client_db
+    _mk(db, did="dp_1"); _mk(db, did="dp_1")
+    resp = tc.post("/api/alerts/resolve", json={"deployment_id": "dp_1"})
+    assert resp.status_code == 200
+    assert resp.json() == {"resolved": 2}
+    assert all(a["status"] == "resolved" for a in tc.get("/api/alerts").json())
+
+
+def test_stats_active_triggers_reflects_open(client_db):
+    tc, db = client_db
+    _mk(db, did="dp_1"); _mk(db, did="dp_2")
+    assert tc.get("/api/stats").json()["active_triggers"] == 2
+    tc.post("/api/alerts/resolve", json={"deployment_id": "dp_1"})
+    assert tc.get("/api/stats").json()["active_triggers"] == 1

--- a/tests/test_alert_management.py
+++ b/tests/test_alert_management.py
@@ -1,4 +1,6 @@
 """Alert lifecycle: manual resolve (Open → Resolved), per-alert + bulk."""
+from datetime import datetime, timezone
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
@@ -152,6 +154,20 @@ def test_batched_counts_are_open_only(client_db):
     store.resolve_alert(db, a.id)
     assert store.alert_counts_by_endpoint(db)["ep_1"] == 1
     assert store.alert_counts_by_tripwire(db)["tw_1"] == 1
+
+
+def test_stats_alerts_24h_excludes_resolved(client_db):
+    tc, db = client_db
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    a = store.create_alert(db, deployment_id="dp_1", tripwire_id="tw_1", endpoint_id="ep_1",
+                           tripwire_name="x", endpoint_hostname="h", token_type="aws",
+                           timestamp=now, triggered_by=None)
+    store.create_alert(db, deployment_id="dp_2", tripwire_id="tw_1", endpoint_id="ep_1",
+                       tripwire_name="x", endpoint_hostname="h", token_type="aws",
+                       timestamp=now, triggered_by=None)
+    assert tc.get("/api/stats").json()["alerts_24h"] == 2
+    store.resolve_alert(db, a.id)
+    assert tc.get("/api/stats").json()["alerts_24h"] == 1
 
 
 def test_endpoints_api_trigger_count_decays(client_db):

--- a/ui/src/api/http.ts
+++ b/ui/src/api/http.ts
@@ -86,6 +86,8 @@ export const httpApi = {
       method: "POST",
       body: JSON.stringify({ deployment_id: deploymentId }),
     }),
+  resolveAllAlerts: () =>
+    req<{ resolved: number }>("/alerts/resolve-all", { method: "POST" }),
 
   // Plugins / integrations
   listManifests: () => req<PluginManifest[]>("/manifests"),

--- a/ui/src/api/http.ts
+++ b/ui/src/api/http.ts
@@ -78,7 +78,14 @@ export const httpApi = {
       { method: "DELETE" }),
 
   // Alerts
-  listAlerts: () => req<Alert[]>("/alerts"),
+  listAlerts: (status?: "open" | "resolved") =>
+    req<Alert[]>(`/alerts${status ? `?status=${status}` : ""}`),
+  resolveAlert: (id: string) => req<Alert>(`/alerts/${id}/resolve`, { method: "POST" }),
+  resolveDeploymentAlerts: (deploymentId: string) =>
+    req<{ resolved: number }>("/alerts/resolve", {
+      method: "POST",
+      body: JSON.stringify({ deployment_id: deploymentId }),
+    }),
 
   // Plugins / integrations
   listManifests: () => req<PluginManifest[]>("/manifests"),

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -102,7 +102,11 @@ export interface Alert {
   event_type: string | null;
   timestamp: string;
   triggered_by: string | null;
+  status: AlertStatus;
+  resolved_at: string | null;
 }
+
+export type AlertStatus = "open" | "resolved";
 
 export interface ConfigField {
   key: string;

--- a/ui/src/components/ui.tsx
+++ b/ui/src/components/ui.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import type { ReactNode } from "react";
-import type { DeploymentState, EndpointStatus } from "../api";
+import type { AlertStatus, DeploymentState, EndpointStatus } from "../api";
 
 export function Topbar({ title, action }: { title: string; action?: ReactNode }) {
   return (
@@ -13,6 +13,15 @@ export function Topbar({ title, action }: { title: string; action?: ReactNode })
 
 export function TypeTag({ type }: { type: string }) {
   return <span className="type-tag">{type}</span>;
+}
+
+/** Alert lifecycle status: open (still active) or resolved (acknowledged). */
+export function AlertBadge({ status }: { status: AlertStatus }) {
+  return (
+    <span className={`badge ${status === "open" ? "triggered" : "resolved"}`}>
+      <span className="dot" /> {status}
+    </span>
+  );
 }
 
 /** Tripwire (definition) rollup status, derived from its instances. */

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -73,8 +73,7 @@ export default function Dashboard() {
   }
 
   function resolveAllOpen() {
-    const deployments = [...new Set(openAlerts.map((a) => a.deployment_id))];
-    Promise.all(deployments.map((d) => api.resolveDeploymentAlerts(d))).then(reload);
+    api.resolveAllAlerts().then(reload);
   }
 
   return (
@@ -115,7 +114,7 @@ export default function Dashboard() {
           </div>
           <div className="stat alert">
             <div className="stat-val">{stats?.alerts_24h ?? "-"}</div>
-            <div className="stat-label">Alerts (24h)</div>
+            <div className="stat-label">Open alerts (24h)</div>
           </div>
           <div className="stat alert">
             <div className="stat-val">{stats?.active_triggers ?? "-"}</div>

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -3,7 +3,9 @@ import { Link, useNavigate } from "react-router-dom";
 import { RefreshCw } from "lucide-react";
 import { api } from "../api";
 import type { Alert, DashboardStats, Tripwire } from "../api";
-import { TripwireBadge, TypeTag, Topbar, timeAgo } from "../components/ui.tsx";
+import { AlertBadge, TripwireBadge, TypeTag, Topbar, timeAgo } from "../components/ui.tsx";
+
+type AlertFilter = "open" | "all" | "resolved";
 
 export default function Dashboard() {
   const [stats, setStats] = useState<DashboardStats | null>(null);
@@ -13,6 +15,7 @@ export default function Dashboard() {
   const [countdown, setCountdown] = useState(60);
   const [spinning, setSpinning] = useState(false);
   const [flash, setFlash] = useState(false);
+  const [filter, setFilter] = useState<AlertFilter>("open");
   const nav = useNavigate();
   const countdownRef = useRef<ReturnType<typeof setInterval>>();
 
@@ -62,6 +65,18 @@ export default function Dashboard() {
     setCountdown(refreshInterval);
   }
 
+  const openAlerts = alerts.filter((a) => a.status === "open");
+  const shownAlerts = (filter === "all" ? alerts : alerts.filter((a) => a.status === filter));
+
+  function resolveOne(id: string) {
+    api.resolveAlert(id).then(reload);
+  }
+
+  function resolveAllOpen() {
+    const deployments = [...new Set(openAlerts.map((a) => a.deployment_id))];
+    Promise.all(deployments.map((d) => api.resolveDeploymentAlerts(d))).then(reload);
+  }
+
   return (
     <>
       <Topbar
@@ -81,9 +96,9 @@ export default function Dashboard() {
         }
       />
       <div className={`content${flash ? " reload-flash" : ""}`}>
-        {alerts.length > 0 && (
+        {openAlerts.length > 0 && (
           <div className="banner">
-            ⚠ <strong>{new Set(alerts.map((a) => a.endpoint_id)).size} endpoint(s) may be
+            ⚠ <strong>{new Set(openAlerts.map((a) => a.endpoint_id)).size} endpoint(s) may be
             compromised.</strong> A planted honeytoken was read - this almost always means a
             process is harvesting credentials.
           </div>
@@ -104,33 +119,57 @@ export default function Dashboard() {
           </div>
           <div className="stat alert">
             <div className="stat-val">{stats?.active_triggers ?? "-"}</div>
-            <div className="stat-label">Triggered instances</div>
+            <div className="stat-label">Active triggers</div>
           </div>
         </div>
 
         <div className="card">
           <div className="card-head">
             <h2>Recent alerts</h2>
-            <span className="muted">live trigger feed</span>
+            <span className="row" style={{ gap: 8, alignItems: "center" }}>
+              <span className="seg">
+                {(["open", "all", "resolved"] as AlertFilter[]).map((f) => (
+                  <button
+                    key={f}
+                    className={`seg-btn${filter === f ? " active" : ""}`}
+                    onClick={() => setFilter(f)}
+                  >
+                    {f}
+                  </button>
+                ))}
+              </span>
+              {openAlerts.length > 0 && (
+                <button className="btn small" onClick={resolveAllOpen}>
+                  Resolve all
+                </button>
+              )}
+            </span>
           </div>
-          {alerts.length === 0 ? (
-            <div className="empty">No alerts. All quiet on the endpoints. 🌵</div>
+          {shownAlerts.length === 0 ? (
+            <div className="empty">
+              {filter === "open"
+                ? "No open alerts. All quiet on the endpoints. 🌵"
+                : "Nothing here."}
+            </div>
           ) : (
             <table>
               <thead>
                 <tr>
                   <th>When</th>
+                  <th>Status</th>
                   <th>Endpoint</th>
                   <th>User</th>
                   <th>Process</th>
                   <th>Tripwire</th>
                   <th>Accessed path</th>
+                  <th></th>
                 </tr>
               </thead>
               <tbody>
-                {alerts.slice(0, 8).map((a) => (
+                {shownAlerts.slice(0, 8).map((a) => (
                   <tr key={a.id}>
                     <td className="muted">{timeAgo(a.timestamp)}</td>
+                    <td><AlertBadge status={a.status} /></td>
                     <td>
                       <Link to={`/endpoints/${a.endpoint_id}`}>{a.endpoint_hostname}</Link>
                     </td>
@@ -144,6 +183,13 @@ export default function Dashboard() {
                       <TypeTag type={a.token_type} />
                     </td>
                     <td className="path">{a.accessed_path ?? "-"}</td>
+                    <td style={{ textAlign: "right" }}>
+                      {a.status === "open" && (
+                        <button className="btn small" onClick={() => resolveOne(a.id)}>
+                          Resolve
+                        </button>
+                      )}
+                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/ui/src/styles/app.css
+++ b/ui/src/styles/app.css
@@ -202,6 +202,14 @@ tr.clickable:hover td { background: var(--bg-elev2); cursor: pointer; }
 .badge.pending { background: rgba(232, 200, 74, 0.12); color: var(--warn); border-color: rgba(232, 200, 74, 0.25); }
 .badge.failed, .badge.unknown,
 .badge.triggered { background: rgba(255, 93, 93, 0.12); color: var(--danger); border-color: rgba(255, 93, 93, 0.28); }
+.badge.resolved { background: rgba(139, 148, 168, 0.10); color: var(--text-dim); border-color: var(--border); }
+
+/* segmented filter (alert status: open / all / resolved) */
+.seg { display: inline-flex; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+.seg-btn { background: transparent; color: var(--text-dim); border: 0; padding: 5px 11px; font-size: 12px; cursor: pointer; text-transform: capitalize; }
+.seg-btn:not(:last-child) { border-right: 1px solid var(--border); }
+.seg-btn:hover { color: var(--text); }
+.seg-btn.active { background: var(--bg-elev2); color: var(--accent); }
 .dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; box-shadow: 0 0 6px 0 currentColor; }
 /* "live" pulse on healthy/online + active-threat badges */
 .badge.deployed .dot,


### PR DESCRIPTION
Alerts now have a lifecycle instead of staying active forever (#11). Adds a `resolved_at` field, per-alert and per-deployment resolve endpoints, and dashboard controls (status badge, Resolve, Resolve all, Open/All/Resolved filter). "Active triggers" now counts only deployments with open alerts, so it decays as you resolve. Manual-only, two-state.

Closes #11.