### PR TITLE
Fix two Alembic heads so the server can start (#67)

### DIFF
--- a/server/thumper/migrations/versions/merge_heads_v1.py
+++ b/server/thumper/migrations/versions/merge_heads_v1.py
@@ -1,0 +1,27 @@
+"""Merge the two migration heads into one.
+
+#56 (alert_resolved_at_v1) and #59 (endpoint_decommission_v1) both branched from
+deploy_fk_cascade_v1 and merged independently, leaving Alembic with two heads -
+so `alembic upgrade head` (run on every startup by init_db) failed with
+"Multiple head revisions are present". This no-op merge revision rejoins them
+into a single head; it's safe for databases that already applied either or both.
+
+Revision ID: merge_heads_v1
+Revises: alert_resolved_at_v1, endpoint_decommission_v1
+Create Date: 2026-06-17
+"""
+from typing import Sequence, Union
+
+revision: str = "merge_heads_v1"
+down_revision: Union[str, Sequence[str], None] = (
+    "alert_resolved_at_v1", "endpoint_decommission_v1")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,19 @@
+"""Migration-chain integrity. A second head sneaks in whenever two PRs each add
+a migration off the same parent and both merge - and it breaks `init_db` for
+everyone (alembic upgrade head -> "Multiple head revisions"). Guard against it."""
+from pathlib import Path
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+
+def _script_dir() -> ScriptDirectory:
+    migrations = Path(__file__).resolve().parents[1] / "server" / "thumper" / "migrations"
+    cfg = Config()
+    cfg.set_main_option("script_location", str(migrations))
+    return ScriptDirectory.from_config(cfg)
+
+
+def test_single_migration_head():
+    heads = _script_dir().get_heads()
+    assert len(heads) == 1, f"expected one alembic head, found {heads}"


### PR DESCRIPTION
Closes #67. #56 and #59 each added a migration off `deploy_fk_cascade_v1`, leaving two heads — so `init_db()`'s `alembic upgrade head` fails on startup. Adds a no-op merge revision rejoining them (safe for DBs that applied either), plus a test asserting a single head. Verified: `init_db()` succeeds; suite green.