### PR TITLE
Validate bait paths: reject traversal/relative (#76)

### DIFF
--- a/agent/thumper_agent.sh
+++ b/agent/thumper_agent.sh
@@ -271,6 +271,12 @@ report_plant() {            # report_plant <deployment_id> <state>
 
 plant() {  # plant <i>
     eval "id=\$dep_id_$1 path=\$dep_path_$1 url=\$dep_content_$1"
+    # Defense-in-depth: never act on a traversal path from the server. The server
+    # validates on tripwire creation, but the agent runs as root, so don't trust
+    # a `..` path even from an authenticated-but-compromised control plane.
+    case "/$path/" in
+        */../*) err "refusing bait path with '..': $path - skipping $id"; report_plant "$id" failed; return 1 ;;
+    esac
     parent=$(dirname "$path")
     [ -z "$parent" ] || mkdir -p "$parent"
 

--- a/server/thumper/api/routes.py
+++ b/server/thumper/api/routes.py
@@ -72,7 +72,11 @@ def _validate_bait_path(path: str) -> str:
         raise HTTPException(400, "path is required")
     if ".." in p.split("/"):
         raise HTTPException(400, "path must not contain '..'")
-    if not (p.startswith("/") or p.startswith("~")):
+    # Accept only `~/` (current user's home), NOT `~user/`: the agent's expand_path
+    # expands only `~/`, so a `~postgres/.pgpass` would pass here but be used
+    # literally by the root agent (`mkdir -p ~postgres` under CWD) - bait lands in
+    # a junk dir while the dashboard reports it deployed.
+    if not (p.startswith("/") or p == "~" or p.startswith("~/")):
         raise HTTPException(400, "path must be absolute (/...) or home-rooted (~/...)")
     return p
 

--- a/server/thumper/api/routes.py
+++ b/server/thumper/api/routes.py
@@ -62,6 +62,21 @@ def _token_eq(provided: str, expected: str) -> bool:
     return hmac.compare_digest(provided, expected)
 
 
+def _validate_bait_path(path: str) -> str:
+    """A bait path is planted by the (root) agent, so a malformed one is a write
+    primitive. Require an absolute or home-rooted path and reject traversal. This
+    blocks `..` and relative paths injected via the (currently open) create API;
+    constraining which absolute roots are allowed is a separate policy decision."""
+    p = (path or "").strip()
+    if not p:
+        raise HTTPException(400, "path is required")
+    if ".." in p.split("/"):
+        raise HTTPException(400, "path must not contain '..'")
+    if not (p.startswith("/") or p.startswith("~")):
+        raise HTTPException(400, "path must be absolute (/...) or home-rooted (~/...)")
+    return p
+
+
 def _parse_ts(timestamp: str | None):
     if not timestamp:
         return None
@@ -170,6 +185,7 @@ def list_tripwires(db: Session = Depends(get_db)):
 
 @router.post("/tripwires", response_model=TripwireOut)
 def create_tripwire(body: CreateTripwireIn, db: Session = Depends(get_db)):
+    path = _validate_bait_path(body.path)
     if body.source == "custom" and not body.custom_content:
         raise HTTPException(400, "custom source requires custom_content")
     token = body.token or render_content(
@@ -177,7 +193,7 @@ def create_tripwire(body: CreateTripwireIn, db: Session = Depends(get_db)):
         custom_content=body.custom_content,
     )
     tripwire = store.create_tripwire(
-        db, name=body.name, token_type=body.token_type, path=body.path,
+        db, name=body.name, token_type=body.token_type, path=path,
         source=body.source, custom_content=body.custom_content, token=token,
     )
     return _tripwire_out(db, tripwire)

--- a/tests/test_tripwire_path_validation.py
+++ b/tests/test_tripwire_path_validation.py
@@ -1,0 +1,39 @@
+"""Bait paths are planted by the root agent, so the create API must reject
+traversal / relative paths that could become an arbitrary-write primitive (#76)."""
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from thumper.db import Base, get_db
+from thumper.main import app
+
+
+@pytest.fixture
+def client():
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False},
+                           poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    db = sessionmaker(bind=engine)()
+    app.dependency_overrides[get_db] = lambda: db
+    yield TestClient(app)
+    del app.dependency_overrides[get_db]
+    db.close()
+
+
+def _create(client, path):
+    return client.post("/api/tripwires",
+                       json={"name": "t", "token_type": "aws", "path": path})
+
+
+@pytest.mark.parametrize("bad", ["../../etc/passwd", "etc/passwd", "a/../b", "", "   "])
+def test_rejects_traversal_and_relative_paths(client, bad):
+    assert _create(client, bad).status_code == 400
+
+
+@pytest.mark.parametrize("ok", ["~/.aws/credentials", "/etc/ssh/ssh_host_ed25519_key"])
+def test_accepts_absolute_and_home_paths(client, ok):
+    resp = _create(client, ok)
+    assert resp.status_code == 200
+    assert resp.json()["path"] == ok

--- a/tests/test_tripwire_path_validation.py
+++ b/tests/test_tripwire_path_validation.py
@@ -32,6 +32,13 @@ def test_rejects_traversal_and_relative_paths(client, bad):
     assert _create(client, bad).status_code == 400
 
 
+# `~user/` passes a naive `startswith("~")` but the agent's expand_path only
+# expands `~/`, so the root agent would use it literally (#76 review).
+@pytest.mark.parametrize("bad", ["~postgres/.pgpass", "~root/.ssh/id_rsa", "~~/x"])
+def test_rejects_other_user_home_paths(client, bad):
+    assert _create(client, bad).status_code == 400
+
+
 @pytest.mark.parametrize("ok", ["~/.aws/credentials", "/etc/ssh/ssh_host_ed25519_key"])
 def test_accepts_absolute_and_home_paths(client, ok):
     resp = _create(client, ok)


### PR DESCRIPTION
Closes #76. A bait path is planted by the root agent, so a malformed one is a write primitive. Reject `..` and require absolute/home-rooted paths at tripwire creation, plus a defense-in-depth `..` guard in the agent. Note: constraining which absolute roots are allowed (e.g. home + /etc/ssh only) is a separate policy decision, deferred.