### PR TITLE
SSRF guard for outbound integration URLs (#74)

### DIFF
--- a/plugins/alert/loki/plugin.py
+++ b/plugins/alert/loki/plugin.py
@@ -5,6 +5,7 @@ import time
 import httpx
 
 from thumper.plugins.base import AlertPlugin, PluginError
+from thumper.services.ssrf import assert_url_allowed
 
 
 class Plugin(AlertPlugin):
@@ -12,6 +13,7 @@ class Plugin(AlertPlugin):
         url = self.config.get("loki_url")
         if not url:
             raise PluginError("loki: loki_url is required")
+        assert_url_allowed(url)  # SSRF guard (#74)
 
         labels = {"app": "thumper", "tripwire": event.get("tripwire_name", "")}
         for pair in (self.config.get("labels") or "").split(","):

--- a/plugins/alert/splunk/plugin.py
+++ b/plugins/alert/splunk/plugin.py
@@ -3,6 +3,7 @@ access to a SIEM via the HTTP Event Collector."""
 import httpx
 
 from thumper.plugins.base import AlertPlugin, PluginError
+from thumper.services.ssrf import assert_url_allowed
 
 
 class Plugin(AlertPlugin):
@@ -11,6 +12,7 @@ class Plugin(AlertPlugin):
         token = self.config.get("hec_token")
         if not url or not token:
             raise PluginError("splunk: hec_url and hec_token are required")
+        assert_url_allowed(url)  # SSRF guard (#74)
 
         payload = {
             "event": {"signature": "thumper_honeytoken_access", **event},

--- a/plugins/alert/webhook/plugin.py
+++ b/plugins/alert/webhook/plugin.py
@@ -15,6 +15,7 @@ import httpx
 
 from thumper.plugins.base import AlertPlugin, PluginError
 from thumper.services.signing import sign_timestamped
+from thumper.services.ssrf import assert_url_allowed
 
 
 def _now_unix() -> int:
@@ -27,6 +28,7 @@ class Plugin(AlertPlugin):
         url = self.config.get("url")
         if not url:
             raise PluginError("webhook: url is required")
+        assert_url_allowed(url)  # SSRF guard (#74)
 
         # Stamp send-time before serializing so the signed timestamp reflects when
         # the alert fired, not when JSON encoding happened to finish.

--- a/plugins/deploy/mdm/plugin.py
+++ b/plugins/deploy/mdm/plugin.py
@@ -13,6 +13,7 @@ that surface - there, copy the install command and distribute it yourself
 """
 from thumper.plugins.base import AgentInstall, DeployPlugin, DeployResult, PluginError
 from thumper.services.jamf import JamfClient, JamfError
+from thumper.services.ssrf import assert_url_allowed
 
 _REQUIRED = ("base_url", "client_id", "client_secret", "smart_group")
 _NAME_PREFIX = "Thumper Agent"
@@ -41,6 +42,7 @@ class Plugin(DeployPlugin):
             raise PluginError(f"MDM plugin missing required config: {', '.join(missing)}")
 
     def _client(self) -> JamfClient:
+        assert_url_allowed(self.config["base_url"])  # SSRF guard (#74)
         return JamfClient(self.config["base_url"], self.config["client_id"],
                           self.config["client_secret"])
 

--- a/server/thumper/api/routes.py
+++ b/server/thumper/api/routes.py
@@ -47,6 +47,7 @@ from ..services.content import render_content
 from ..services.deploy import build_install, build_install_command, distribute
 from ..services.integrations import mask_config, merge_config, saved_config
 from ..services.signing import verify
+from ..services.ssrf import SsrfError, assert_config_urls_allowed
 from ..tokens import TOKEN_TYPES
 
 router = APIRouter(prefix="/api")
@@ -400,6 +401,10 @@ def save_integration(plugin: str, config: dict, db: Session = Depends(get_db)):
     if manifest is None:
         raise HTTPException(404, "unknown plugin")
     merged = merge_config(saved_config(db, plugin), config)
+    try:
+        assert_config_urls_allowed(plugin, merged)  # SSRF guard (#74)
+    except SsrfError as exc:
+        raise HTTPException(400, str(exc))
     store.upsert_integration(db, plugin=plugin, kind=manifest["kind"], config=merged)
     return IntegrationOut(plugin=plugin, kind=manifest["kind"], configured=True,
                           config=mask_config(manifest, merged))

--- a/server/thumper/config.py
+++ b/server/thumper/config.py
@@ -3,10 +3,29 @@
 Defaults assume the repo layout (server/thumper/config.py → repo root is two
 parents up) so `uvicorn thumper.main:app` works from a checkout with no setup.
 """
+import ipaddress
 import os
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _parse_cidrs(raw: str):
+    nets = []
+    for tok in raw.split(","):
+        tok = tok.strip()
+        if not tok:
+            continue
+        try:
+            nets.append(ipaddress.ip_network(tok, strict=False))
+        except ValueError:
+            pass  # ignore malformed entries rather than crash startup
+    return nets
+
+
+# CIDRs/IPs operators explicitly allow as outbound integration targets, so the
+# SSRF guard (#74) doesn't block a legitimately-internal Splunk/Loki/webhook.
+ALLOWED_HOOK_CIDRS = _parse_cidrs(os.environ.get("THUMPER_ALLOWED_HOOK_CIDRS", ""))
 
 # Directory holding the installable plugins (each: plugin.py + manifest.yaml).
 # This is the repo-root `plugins/` tree, NOT server/thumper/plugins/ (which is

--- a/server/thumper/services/ssrf.py
+++ b/server/thumper/services/ssrf.py
@@ -1,22 +1,23 @@
 """SSRF guard for operator-configured outbound integration URLs (#74).
 
 Integration targets (webhook / loki / splunk / jamf) are fetched server-side, so
-an attacker-set URL could reach internal services or cloud metadata. Block
-private / loopback / link-local destinations by default; operators opt-in real
-internal hosts via THUMPER_ALLOWED_HOOK_CIDRS. The host is resolved and every
-resolved IP is checked, so a hostname pointing at an internal address is caught.
+an attacker-set URL could reach internal services or cloud metadata. Block any
+non-globally-routable destination by default (private / loopback / link-local /
+CGNAT / reserved); operators opt-in real internal hosts via
+THUMPER_ALLOWED_HOOK_CIDRS. The host is resolved and every resolved IP is
+checked, so a hostname pointing at an internal address is caught.
+
+Known gap (TOCTOU / DNS rebinding): we validate the IPs resolved here, but httpx
+re-resolves the host when it sends the request, so a host that returns a public
+IP now and an internal IP a moment later still gets through. Acceptable for
+operator-set URLs as v1; the real fix is to pin a validated IP for the actual
+connection. Tracked alongside the SSH-tunnel follow-up.
 """
 import ipaddress
 import socket
 from urllib.parse import urlparse
 
 from ..config import ALLOWED_HOOK_CIDRS
-
-_BLOCKED = [ipaddress.ip_network(c) for c in (
-    "0.0.0.0/8", "10.0.0.0/8", "127.0.0.0/8", "169.254.0.0/16",
-    "172.16.0.0/12", "192.168.0.0/16",
-    "::1/128", "fc00::/7", "fe80::/10",
-)]
 
 # Which config fields hold an outbound URL, per plugin (for save-time validation).
 INTEGRATION_URL_FIELDS = {
@@ -33,9 +34,18 @@ class SsrfError(Exception):
 
 def _ip_blocked(ip: str, allowlist) -> bool:
     addr = ipaddress.ip_address(ip)
+    # Unwrap IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1) so the embedded IPv4 is
+    # classified directly. is_global only handles these correctly on CPython
+    # 3.12.4+, and unwrapping also lets IPv4 allowlist CIDRs match.
+    mapped = getattr(addr, "ipv4_mapped", None)
+    if mapped is not None:
+        addr = mapped
     if any(addr in net for net in allowlist):
         return False
-    return any(addr in net for net in _BLOCKED)
+    # Block anything not globally routable: covers private, loopback,
+    # link-local, CGNAT (100.64/10), reserved (240/4) and unspecified ranges
+    # that a hand-maintained net list is easy to leave incomplete.
+    return not addr.is_global
 
 
 def assert_url_allowed(url: str, *, allowlist=None) -> None:

--- a/server/thumper/services/ssrf.py
+++ b/server/thumper/services/ssrf.py
@@ -1,0 +1,68 @@
+"""SSRF guard for operator-configured outbound integration URLs (#74).
+
+Integration targets (webhook / loki / splunk / jamf) are fetched server-side, so
+an attacker-set URL could reach internal services or cloud metadata. Block
+private / loopback / link-local destinations by default; operators opt-in real
+internal hosts via THUMPER_ALLOWED_HOOK_CIDRS. The host is resolved and every
+resolved IP is checked, so a hostname pointing at an internal address is caught.
+"""
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+from ..config import ALLOWED_HOOK_CIDRS
+
+_BLOCKED = [ipaddress.ip_network(c) for c in (
+    "0.0.0.0/8", "10.0.0.0/8", "127.0.0.0/8", "169.254.0.0/16",
+    "172.16.0.0/12", "192.168.0.0/16",
+    "::1/128", "fc00::/7", "fe80::/10",
+)]
+
+# Which config fields hold an outbound URL, per plugin (for save-time validation).
+INTEGRATION_URL_FIELDS = {
+    "webhook": ("url",),
+    "loki": ("loki_url",),
+    "splunk": ("hec_url",),
+    "mdm": ("base_url",),
+}
+
+
+class SsrfError(Exception):
+    """An outbound URL targets a blocked (internal) address or is malformed."""
+
+
+def _ip_blocked(ip: str, allowlist) -> bool:
+    addr = ipaddress.ip_address(ip)
+    if any(addr in net for net in allowlist):
+        return False
+    return any(addr in net for net in _BLOCKED)
+
+
+def assert_url_allowed(url: str, *, allowlist=None) -> None:
+    """Raise SsrfError unless `url` is an http(s) URL whose every resolved IP is
+    public (or explicitly allowlisted)."""
+    allowlist = ALLOWED_HOOK_CIDRS if allowlist is None else allowlist
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise SsrfError(f"unsupported URL scheme: {parsed.scheme or '(none)'!r}")
+    host = parsed.hostname
+    if not host:
+        raise SsrfError("URL has no host")
+    try:
+        infos = socket.getaddrinfo(host, parsed.port, 0, socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise SsrfError(f"cannot resolve host {host!r}") from exc
+    for info in infos:
+        ip = info[4][0]
+        if _ip_blocked(ip, allowlist):
+            raise SsrfError(
+                f"blocked outbound target {host} -> {ip} (private/loopback/"
+                "link-local; allow it via THUMPER_ALLOWED_HOOK_CIDRS)")
+
+
+def assert_config_urls_allowed(plugin: str, config: dict) -> None:
+    """Validate every URL field in a plugin's config (save-time check)."""
+    for key in INTEGRATION_URL_FIELDS.get(plugin, ()):
+        val = (config.get(key) or "").strip()
+        if val:
+            assert_url_allowed(val)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 """Shared test fixtures."""
+import ipaddress
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
@@ -7,6 +9,19 @@ from sqlalchemy.pool import StaticPool
 
 from thumper.db import Base, get_db
 from thumper.main import app
+
+
+@pytest.fixture(autouse=True)
+def _allow_local_integration_hosts(monkeypatch):
+    """Integration tests point plugins at localhost/private stub servers - exactly
+    what the SSRF guard (#74) blocks by default. Mirror a real operator and
+    allowlist local/private ranges for the test session. The dedicated SSRF tests
+    pass an explicit empty allowlist, so they still verify blocking."""
+    from thumper.services import ssrf
+    monkeypatch.setattr(ssrf, "ALLOWED_HOOK_CIDRS", [
+        ipaddress.ip_network(c) for c in
+        ("127.0.0.0/8", "::1/128", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")
+    ])
 
 
 @pytest.fixture

--- a/tests/test_mdm_plugin.py
+++ b/tests/test_mdm_plugin.py
@@ -53,6 +53,9 @@ def plugin_module(monkeypatch):
     module = load_plugin_module()
     FakeClient.instances = []
     monkeypatch.setattr(module, "JamfClient", FakeClient)
+    # base_url here is a non-resolvable stub ("https://jss"); neutralize the SSRF
+    # guard so these orchestration tests don't do DNS (covered in test_ssrf.py).
+    monkeypatch.setattr(module, "assert_url_allowed", lambda url: None)
     return module
 
 

--- a/tests/test_ssrf.py
+++ b/tests/test_ssrf.py
@@ -14,10 +14,24 @@ from thumper.services.ssrf import SsrfError, assert_url_allowed
     "http://192.168.1.1/x",
     "http://172.16.0.9/x",
     "http://[::1]/x",
+    "http://100.64.0.1/x",          # CGNAT (100.64/10) - missed by a basic list
+    "http://240.0.0.1/x",           # reserved (240/4)
+    "http://[::ffff:127.0.0.1]/x",  # IPv4-mapped IPv6 loopback
+    "http://0.0.0.0/x",             # unspecified
 ])
 def test_blocks_internal_targets(url):
     with pytest.raises(SsrfError):
         assert_url_allowed(url, allowlist=[])
+
+
+def test_blocks_ipv4_mapped_metadata(monkeypatch):
+    # A host resolving to an IPv4-mapped IPv6 form of the metadata IP must
+    # still be blocked, regardless of CPython's version-dependent is_global.
+    def fake_getaddrinfo(host, port, *a, **k):
+        return [(10, 1, 6, "", ("::ffff:169.254.169.254", port or 80, 0, 0))]
+    monkeypatch.setattr(ssrf.socket, "getaddrinfo", fake_getaddrinfo)
+    with pytest.raises(SsrfError):
+        assert_url_allowed("http://evil.example.com/x", allowlist=[])
 
 
 @pytest.mark.parametrize("url", ["http://8.8.8.8/hook", "https://1.1.1.1/x"])

--- a/tests/test_ssrf.py
+++ b/tests/test_ssrf.py
@@ -1,0 +1,67 @@
+"""SSRF guard for outbound integration URLs (#74)."""
+import ipaddress
+
+import pytest
+
+from thumper.services import ssrf
+from thumper.services.ssrf import SsrfError, assert_url_allowed
+
+
+@pytest.mark.parametrize("url", [
+    "http://127.0.0.1/hook",
+    "http://169.254.169.254/latest/meta-data/",   # cloud metadata
+    "http://10.0.0.5:9000/x",
+    "http://192.168.1.1/x",
+    "http://172.16.0.9/x",
+    "http://[::1]/x",
+])
+def test_blocks_internal_targets(url):
+    with pytest.raises(SsrfError):
+        assert_url_allowed(url, allowlist=[])
+
+
+@pytest.mark.parametrize("url", ["http://8.8.8.8/hook", "https://1.1.1.1/x"])
+def test_allows_public_ips(url):
+    assert_url_allowed(url, allowlist=[])  # no raise
+
+
+def test_non_http_scheme_blocked():
+    with pytest.raises(SsrfError):
+        assert_url_allowed("file:///etc/passwd", allowlist=[])
+    with pytest.raises(SsrfError):
+        assert_url_allowed("gopher://10.0.0.1", allowlist=[])
+
+
+def test_allowlist_permits_internal():
+    allow = [ipaddress.ip_network("10.0.0.0/8")]
+    assert_url_allowed("http://10.1.2.3/x", allowlist=allow)  # no raise
+
+
+def test_hostname_resolving_to_internal_is_blocked(monkeypatch):
+    # A public-looking hostname that resolves to the metadata IP must be caught.
+    def fake_getaddrinfo(host, port, *a, **k):
+        return [(2, 1, 6, "", ("169.254.169.254", port or 80))]
+    monkeypatch.setattr(ssrf.socket, "getaddrinfo", fake_getaddrinfo)
+    with pytest.raises(SsrfError):
+        assert_url_allowed("http://evil.example.com/x", allowlist=[])
+
+
+def test_assert_config_urls_allowed_checks_right_field():
+    with pytest.raises(SsrfError):
+        ssrf.assert_config_urls_allowed("webhook", {"url": "http://169.254.169.254/x"})
+    # unrelated field is ignored
+    ssrf.assert_config_urls_allowed("webhook", {"signing_secret": "s"})
+
+
+def test_save_integration_blocks_metadata_url(client_db):
+    # 169.254.x is not in the test allowlist, so saving it must 400.
+    tc, _ = client_db
+    resp = tc.post("/api/integrations/webhook",
+                   json={"url": "http://169.254.169.254/latest/meta-data/"})
+    assert resp.status_code == 400
+
+
+def test_save_integration_allows_public_url(client_db):
+    tc, _ = client_db
+    resp = tc.post("/api/integrations/webhook", json={"url": "http://8.8.8.8/hook"})
+    assert resp.status_code == 200

--- a/tests/test_webhook_plugin.py
+++ b/tests/test_webhook_plugin.py
@@ -46,6 +46,9 @@ EVENT = {"alert_id": "al_1", "tripwire_name": "aws-creds", "process": "node (pid
 def module(monkeypatch):
     mod = load_plugin_module()
     monkeypatch.setattr(mod, "_now_unix", lambda: 1749369600)
+    # These tests use a non-resolvable fake host ("recv") and only exercise
+    # signing/headers - neutralize the SSRF guard (covered in test_ssrf.py).
+    monkeypatch.setattr(mod, "assert_url_allowed", lambda url: None)
     return mod
 
 


### PR DESCRIPTION
Closes #74. New `services/ssrf.py` blocks private/loopback/link-local (incl. cloud metadata) outbound targets by default, resolving the host and checking every IP; operators allowlist real internal hosts via `THUMPER_ALLOWED_HOOK_CIDRS`. Enforced at request time (webhook/loki/splunk/mdm) and save time (400).

Rollout note: existing internal integrations must be added to `THUMPER_ALLOWED_HOOK_CIDRS`. SSH host validation is a separate follow-up.