### PR TITLE
Isolate deploy-plugin failures (#30)

### DIFF
--- a/server/thumper/services/deploy.py
+++ b/server/thumper/services/deploy.py
@@ -60,8 +60,15 @@ def distribute(conn, tripwire_id: str) -> dict:
     install = build_install(tripwire_id)
     results = []
     for integ in configured:
-        plugin = load_plugin(integ.plugin, json.loads(integ.config_json))
-        res = plugin.deploy(install, [])
-        results.append({"plugin": integ.plugin, "state": res.state,
-                        "deployed_count": res.deployed_count, "message": res.message})
+        # Isolate each plugin: one failing (bad creds, unreachable host, a bug)
+        # must not abort the rest or discard their results - report it as failed
+        # and carry on.
+        try:
+            plugin = load_plugin(integ.plugin, json.loads(integ.config_json))
+            res = plugin.deploy(install, [])
+            results.append({"plugin": integ.plugin, "state": res.state,
+                            "deployed_count": res.deployed_count, "message": res.message})
+        except Exception as exc:  # noqa: BLE001 - one plugin must not break the others
+            results.append({"plugin": integ.plugin, "state": "failed",
+                            "deployed_count": 0, "message": str(exc)})
     return {"results": results}

--- a/tests/test_deploy_isolation.py
+++ b/tests/test_deploy_isolation.py
@@ -1,0 +1,49 @@
+"""distribute() must isolate deploy-plugin failures: one plugin raising should
+not abort the others or lose their results (#30)."""
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from thumper import store
+from thumper.db import Base
+from thumper.plugins.base import DeployResult
+from thumper.services import deploy as deploy_svc
+
+
+@pytest.fixture
+def db():
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False},
+                           poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    s = sessionmaker(bind=engine)()
+    yield s
+    s.close()
+
+
+def test_one_failing_deploy_plugin_does_not_abort_others(db, monkeypatch):
+    tw = store.create_tripwire(db, name="t", token_type="aws",
+                               path="~/.aws/credentials", token="x")
+    # Two configured deploy plugins; the first one will blow up.
+    store.upsert_integration(db, plugin="ssh", kind="deploy", config={})
+    store.upsert_integration(db, plugin="mdm", kind="deploy", config={})
+
+    class Boom:
+        def deploy(self, install, targets):
+            raise RuntimeError("ssh unreachable")
+
+    class Ok:
+        def deploy(self, install, targets):
+            return DeployResult(state="deployed", deployed_count=2, message="pushed")
+
+    monkeypatch.setattr(deploy_svc, "load_plugin",
+                        lambda name, config: Boom() if name == "ssh" else Ok())
+
+    out = deploy_svc.distribute(db, tw.id)
+    results = {r["plugin"]: r for r in out["results"]}
+
+    assert set(results) == {"ssh", "mdm"}, "a failing plugin aborted the others"
+    assert results["ssh"]["state"] == "failed"
+    assert "ssh unreachable" in results["ssh"]["message"]
+    assert results["mdm"]["state"] == "deployed"
+    assert results["mdm"]["deployed_count"] == 2


### PR DESCRIPTION
Closes #30. `distribute()` ran each deploy plugin with no error handling, so the first to raise aborted the rest and lost their results. Each plugin is now wrapped: a failure is recorded as `failed` and the loop continues. TDD test included.