### PR TITLE
feat: add deploy trigger workflow (cross-repo dispatch)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Trigger Deploy
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: jestasecurity
+          repositories: workflows
+
+      - name: Dispatch deploy to workflows repo
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: jestasecurity/workflows
+          event-type: deploy-thumper


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that triggers a deploy in `jestasecurity/workflows` on push to `main` or manual dispatch
- Uses a GitHub App token scoped to the target repo for authentication
- Sends a `repository-dispatch` event (`deploy-thumper`) to the workflows repo

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)