### PR TITLE
Handle duplicate-deployment race instead of 500 (#29)

### DIFF
--- a/server/thumper/store.py
+++ b/server/thumper/store.py
@@ -131,20 +131,34 @@ def delete_endpoint(db: Session, eid: str) -> bool:
 
 
 # ── deployments (instances) ──────────────────────────────────────────────────
-def materialize_deployment(db: Session, *, tripwire_id: str, endpoint_id: str,
-                           path: str, content: str) -> Deployment:
-    """Create the per-(tripwire,endpoint) instance if absent; else return existing."""
-    existing = db.query(Deployment).filter(
+def _find_deployment(db: Session, tripwire_id: str, endpoint_id: str) -> Optional[Deployment]:
+    return db.query(Deployment).filter(
         Deployment.tripwire_id == tripwire_id,
         Deployment.endpoint_id == endpoint_id,
     ).first()
+
+
+def materialize_deployment(db: Session, *, tripwire_id: str, endpoint_id: str,
+                           path: str, content: str) -> Deployment:
+    """Create the per-(tripwire,endpoint) instance if absent; else return existing.
+
+    Concurrency-safe: two requests for the same (tripwire, endpoint) can both pass
+    the existence check and both try to insert. The unique constraint lets exactly
+    one win; the loser catches the IntegrityError and returns the winner's row
+    instead of surfacing a 500 (e.g. an agent retrying on a flaky network)."""
+    existing = _find_deployment(db, tripwire_id, endpoint_id)
     if existing:
         return existing
     row = Deployment(id=_id("dp"), tripwire_id=tripwire_id, endpoint_id=endpoint_id,
                      path=path, content=content, hmac_secret=secrets.token_hex(32),
                      state="pending", created_at=iso_now())
     db.add(row)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        # Another request won the race between our check and insert.
+        return _find_deployment(db, tripwire_id, endpoint_id)
     db.refresh(row)
     return row
 

--- a/tests/test_deployment_race.py
+++ b/tests/test_deployment_race.py
@@ -1,0 +1,55 @@
+"""materialize_deployment must be safe under a duplicate (tripwire, endpoint)
+race: two requests both pass the existence check, both insert, and the second
+violates the unique constraint. It should recover and return the existing row,
+not raise (which surfaces as a 500)."""
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from thumper import store
+from thumper.db import Base
+
+
+@pytest.fixture
+def db():
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False},
+                           poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    s = sessionmaker(bind=engine)()
+    yield s
+    s.close()
+
+
+def _materialize(db):
+    return store.materialize_deployment(
+        db, tripwire_id="tw_1", endpoint_id="ep_1", path="/x", content="bait")
+
+
+def test_materialize_is_idempotent(db):
+    first = _materialize(db)
+    again = _materialize(db)
+    assert again.id == first.id
+    assert store.count_deployments(db) == 1
+
+
+def test_materialize_recovers_from_duplicate_race(db, monkeypatch):
+    """Simulate the race: the winner already inserted, but our existence check
+    misses it (as if its commit hadn't landed yet), so we take the INSERT path
+    and hit the unique constraint - and must return the winner's row, not raise."""
+    winner = _materialize(db)
+
+    real_find = store._find_deployment
+    calls = {"n": 0}
+
+    def flaky_find(session, tripwire_id, endpoint_id):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return None  # first lookup misses -> forces the INSERT path
+        return real_find(session, tripwire_id, endpoint_id)
+
+    monkeypatch.setattr(store, "_find_deployment", flaky_find)
+
+    result = _materialize(db)  # must NOT raise IntegrityError
+    assert result.id == winner.id
+    assert store.count_deployments(db) == 1


### PR DESCRIPTION
Closes #29. `materialize_deployment` did check-then-insert, so two concurrent requests for the same (tripwire, endpoint) could both insert and the second 500'd on the unique constraint. Now it catches the `IntegrityError`, rolls back, and returns the winner's row. TDD: deterministic race-recovery test + idempotency test.