### PR TITLE
Detail pages: not-found state instead of infinite Loading (#21)

### DIFF
--- a/ui/src/api/http.ts
+++ b/ui/src/api/http.ts
@@ -20,6 +20,18 @@ import type {
 
 const BASE = "/api";
 
+// Carries the HTTP status so callers can distinguish a 404 (show a not-found
+// state) from a transient 5xx/network failure (show an error). The message keeps
+// the `${status}: ${detail}` shape existing call sites already surface.
+export class ApiError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+  }
+}
+
 async function req<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(`${BASE}${path}`, {
     headers: { "content-type": "application/json" },
@@ -33,7 +45,7 @@ async function req<T>(path: string, init?: RequestInit): Promise<T> {
     } catch {
       /* non-JSON error body */
     }
-    throw new Error(`${res.status}: ${detail}`);
+    throw new ApiError(res.status, `${res.status}: ${detail}`);
   }
   return res.json() as Promise<T>;
 }

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -4,5 +4,5 @@
 // Token generation + the token-type catalog come from the SERVER
 // (api.getTokenTypes / api.previewToken) - the browser never generates
 // honeytokens, because creating one is security-relevant (per-instance HMAC).
-export { httpApi as api } from "./http";
+export { httpApi as api, ApiError } from "./http";
 export * from "./types";

