### PR TITLE
Detail pages: not-found state instead of infinite Loading (#21)

### DIFF
--- a/ui/src/pages/EndpointDetail.tsx
+++ b/ui/src/pages/EndpointDetail.tsx
@@ -24,11 +24,14 @@ export default function EndpointDetail() {
   const [error, setError] = useState<string | null>(null);
   const [removing, setRemoving] = useState<{ tripwireId: string; name: string } | null>(null);
   const [confirm, setConfirm] = useState<"decommission" | "force" | null>(null);
+  const [notFound, setNotFound] = useState(false);
   const pickerRef = useRef<HTMLDivElement>(null);
   const nav = useNavigate();
 
+  // A bad/deleted id rejects the promise; show a terminal not-found state instead
+  // of hanging on "Loading…" forever (#21).
   const reload = useCallback(() => {
-    api.getEndpoint(id).then(setEp);
+    api.getEndpoint(id).then(setEp).catch(() => setNotFound(true));
   }, [id]);
 
   useEffect(() => {
@@ -45,6 +48,17 @@ export default function EndpointDetail() {
     return () => document.removeEventListener("mousedown", close);
   }, [showPicker]);
 
+  if (notFound) return (
+    <>
+      <Topbar title="Endpoint not found" />
+      <div className="content">
+        <div className="empty">
+          This endpoint doesn't exist or was removed.{" "}
+          <Link to="/endpoints">← All endpoints</Link>
+        </div>
+      </div>
+    </>
+  );
   if (!ep) return <div className="content">Loading…</div>;
 
   const onEndpoint = new Set(ep.deployments.map((d) => d.tripwire_id));

--- a/ui/src/pages/TripwireDetail.tsx
+++ b/ui/src/pages/TripwireDetail.tsx
@@ -17,8 +17,11 @@ export default function TripwireDetail() {
   const [draft, setDraft] = useState("");
   const [busy, setBusy] = useState(false);
   const [actionErr, setActionErr] = useState<string | null>(null);
+  const [notFound, setNotFound] = useState(false);
 
-  const load = () => api.getTripwire(id).then(setTw);
+  // A bad/deleted id rejects the promise; show a terminal not-found state instead
+  // of hanging on "Loading…" forever (#21).
+  const load = () => api.getTripwire(id).then(setTw).catch(() => setNotFound(true));
   useEffect(() => {
     load();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -64,6 +67,17 @@ export default function TripwireDetail() {
     }
   }
 
+  if (notFound) return (
+    <>
+      <Topbar title="Tripwire not found" />
+      <div className="content">
+        <div className="empty">
+          This tripwire doesn't exist or was deleted.{" "}
+          <Link to="/tripwires">← All tripwires</Link>
+        </div>
+      </div>
+    </>
+  );
   if (!tw) return <div className="content">Loading…</div>;
 
   return (


### PR DESCRIPTION
Closes #21.

`TripwireDetail`/`EndpointDetail` awaited `getTripwire`/`getEndpoint` with no error handling, so a 404 (bad URL, or the resource deleted in another tab) rejected the promise and the page stayed on "Loading…" forever. Now each `.catch(...)` flips a `notFound` flag and the page renders a terminal not-found state with a link back to the list. Verified live (screenshot): a bad tripwire id now shows "Tripwire not found" instead of hanging.