### PR TITLE
Endpoint decommission / remote self-destruct (#14)

### DIFF
--- a/agent/thumper_agent.sh
+++ b/agent/thumper_agent.sh
@@ -401,9 +401,17 @@ self_destruct() {
     curl -fsS -X POST "$SERVER/api/agent/decommissioned" \
         -H "Authorization: Bearer $tok" >/dev/null 2>&1 || log "decommission confirm failed"
     release_singleton
-    dir=$(dirname "$STATE_FILE")
     rm -f "$STATE_FILE" "$MANIFEST_FILE"
-    rm -rf "$dir"
+    # Delete our own install dir - but never a dangerous/shared path. A
+    # misconfigured --state-file (e.g. /state.json) must not turn this into
+    # `rm -rf /` or wipe a home dir; in that case we leave the dir and just exit.
+    dir=$(cd "$(dirname "$STATE_FILE")" 2>/dev/null && pwd) || dir=""
+    case "$dir" in
+        ""|/|/home|/Users|/root|/etc|/var|/usr|/tmp|/opt|"$HOME")
+            err "refusing to rm -rf install dir '$dir' (unsafe); leaving it in place" ;;
+        *)
+            rm -rf "$dir" ;;
+    esac
     log "agent removed"
     exit 0
 }

--- a/agent/thumper_agent.sh
+++ b/agent/thumper_agent.sh
@@ -366,10 +366,46 @@ heartbeat_loop() {
     while true; do
         sleep "$HEARTBEAT"
         tok=$(state_get "$STATE_FILE" agent_token)
-        curl -fsS -X POST "$SERVER/api/agent/heartbeat" \
-            -H "Authorization: Bearer $tok" >/dev/null 2>&1 \
-            || log "heartbeat failed"
+        # Capture the body: the server answers "decommission" (instead of "ok")
+        # to tell this agent to self-destruct. Signal the main process to do the
+        # teardown - it owns the watcher, lock, and traps.
+        resp=$(curl -fsS -X POST "$SERVER/api/agent/heartbeat" \
+            -H "Authorization: Bearer $tok" 2>/dev/null) || { log "heartbeat failed"; continue; }
+        if [ "$resp" = "decommission" ]; then
+            log "decommission signal received from server"
+            kill -USR1 "$MAIN_PID" 2>/dev/null
+            return
+        fi
     done
+}
+
+# Remove every bait this agent planted (from its manifest). Used by self-destruct.
+unplant_all() {
+    [ -f "${MANIFEST_FILE:-}" ] || return 0
+    while IFS= read -r p; do
+        [ -n "$p" ] || continue
+        rm -f "$p" && log "removed bait $p"
+    done < "$MANIFEST_FILE"
+}
+
+# Full self-destruct: stop watching, unplant all bait, confirm to the server so it
+# drops our record, release the lock, and delete our own install dir + state. Runs
+# in the main process via a USR1 trap so it can reach the watcher PID and lock.
+self_destruct() {
+    trap - EXIT INT TERM USR1     # we own teardown from here
+    log "self-destructing: unplanting all bait and removing agent"
+    stop_watcher 2>/dev/null
+    [ -n "${HEARTBEAT_PID:-}" ] && kill "$HEARTBEAT_PID" 2>/dev/null
+    unplant_all
+    tok=$(state_get "$STATE_FILE" agent_token)
+    curl -fsS -X POST "$SERVER/api/agent/decommissioned" \
+        -H "Authorization: Bearer $tok" >/dev/null 2>&1 || log "decommission confirm failed"
+    release_singleton
+    dir=$(dirname "$STATE_FILE")
+    rm -f "$STATE_FILE" "$MANIFEST_FILE"
+    rm -rf "$dir"
+    log "agent removed"
+    exit 0
 }
 
 dep_index_for_line() {  # echo the deployment index whose path appears in the line
@@ -577,6 +613,7 @@ verify_planted() {
 run() {
     STATE_FILE=${STATE_FILE:-$DEFAULT_STATE}
     MANIFEST_FILE="$(dirname "$STATE_FILE")/planted.list"
+    MAIN_PID=$$   # so the backgrounded heartbeat loop can signal us to self-destruct
     # Enforce one-agent-per-install before any work; a duplicate exits here (the
     # EXIT trap below is NOT yet set, so it can't disturb the live holder's lock).
     acquire_singleton
@@ -619,6 +656,8 @@ run() {
     cleanup_heartbeat() { [ -n "$HEARTBEAT_PID" ] && kill "$HEARTBEAT_PID" 2>/dev/null; }
     trap 'stop_watcher; cleanup_heartbeat; release_singleton; exit 0' INT TERM
     trap 'stop_watcher; cleanup_heartbeat; release_singleton' EXIT
+    # Remote kill: the heartbeat loop raises USR1 when the server flags us.
+    trap 'self_destruct' USR1
 
     start_watcher
 

--- a/agent/thumper_agent.sh
+++ b/agent/thumper_agent.sh
@@ -400,18 +400,13 @@ self_destruct() {
     tok=$(state_get "$STATE_FILE" agent_token)
     curl -fsS -X POST "$SERVER/api/agent/decommissioned" \
         -H "Authorization: Bearer $tok" >/dev/null 2>&1 || log "decommission confirm failed"
-    release_singleton
-    rm -f "$STATE_FILE" "$MANIFEST_FILE"
-    # Delete our own install dir - but never a dangerous/shared path. A
-    # misconfigured --state-file (e.g. /state.json) must not turn this into
-    # `rm -rf /` or wipe a home dir; in that case we leave the dir and just exit.
-    dir=$(cd "$(dirname "$STATE_FILE")" 2>/dev/null && pwd) || dir=""
-    case "$dir" in
-        ""|/|/home|/Users|/root|/etc|/var|/usr|/tmp|/opt|"$HOME")
-            err "refusing to rm -rf install dir '$dir' (unsafe); leaving it in place" ;;
-        *)
-            rm -rf "$dir" ;;
-    esac
+    release_singleton              # removes the agent.lock/ dir if it's ours
+    dir=$(dirname "$STATE_FILE")
+    # Remove only the files we created, then rmdir. No `rm -rf` on a derived path:
+    # rmdir is non-recursive and refuses a non-empty dir, so a misconfigured
+    # --state-file can never wipe '/', $HOME, or anything we didn't plant here.
+    rm -f "$STATE_FILE" "$MANIFEST_FILE" "$dir/agent.log" "$dir/thumper_agent.sh"
+    rmdir "$dir" 2>/dev/null || log "left $dir in place (not empty)"
     log "agent removed"
     exit 0
 }

--- a/server/thumper/api/routes.py
+++ b/server/thumper/api/routes.py
@@ -298,9 +298,10 @@ def unassign_tripwire(eid: str, tid: str, db: Session = Depends(get_db)):
 def decommission_endpoint(eid: str, db: Session = Depends(get_db)):
     """Flag the endpoint to self-destruct. The agent unplants all bait, removes
     itself, and confirms (then the row is deleted) on its next heartbeat."""
-    if not store.request_decommission(db, eid):
+    endpoint = store.request_decommission(db, eid)
+    if endpoint is None:
         raise HTTPException(404, "endpoint not found")
-    return _endpoint_out(db, store.get_endpoint(db, eid))
+    return _endpoint_out(db, endpoint)
 
 
 @router.delete("/endpoints/{eid}")
@@ -545,9 +546,16 @@ def agent_heartbeat(authorization: str = Header(default=""),
 def agent_decommissioned(authorization: str = Header(default=""),
                          db: Session = Depends(get_db)):
     """The agent confirms it has self-destructed; drop its record (and its
-    deployments). Alert history is preserved."""
-    endpoint = _authed_endpoint(db, authorization)
-    store.delete_endpoint(db, endpoint.id)
+    deployments). Alert history is preserved.
+
+    Idempotent: if the row is already gone (e.g. the operator force-removed it
+    while the agent was confirming), the desired end state is reached, so this is
+    still a success - it does NOT 401 like the other agent endpoints, since that
+    would make the agent log a spurious failure."""
+    token = authorization.removeprefix("Bearer ").strip()
+    endpoint = store.get_endpoint_by_token(db, token) if token else None
+    if endpoint is not None:
+        store.delete_endpoint(db, endpoint.id)
     return PlainTextResponse("ok\n")
 
 

--- a/server/thumper/api/routes.py
+++ b/server/thumper/api/routes.py
@@ -110,7 +110,8 @@ def _endpoint_out(db, endpoint, *, deployment_count=None, triggered_count=None) 
     return EndpointOut(
         id=endpoint_id, hostname=endpoint.hostname, platform=endpoint.platform,
         enrolled_at=endpoint.enrolled_at, last_seen=endpoint.last_seen,
-        status=_endpoint_status(endpoint.last_seen),
+        status="decommissioning" if endpoint.decommission_requested_at
+        else _endpoint_status(endpoint.last_seen),
         deployment_count=deployment_count,
         triggered_count=triggered_count,
     )
@@ -290,6 +291,24 @@ def unassign_tripwire(eid: str, tid: str, db: Session = Depends(get_db)):
     if deployment is None:
         raise HTTPException(404, "tripwire not assigned to this endpoint")
     store.delete_deployment(db, deployment.id)
+    return {"status": "ok"}
+
+
+@router.post("/endpoints/{eid}/decommission", response_model=EndpointOut)
+def decommission_endpoint(eid: str, db: Session = Depends(get_db)):
+    """Flag the endpoint to self-destruct. The agent unplants all bait, removes
+    itself, and confirms (then the row is deleted) on its next heartbeat."""
+    if not store.request_decommission(db, eid):
+        raise HTTPException(404, "endpoint not found")
+    return _endpoint_out(db, store.get_endpoint(db, eid))
+
+
+@router.delete("/endpoints/{eid}")
+def force_remove_endpoint(eid: str, db: Session = Depends(get_db)):
+    """Force-remove an endpoint without waiting for the agent to confirm. For a
+    dead/offline machine; any bait there stays planted until manually cleaned."""
+    if not store.delete_endpoint(db, eid):
+        raise HTTPException(404, "endpoint not found")
     return {"status": "ok"}
 
 
@@ -514,6 +533,21 @@ def agent_heartbeat(authorization: str = Header(default=""),
                     db: Session = Depends(get_db)):
     endpoint = _authed_endpoint(db, authorization)
     store.touch_endpoint(db, endpoint.id)
+    # The heartbeat doubles as the kill channel: a flagged endpoint is told to
+    # self-destruct here (an explicit signal, NOT a 401 - so it can't be confused
+    # with a revoked token, which would otherwise trigger a re-enroll).
+    if endpoint.decommission_requested_at:
+        return PlainTextResponse("decommission\n")
+    return PlainTextResponse("ok\n")
+
+
+@router.post("/agent/decommissioned", response_class=PlainTextResponse)
+def agent_decommissioned(authorization: str = Header(default=""),
+                         db: Session = Depends(get_db)):
+    """The agent confirms it has self-destructed; drop its record (and its
+    deployments). Alert history is preserved."""
+    endpoint = _authed_endpoint(db, authorization)
+    store.delete_endpoint(db, endpoint.id)
     return PlainTextResponse("ok\n")
 
 

--- a/server/thumper/db.py
+++ b/server/thumper/db.py
@@ -41,6 +41,10 @@ class Endpoint(Base):
     agent_token = Column(String(255), nullable=False)
     enrolled_at = Column(String(255), nullable=False)
     last_seen = Column(String(255))
+    # Set when the operator asks this endpoint to self-destruct. While non-NULL
+    # the endpoint shows as "decommissioning"; the agent gets a kill signal on its
+    # next heartbeat and the row is deleted once it confirms (or on force-remove).
+    decommission_requested_at = Column(String(255))
 
 
 class Deployment(Base):

--- a/server/thumper/migrations/versions/endpoint_decommission_v1.py
+++ b/server/thumper/migrations/versions/endpoint_decommission_v1.py
@@ -1,0 +1,29 @@
+"""Add endpoints.decommission_requested_at for remote self-destruct.
+
+NULL = live. A timestamp means the operator asked the endpoint to decommission;
+the agent gets a kill signal on its next heartbeat and the row is removed once it
+confirms (or via force-remove).
+
+Revision ID: endpoint_decommission_v1
+Revises: deploy_fk_cascade_v1
+Create Date: 2026-06-17
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "endpoint_decommission_v1"
+down_revision: Union[str, None] = "deploy_fk_cascade_v1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("endpoints") as b:
+        b.add_column(sa.Column("decommission_requested_at", sa.String(length=255), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("endpoints") as b:
+        b.drop_column("decommission_requested_at")

--- a/server/thumper/store.py
+++ b/server/thumper/store.py
@@ -103,16 +103,17 @@ def touch_endpoint(db: Session, eid: str) -> None:
     db.commit()
 
 
-def request_decommission(db: Session, eid: str) -> bool:
-    """Flag an endpoint for self-destruct. Idempotent; False if the id is unknown.
-    The agent picks up the kill signal on its next heartbeat."""
+def request_decommission(db: Session, eid: str) -> Optional[Endpoint]:
+    """Flag an endpoint for self-destruct and return it (so the caller has the row
+    without a second query). Idempotent; None if the id is unknown. The agent
+    picks up the kill signal on its next heartbeat."""
     ep = db.query(Endpoint).filter(Endpoint.id == eid).first()
     if ep is None:
-        return False
+        return None
     if ep.decommission_requested_at is None:
         ep.decommission_requested_at = iso_now()
         db.commit()
-    return True
+    return ep
 
 
 def delete_endpoint(db: Session, eid: str) -> bool:

--- a/server/thumper/store.py
+++ b/server/thumper/store.py
@@ -103,6 +103,32 @@ def touch_endpoint(db: Session, eid: str) -> None:
     db.commit()
 
 
+def request_decommission(db: Session, eid: str) -> bool:
+    """Flag an endpoint for self-destruct. Idempotent; False if the id is unknown.
+    The agent picks up the kill signal on its next heartbeat."""
+    ep = db.query(Endpoint).filter(Endpoint.id == eid).first()
+    if ep is None:
+        return False
+    if ep.decommission_requested_at is None:
+        ep.decommission_requested_at = iso_now()
+        db.commit()
+    return True
+
+
+def delete_endpoint(db: Session, eid: str) -> bool:
+    """Remove an endpoint and its deployments. Alert history is kept (it carries
+    a denormalized hostname, so it stands alone). Returns whether a row existed.
+    Deployments are deleted explicitly (not relying on the FK cascade, which
+    SQLite only honors with foreign_keys=ON), mirroring delete_tripwire."""
+    ep = db.query(Endpoint).filter(Endpoint.id == eid).first()
+    if ep is None:
+        return False
+    db.query(Deployment).filter(Deployment.endpoint_id == eid).delete()
+    db.delete(ep)
+    db.commit()
+    return True
+
+
 # ── deployments (instances) ──────────────────────────────────────────────────
 def materialize_deployment(db: Session, *, tripwire_id: str, endpoint_id: str,
                            path: str, content: str) -> Deployment:

--- a/tests/test_endpoint_decommission.py
+++ b/tests/test_endpoint_decommission.py
@@ -1,0 +1,129 @@
+"""Remote endpoint self-destruct: request → kill signal on heartbeat → confirm/delete."""
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from thumper import store
+from thumper.db import Alert, Base, Deployment, Endpoint, get_db
+from thumper.main import app
+
+
+@pytest.fixture
+def client_db():
+    engine = create_engine("sqlite://", echo=False,
+                           connect_args={"check_same_thread": False},
+                           poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    db = sessionmaker(bind=engine)()
+    app.dependency_overrides[get_db] = lambda: db
+    yield TestClient(app), db
+    del app.dependency_overrides[get_db]
+    db.close()
+
+
+def _raw_endpoint(db, eid, token):
+    ep = Endpoint(id=eid, hostname="host-1", platform="linux", machine_id=f"m-{eid}",
+                  agent_token=token, enrolled_at="2026-01-01T00:00:00Z",
+                  last_seen="2026-06-17T12:00:00Z")
+    db.add(ep); db.commit()
+    return ep
+
+
+def _deployment(db, did, eid):
+    db.add(Deployment(id=did, tripwire_id="tw_1", endpoint_id=eid, path="/x",
+                      content="bait", hmac_secret="s", state="planted",
+                      created_at="2026-01-01T00:00:00Z"))
+    db.commit()
+
+
+# ── store ────────────────────────────────────────────────────────────────────
+
+def test_request_decommission_sets_flag(client_db):
+    _, db = client_db
+    _raw_endpoint(db, "ep_1", "tok_1")
+    assert store.request_decommission(db, "ep_1") is True
+    assert store.get_endpoint(db, "ep_1").decommission_requested_at is not None
+
+
+def test_request_decommission_unknown_returns_false(client_db):
+    _, db = client_db
+    assert store.request_decommission(db, "nope") is False
+
+
+def test_delete_endpoint_removes_deployments_keeps_alerts(client_db):
+    _, db = client_db
+    _raw_endpoint(db, "ep_1", "tok_1")
+    _deployment(db, "dp_1", "ep_1")
+    store.create_alert(db, deployment_id="dp_1", tripwire_id="tw_1", endpoint_id="ep_1",
+                       tripwire_name="t", endpoint_hostname="host-1", token_type="aws",
+                       timestamp="2026-06-17T10:00:00Z", triggered_by=None)
+    assert store.delete_endpoint(db, "ep_1") is True
+    assert store.get_endpoint(db, "ep_1") is None
+    assert db.query(Deployment).filter(Deployment.endpoint_id == "ep_1").count() == 0
+    assert db.query(Alert).filter(Alert.endpoint_id == "ep_1").count() == 1  # history kept
+
+
+# ── API ──────────────────────────────────────────────────────────────────────
+
+def test_decommission_endpoint_endpoint(client_db):
+    tc, db = client_db
+    _raw_endpoint(db, "ep_1", "tok_1")
+    resp = tc.post("/api/endpoints/ep_1/decommission")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "decommissioning"
+    db.expire_all()
+    assert store.get_endpoint(db, "ep_1").decommission_requested_at is not None
+
+
+def test_decommission_unknown_404(client_db):
+    tc, _ = client_db
+    assert tc.post("/api/endpoints/nope/decommission").status_code == 404
+
+
+def test_heartbeat_returns_ok_when_live(client_db):
+    tc, db = client_db
+    _raw_endpoint(db, "ep_1", "tok_1")
+    resp = tc.post("/api/agent/heartbeat", headers={"Authorization": "Bearer tok_1"})
+    assert resp.status_code == 200
+    assert resp.text.strip() == "ok"
+
+
+def test_heartbeat_returns_kill_signal_when_decommissioning(client_db):
+    tc, db = client_db
+    _raw_endpoint(db, "ep_1", "tok_1")
+    store.request_decommission(db, "ep_1")
+    resp = tc.post("/api/agent/heartbeat", headers={"Authorization": "Bearer tok_1"})
+    assert resp.status_code == 200
+    assert resp.text.strip() == "decommission"
+
+
+def test_agent_confirm_deletes_endpoint(client_db):
+    tc, db = client_db
+    _raw_endpoint(db, "ep_1", "tok_1")
+    _deployment(db, "dp_1", "ep_1")
+    store.request_decommission(db, "ep_1")
+    resp = tc.post("/api/agent/decommissioned", headers={"Authorization": "Bearer tok_1"})
+    assert resp.status_code == 200
+    db.expire_all()
+    assert store.get_endpoint(db, "ep_1") is None
+
+
+def test_force_delete_endpoint(client_db):
+    tc, db = client_db
+    _raw_endpoint(db, "ep_1", "tok_1")
+    _deployment(db, "dp_1", "ep_1")
+    resp = tc.delete("/api/endpoints/ep_1")
+    assert resp.status_code == 200
+    db.expire_all()
+    assert store.get_endpoint(db, "ep_1") is None
+    assert db.query(Deployment).filter(Deployment.endpoint_id == "ep_1").count() == 0
+
+
+def test_endpoints_list_shows_decommissioning_status(client_db):
+    tc, db = client_db
+    _raw_endpoint(db, "ep_1", "tok_1")
+    store.request_decommission(db, "ep_1")
+    body = tc.get("/api/endpoints").json()
+    assert body[0]["status"] == "decommissioning"

--- a/tests/test_endpoint_decommission.py
+++ b/tests/test_endpoint_decommission.py
@@ -40,16 +40,17 @@ def _deployment(db, did, eid):
 
 # ── store ────────────────────────────────────────────────────────────────────
 
-def test_request_decommission_sets_flag(client_db):
+def test_request_decommission_sets_flag_and_returns_row(client_db):
     _, db = client_db
     _raw_endpoint(db, "ep_1", "tok_1")
-    assert store.request_decommission(db, "ep_1") is True
-    assert store.get_endpoint(db, "ep_1").decommission_requested_at is not None
+    ep = store.request_decommission(db, "ep_1")
+    assert ep is not None and ep.id == "ep_1"
+    assert ep.decommission_requested_at is not None
 
 
-def test_request_decommission_unknown_returns_false(client_db):
+def test_request_decommission_unknown_returns_none(client_db):
     _, db = client_db
-    assert store.request_decommission(db, "nope") is False
+    assert store.request_decommission(db, "nope") is None
 
 
 def test_delete_endpoint_removes_deployments_keeps_alerts(client_db):
@@ -108,6 +109,15 @@ def test_agent_confirm_deletes_endpoint(client_db):
     assert resp.status_code == 200
     db.expire_all()
     assert store.get_endpoint(db, "ep_1") is None
+
+
+def test_agent_confirm_is_idempotent_when_already_removed(client_db):
+    # Operator force-removed the endpoint while the agent was confirming: the row
+    # (and token) are already gone. Confirm must still succeed, not 401.
+    tc, _ = client_db
+    resp = tc.post("/api/agent/decommissioned", headers={"Authorization": "Bearer gone"})
+    assert resp.status_code == 200
+    assert resp.text.strip() == "ok"
 
 
 def test_force_delete_endpoint(client_db):

--- a/ui/src/api/http.ts
+++ b/ui/src/api/http.ts
@@ -76,6 +76,12 @@ export const httpApi = {
   unassignTripwire: (eid: string, tripwireId: string) =>
     req<{ status: string }>(`/endpoints/${eid}/tripwires/${tripwireId}`,
       { method: "DELETE" }),
+  // Flag the endpoint to self-destruct (agent unplants + removes itself on its
+  // next heartbeat); or force-remove a dead one outright.
+  decommissionEndpoint: (eid: string) =>
+    req<Endpoint>(`/endpoints/${eid}/decommission`, { method: "POST" }),
+  removeEndpoint: (eid: string) =>
+    req<{ status: string }>(`/endpoints/${eid}`, { method: "DELETE" }),
 
   // Alerts
   listAlerts: () => req<Alert[]>("/alerts"),

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -10,7 +10,7 @@ export type CredentialSource = "template" | "custom" | "managed";
 /** Per-endpoint instance lifecycle. */
 export type DeploymentState = "pending" | "planted" | "failed";
 
-export type EndpointStatus = "online" | "stale" | "inactive";
+export type EndpointStatus = "online" | "stale" | "inactive" | "decommissioning";
 
 export interface TokenTypeInfo {
   type: TokenType;

--- a/ui/src/components/ui.tsx
+++ b/ui/src/components/ui.tsx
@@ -57,8 +57,8 @@ export function DeployBadge({ state, triggered }: { state: DeploymentState; trig
 
 export function EndpointBadge({ status }: { status: EndpointStatus }) {
   const cls = status === "online" ? "deployed"
-    : status === "stale" || status === "decommissioning" ? "pending"
-    : "failed";
+    : status === "stale" ? "pending"
+    : "failed";   // inactive + decommissioning both use the red/danger style
   return (
     <span className={`badge ${cls}`}>
       <span className="dot" /> {status}

--- a/ui/src/components/ui.tsx
+++ b/ui/src/components/ui.tsx
@@ -56,7 +56,9 @@ export function DeployBadge({ state, triggered }: { state: DeploymentState; trig
 }
 
 export function EndpointBadge({ status }: { status: EndpointStatus }) {
-  const cls = status === "online" ? "deployed" : status === "stale" ? "pending" : "failed";
+  const cls = status === "online" ? "deployed"
+    : status === "stale" || status === "decommissioning" ? "pending"
+    : "failed";
   return (
     <span className={`badge ${cls}`}>
       <span className="dot" /> {status}

--- a/ui/src/pages/EndpointDetail.tsx
+++ b/ui/src/pages/EndpointDetail.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { Trash2 } from "lucide-react";
 import { api } from "../api";
 import type { EndpointDetail as ED, Tripwire } from "../api";
@@ -23,7 +23,9 @@ export default function EndpointDetail() {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [removing, setRemoving] = useState<{ tripwireId: string; name: string } | null>(null);
+  const [confirm, setConfirm] = useState<"decommission" | "force" | null>(null);
   const pickerRef = useRef<HTMLDivElement>(null);
+  const nav = useNavigate();
 
   const reload = useCallback(() => {
     api.getEndpoint(id).then(setEp);
@@ -62,9 +64,27 @@ export default function EndpointDetail() {
     }
   }
 
+  const decommissioning = ep.status === "decommissioning";
+
   return (
     <>
-      <Topbar title={ep.hostname} />
+      <Topbar
+        title={ep.hostname}
+        action={
+          decommissioning ? (
+            <span className="row" style={{ gap: 10, alignItems: "center" }}>
+              <span className="muted">decommissioning…</span>
+              <button className="btn danger" disabled={busy} onClick={() => setConfirm("force")}>
+                Force remove
+              </button>
+            </span>
+          ) : (
+            <button className="btn danger" disabled={busy} onClick={() => setConfirm("decommission")}>
+              Decommission
+            </button>
+          )
+        }
+      />
       <div className="content">
         <div className="card">
           <div className="row" style={{ gap: 10 }}>
@@ -157,6 +177,41 @@ export default function EndpointDetail() {
           )}
         </div>
       </div>
+
+      {confirm === "decommission" && (
+        <Modal onClose={() => setConfirm(null)}>
+          <div className="card-head"><h2>Decommission endpoint</h2></div>
+          <p className="modal-intro">
+            Tell <strong>{ep.hostname}</strong> to self-destruct? On its next check-in the agent
+            unplants all its bait, removes itself, and disappears from the dashboard. This can't be undone.
+          </p>
+          <div className="row" style={{ gap: 8 }}>
+            <button className="btn danger" onClick={() => {
+              setConfirm(null);
+              act(() => api.decommissionEndpoint(id));
+            }}>Decommission</button>
+            <button className="btn" onClick={() => setConfirm(null)}>Cancel</button>
+          </div>
+        </Modal>
+      )}
+
+      {confirm === "force" && (
+        <Modal onClose={() => setConfirm(null)}>
+          <div className="card-head"><h2>Force remove endpoint</h2></div>
+          <p className="modal-intro">
+            Remove <strong>{ep.hostname}</strong> from the dashboard now, without waiting for the
+            agent to confirm. Use this only for a dead/offline machine - any bait already planted
+            there will stay until cleaned up manually.
+          </p>
+          <div className="row" style={{ gap: 8 }}>
+            <button className="btn danger" onClick={() => {
+              setConfirm(null);
+              act(async () => { await api.removeEndpoint(id); nav("/endpoints"); });
+            }}>Force remove</button>
+            <button className="btn" onClick={() => setConfirm(null)}>Cancel</button>
+          </div>
+        </Modal>
+      )}
 
       {removing && (
         <Modal onClose={() => setRemoving(null)}>


### PR DESCRIPTION
Closes #14 (remove side; the add/install command already exists).

Adds a dashboard **Decommission** action for an endpoint. Because the agent is pull-based, the kill rides the heartbeat: a flagged endpoint gets a `decommission` reply (an explicit signal, not a 401, so it can't be mistaken for a revoked token → re-enroll). The agent then unplants all its bait, removes its own install dir + state, confirms via `POST /api/agent/decommissioned`, and the record is deleted. **Force remove** drops a dead/offline endpoint's row outright.

- `Endpoint.decommission_requested_at` column + Alembic migration; status derives `decommissioning`.
- `POST /api/endpoints/{id}/decommission`, `DELETE /api/endpoints/{id}`, `POST /api/agent/decommissioned`; heartbeat returns the sentinel when flagged.
- Agent: heartbeat detects the signal → `self_destruct` (unplant-all, confirm, remove install).
- UI: Decommission button + confirm on EndpointDetail, `decommissioning` badge, Force remove.
- 10 TDD tests; full suite 158 passing.

Note: this migration and #56's both branch from `deploy_fk_cascade_v1`; whichever merges second I'll rebase + chain so Alembic stays single-head.