--- a/ui/src/pages/EndpointDetail.tsx
+++ b/ui/src/pages/EndpointDetail.tsx
@@ -24,11 +24,14 @@ export default function EndpointDetail() {
   const [error, setError] = useState<string | null>(null);
   const [removing, setRemoving] = useState<{ tripwireId: string; name: string } | null>(null);
   const [confirm, setConfirm] = useState<"decommission" | "force" | null>(null);
+  const [notFound, setNotFound] = useState(false);
   const pickerRef = useRef<HTMLDivElement>(null);
   const nav = useNavigate();
 
+  // A bad/deleted id rejects the promise; show a terminal not-found state instead
+  // of hanging on "Loading…" forever (#21).
   const reload = useCallback(() => {
-    api.getEndpoint(id).then(setEp);
+    api.getEndpoint(id).then(setEp).catch(() => setNotFound(true));
   }, [id]);
 
   useEffect(() => {
@@ -45,6 +48,17 @@ export default function EndpointDetail() {
     return () => document.removeEventListener("mousedown", close);
   }, [showPicker]);
 
+  if (notFound) return (
+    <>
+      <Topbar title="Endpoint not found" />
+      <div className="content">
+        <div className="empty">
+          This endpoint doesn't exist or was removed.{" "}
+          <Link to="/endpoints">← All endpoints</Link>
+        </div>
+      </div>
+    </>
+  );
   if (!ep) return <div className="content">Loading…</div>;
 
   const onEndpoint = new Set(ep.deployments.map((d) => d.tripwire_id));

--- a/ui/src/pages/EndpointDetail.tsx
+++ b/ui/src/pages/EndpointDetail.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { Trash2 } from "lucide-react";
-import { api } from "../api";
+import { api, ApiError } from "../api";
 import type { EndpointDetail as ED, Tripwire } from "../api";
 import { DeployBadge, EndpointBadge, Topbar, timeAgo } from "../components/ui.tsx";
 
@@ -25,13 +25,15 @@ export default function EndpointDetail() {
   const [removing, setRemoving] = useState<{ tripwireId: string; name: string } | null>(null);
   const [confirm, setConfirm] = useState<"decommission" | "force" | null>(null);
   const [notFound, setNotFound] = useState(false);
+  const [loadErr, setLoadErr] = useState<string | null>(null);
   const pickerRef = useRef<HTMLDivElement>(null);
   const nav = useNavigate();
 
-  // A bad/deleted id rejects the promise; show a terminal not-found state instead
-  // of hanging on "Loading…" forever (#21).
   const reload = useCallback(() => {
-    api.getEndpoint(id).then(setEp).catch(() => setNotFound(true));
+    api.getEndpoint(id).then(setEp).catch((e) => {
+      if (e instanceof ApiError && e.status === 404) setNotFound(true);
+      else setLoadErr(e instanceof Error ? e.message : "failed to load endpoint");
+    });
   }, [id]);
 
   useEffect(() => {
@@ -55,6 +57,18 @@ export default function EndpointDetail() {
         <div className="empty">
           This endpoint doesn't exist or was removed.{" "}
           <Link to="/endpoints">← All endpoints</Link>
+        </div>
+      </div>
+    </>
+  );
+  if (loadErr) return (
+    <>
+      <Topbar title="Couldn't load endpoint" />
+      <div className="content">
+        <div className="empty">
+          {loadErr}{" "}
+          <button className="btn" onClick={() => { setLoadErr(null); reload(); }}>Retry</button>
+          {" "}<Link to="/endpoints">← All endpoints</Link>
         </div>
       </div>
     </>

--- a/ui/src/pages/TripwireDetail.tsx
+++ b/ui/src/pages/TripwireDetail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import { api } from "../api";
+import { api, ApiError } from "../api";
 import type { TripwireDetail as TD } from "../api";
 import { CopyField, DeployBadge, Modal, TypeTag, Topbar, timeAgo } from "../components/ui.tsx";
 import { Pencil, Trash2 } from "lucide-react";
@@ -18,10 +18,13 @@ export default function TripwireDetail() {
   const [busy, setBusy] = useState(false);
   const [actionErr, setActionErr] = useState<string | null>(null);
   const [notFound, setNotFound] = useState(false);
+  const [loadErr, setLoadErr] = useState<string | null>(null);
 
-  // A bad/deleted id rejects the promise; show a terminal not-found state instead
-  // of hanging on "Loading…" forever (#21).
-  const load = () => api.getTripwire(id).then(setTw).catch(() => setNotFound(true));
+  const load = () =>
+    api.getTripwire(id).then(setTw).catch((e) => {
+      if (e instanceof ApiError && e.status === 404) setNotFound(true);
+      else setLoadErr(e instanceof Error ? e.message : "failed to load tripwire");
+    });
   useEffect(() => {
     load();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -74,6 +77,18 @@ export default function TripwireDetail() {
         <div className="empty">
           This tripwire doesn't exist or was deleted.{" "}
           <Link to="/tripwires">← All tripwires</Link>
+        </div>
+      </div>
+    </>
+  );
+  if (loadErr) return (
+    <>
+      <Topbar title="Couldn't load tripwire" />
+      <div className="content">
+        <div className="empty">
+          {loadErr}{" "}
+          <button className="btn" onClick={() => { setLoadErr(null); load(); }}>Retry</button>
+          {" "}<Link to="/tripwires">← All tripwires</Link>
         </div>
       </div>
     </>

--- a/ui/src/pages/TripwireDetail.tsx
+++ b/ui/src/pages/TripwireDetail.tsx
@@ -17,8 +17,11 @@ export default function TripwireDetail() {
   const [draft, setDraft] = useState("");
   const [busy, setBusy] = useState(false);
   const [actionErr, setActionErr] = useState<string | null>(null);
+  const [notFound, setNotFound] = useState(false);
 
-  const load = () => api.getTripwire(id).then(setTw);
+  // A bad/deleted id rejects the promise; show a terminal not-found state instead
+  // of hanging on "Loading…" forever (#21).
+  const load = () => api.getTripwire(id).then(setTw).catch(() => setNotFound(true));
   useEffect(() => {
     load();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -64,6 +67,17 @@ export default function TripwireDetail() {
     }
   }
 
+  if (notFound) return (
+    <>
+      <Topbar title="Tripwire not found" />
+      <div className="content">
+        <div className="empty">
+          This tripwire doesn't exist or was deleted.{" "}
+          <Link to="/tripwires">← All tripwires</Link>
+        </div>
+      </div>
+    </>
+  );
   if (!tw) return <div className="content">Loading…</div>;
 
   return (


### PR DESCRIPTION
Closes #21. TripwireDetail/EndpointDetail awaited the fetch with no error handling, so a 404 left the page stuck on "Loading…". Each now `.catch(...)` flips a `notFound` flag and renders a terminal not-found state with a link back to the list. Verified live.