### PR TITLE
Warn at startup on dev-default tokens (#22)

### DIFF
--- a/server/thumper/config.py
+++ b/server/thumper/config.py
@@ -24,13 +24,29 @@ BASE_URL = os.environ.get("THUMPER_BASE_URL", "http://localhost:8000").rstrip("/
 # Shared enrollment token: an agent presents this to POST /api/enroll. The org
 # embeds it in the install command it distributes (via MDM/SSH/etc). Dev default
 # is obvious-and-insecure on purpose - override in production.
-ENROLL_TOKEN = os.environ.get("THUMPER_ENROLL_TOKEN", "dev-enroll-token")
+_DEFAULT_ENROLL_TOKEN = "dev-enroll-token"
+ENROLL_TOKEN = os.environ.get("THUMPER_ENROLL_TOKEN", _DEFAULT_ENROLL_TOKEN)
 
 # Admin token gating the installer endpoint (GET /api/install.sh). The installer
 # embeds the ENROLL_TOKEN, so it must not be fetchable anonymously; only the
 # server-generated deploy command (which carries this token) can retrieve it.
 # Dev default is obvious-and-insecure on purpose - override in production.
-INSTALL_TOKEN = os.environ.get("THUMPER_INSTALL_TOKEN", "dev-install-token")
+_DEFAULT_INSTALL_TOKEN = "dev-install-token"
+INSTALL_TOKEN = os.environ.get("THUMPER_INSTALL_TOKEN", _DEFAULT_INSTALL_TOKEN)
+
+
+def insecure_default_tokens(enroll: str | None = None, install: str | None = None) -> list[str]:
+    """Names of the shared tokens still set to their built-in dev defaults.
+    Used to warn loudly at startup so a production deploy doesn't silently run
+    with publicly-known credentials."""
+    enroll = ENROLL_TOKEN if enroll is None else enroll
+    install = INSTALL_TOKEN if install is None else install
+    flagged = []
+    if enroll == _DEFAULT_ENROLL_TOKEN:
+        flagged.append("THUMPER_ENROLL_TOKEN")
+    if install == _DEFAULT_INSTALL_TOKEN:
+        flagged.append("THUMPER_INSTALL_TOKEN")
+    return flagged
 
 # Built static UI (ui/dist) - mounted at / when present (Docker / monolith mode).
 UI_DIST = Path(os.environ.get("THUMPER_UI_DIST", str(REPO_ROOT / "ui" / "dist")))

--- a/server/thumper/main.py
+++ b/server/thumper/main.py
@@ -13,15 +13,23 @@ from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from .api import router
-from .config import UI_DIST
+from .config import UI_DIST, insecure_default_tokens
 from .db import init_db
 
 logging.basicConfig(level=logging.INFO)
+log = logging.getLogger("thumper")
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     init_db()
+    flagged = insecure_default_tokens()
+    if flagged:
+        log.warning(
+            "SECURITY: %s still set to the built-in dev default(s) - anyone can "
+            "guess them. Set them to random secrets (env vars) before production.",
+            ", ".join(flagged),
+        )
     yield
 
 

--- a/tests/test_default_token_warning.py
+++ b/tests/test_default_token_warning.py
@@ -1,0 +1,18 @@
+"""insecure_default_tokens() flags shared tokens left at the built-in dev
+defaults, so startup can warn loudly instead of silently shipping guessable
+credentials (#22)."""
+from thumper.config import insecure_default_tokens
+
+
+def test_both_defaults_flagged():
+    assert insecure_default_tokens("dev-enroll-token", "dev-install-token") == [
+        "THUMPER_ENROLL_TOKEN", "THUMPER_INSTALL_TOKEN"]
+
+
+def test_no_defaults_when_overridden():
+    assert insecure_default_tokens("s3cr3t-enroll", "s3cr3t-install") == []
+
+
+def test_only_install_default():
+    assert insecure_default_tokens("s3cr3t-enroll", "dev-install-token") == [
+        "THUMPER_INSTALL_TOKEN"]


### PR DESCRIPTION
Closes #22. Adds `config.insecure_default_tokens()` and a loud SECURITY warning in the app lifespan when `ENROLL_TOKEN`/`INSTALL_TOKEN` are still the built-in dev values. Warn (not fail-closed) to keep the dev compose flow.

Note: touches `main.py` lifespan — will conflict at merge time with #75 and #24 (trivial resolution: keep all warnings + one logger).