### PR TITLE
Warn on plaintext non-loopback BASE_URL (#75)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,6 +84,7 @@ All options overridable via environment:
 | --- | --- | --- |
 | `THUMPER_DB` | `./thumper.db` | Database URL |
 | `THUMPER_BASE_URL` | `http://localhost:8000` | Server's public URL (must be reachable from endpoints) |
+| `THUMPER_ALLOW_INSECURE_BASE_URL` | _(unset)_ | Opt-in to start with a plaintext non-loopback `BASE_URL` (otherwise the server refuses) |
 | `THUMPER_ENROLL_TOKEN` | `dev-enroll-token` | Shared token for agent enrollment |
 | `THUMPER_INSTALL_TOKEN` | `dev-install-token` | Gates `/install.sh` |
 | `THUMPER_UI_DIST` | `./ui/dist` | Built SPA location |
@@ -98,5 +99,7 @@ server-built script into `sudo sh`, and the agent then fetches bait and posts
 callbacks at URLs the server hands it. So in production `THUMPER_BASE_URL` **must
 be `https://`** (directly or via a TLS-terminating proxy) — over plaintext http a
 network MITM can serve a malicious agent and get root on endpoints. The server
-logs a warning at startup if `BASE_URL` is plaintext http to a non-loopback host
-(`http://localhost` is fine for development).
+**refuses to start** if `BASE_URL` is plaintext http to a non-loopback host,
+unless `THUMPER_ALLOW_INSECURE_BASE_URL=1` is set to opt in (which downgrades it
+to a startup warning, for a deliberately-isolated network). `http://localhost` is
+fine for development and is never flagged.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,3 +90,13 @@ All options overridable via environment:
 | `THUMPER_AGENT_PATH` | `./agent/thumper_agent.sh` | Agent script to serve |
 | `THUMPER_PLUGINS_DIR` | `./plugins` | Plugin discovery root |
 | `THUMPER_DASHBOARD_REFRESH` | `60` | Auto-refresh interval (seconds, 0 = off) |
+
+## Security & trust model
+
+Endpoints **trust the server** (trust-on-first-use): the install command pipes a
+server-built script into `sudo sh`, and the agent then fetches bait and posts
+callbacks at URLs the server hands it. So in production `THUMPER_BASE_URL` **must
+be `https://`** (directly or via a TLS-terminating proxy) — over plaintext http a
+network MITM can serve a malicious agent and get root on endpoints. The server
+logs a warning at startup if `BASE_URL` is plaintext http to a non-loopback host
+(`http://localhost` is fine for development).

--- a/server/thumper/config.py
+++ b/server/thumper/config.py
@@ -5,8 +5,22 @@ parents up) so `uvicorn thumper.main:app` works from a checkout with no setup.
 """
 import os
 from pathlib import Path
+from urllib.parse import urlparse
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1", ""}
+
+
+def insecure_base_url(base_url: str | None = None) -> bool:
+    """True when BASE_URL is plaintext http:// to a NON-loopback host - i.e.
+    endpoints would download the agent/bait and post callbacks in cleartext, so a
+    MITM can serve a malicious agent (root RCE). http://localhost is the legit dev
+    default and is NOT flagged."""
+    parsed = urlparse(BASE_URL if base_url is None else base_url)
+    if parsed.scheme != "http":
+        return False
+    return (parsed.hostname or "").lower() not in _LOOPBACK_HOSTS
 
 # Directory holding the installable plugins (each: plugin.py + manifest.yaml).
 # This is the repo-root `plugins/` tree, NOT server/thumper/plugins/ (which is

--- a/server/thumper/config.py
+++ b/server/thumper/config.py
@@ -35,6 +35,26 @@ DB_URL = _db_raw if "://" in _db_raw else f"sqlite:///{_db_raw}"
 # Must be reachable from managed endpoints in production.
 BASE_URL = os.environ.get("THUMPER_BASE_URL", "http://localhost:8000").rstrip("/")
 
+
+def _truthy(val: str | None) -> bool:
+    return (val or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+# A plaintext non-loopback BASE_URL is fail-closed at startup (MITM -> root RCE).
+# This is the deliberate escape hatch - e.g. an isolated test network, or TLS
+# terminated by a proxy in front but BASE_URL still written http:// - and lets
+# the server start with a loud warning instead of refusing.
+ALLOW_INSECURE_BASE_URL = _truthy(os.environ.get("THUMPER_ALLOW_INSECURE_BASE_URL"))
+
+
+def base_url_fail_closed(base_url: str | None = None, allow_insecure: bool | None = None) -> bool:
+    """True when startup must REFUSE: an insecure BASE_URL with no explicit
+    opt-out. Given the MITM -> root RCE exposure, warn-only isn't enough; main()
+    raises on this, and THUMPER_ALLOW_INSECURE_BASE_URL downgrades it to a
+    warning for a deliberately-insecure network."""
+    allow = ALLOW_INSECURE_BASE_URL if allow_insecure is None else allow_insecure
+    return insecure_base_url(base_url) and not allow
+
 # Shared enrollment token: an agent presents this to POST /api/enroll. The org
 # embeds it in the install command it distributes (via MDM/SSH/etc). Dev default
 # is obvious-and-insecure on purpose - override in production.

--- a/server/thumper/main.py
+++ b/server/thumper/main.py
@@ -13,7 +13,8 @@ from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from .api import router
-from .config import UI_DIST, insecure_base_url, insecure_default_tokens
+from .config import (
+    UI_DIST, base_url_fail_closed, insecure_base_url, insecure_default_tokens)
 from .db import init_db
 
 logging.basicConfig(level=logging.INFO)
@@ -30,12 +31,23 @@ async def lifespan(app: FastAPI):
             "guess them. Set them to random secrets (env vars) before production.",
             ", ".join(flagged),
         )
+    # MITM on a plaintext non-loopback BASE_URL is agent/bait fetch + callbacks in
+    # cleartext -> a malicious agent served to the endpoint -> root RCE. Severe
+    # enough to fail closed: refuse to start unless the operator opts in.
+    detail = (
+        "THUMPER_BASE_URL is plaintext http:// to a non-loopback host - endpoints "
+        "fetch the agent/bait and post callbacks in cleartext, so a MITM can serve "
+        "a malicious agent (root RCE)")
+    if base_url_fail_closed():
+        raise RuntimeError(
+            f"SECURITY: {detail}. Refusing to start. Use https:// (or a TLS-"
+            "terminating proxy), or set THUMPER_ALLOW_INSECURE_BASE_URL=1 to "
+            "override on a deliberately-insecure network.")
     if insecure_base_url():
         log.warning(
-            "SECURITY: THUMPER_BASE_URL is plaintext http:// to a non-loopback "
-            "host - endpoints fetch the agent/bait and post callbacks in "
-            "cleartext, so a MITM can serve a malicious agent (root RCE). Use "
-            "https:// (or a TLS-terminating proxy) in production.")
+            "SECURITY: %s. Starting anyway because THUMPER_ALLOW_INSECURE_BASE_URL "
+            "is set - use https:// (or a TLS-terminating proxy) in production.",
+            detail)
     yield
 
 

--- a/server/thumper/main.py
+++ b/server/thumper/main.py
@@ -13,7 +13,7 @@ from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from .api import router
-from .config import UI_DIST, insecure_default_tokens
+from .config import UI_DIST, insecure_base_url, insecure_default_tokens
 from .db import init_db
 
 logging.basicConfig(level=logging.INFO)
@@ -30,6 +30,12 @@ async def lifespan(app: FastAPI):
             "guess them. Set them to random secrets (env vars) before production.",
             ", ".join(flagged),
         )
+    if insecure_base_url():
+        log.warning(
+            "SECURITY: THUMPER_BASE_URL is plaintext http:// to a non-loopback "
+            "host - endpoints fetch the agent/bait and post callbacks in "
+            "cleartext, so a MITM can serve a malicious agent (root RCE). Use "
+            "https:// (or a TLS-terminating proxy) in production.")
     yield
 
 

--- a/tests/test_base_url_warning.py
+++ b/tests/test_base_url_warning.py
@@ -1,0 +1,25 @@
+"""insecure_base_url() flags a plaintext, non-loopback BASE_URL so startup can
+warn about the MITM/RCE exposure (#75). http://localhost (dev) is not flagged."""
+import pytest
+
+from thumper.config import insecure_base_url
+
+
+@pytest.mark.parametrize("url", [
+    "http://thumper.example.com",
+    "http://thumper.example.com:8000",
+    "http://10.0.0.5:8000",
+])
+def test_plaintext_non_loopback_is_flagged(url):
+    assert insecure_base_url(url) is True
+
+
+@pytest.mark.parametrize("url", [
+    "http://localhost:8000",
+    "http://127.0.0.1:8000",
+    "http://[::1]:8000",
+    "https://thumper.example.com",
+    "https://localhost:8000",
+])
+def test_https_or_loopback_not_flagged(url):
+    assert insecure_base_url(url) is False

--- a/tests/test_base_url_warning.py
+++ b/tests/test_base_url_warning.py
@@ -1,8 +1,9 @@
-"""insecure_base_url() flags a plaintext, non-loopback BASE_URL so startup can
-warn about the MITM/RCE exposure (#75). http://localhost (dev) is not flagged."""
+"""insecure_base_url() flags a plaintext, non-loopback BASE_URL, and startup
+fails closed on it (MITM -> root RCE) unless THUMPER_ALLOW_INSECURE_BASE_URL is
+set (#75). http://localhost (dev) is not flagged."""
 import pytest
 
-from thumper.config import insecure_base_url
+from thumper.config import base_url_fail_closed, insecure_base_url
 
 
 @pytest.mark.parametrize("url", [
@@ -23,3 +24,42 @@ def test_plaintext_non_loopback_is_flagged(url):
 ])
 def test_https_or_loopback_not_flagged(url):
     assert insecure_base_url(url) is False
+
+
+def test_insecure_base_url_fails_closed_without_optout():
+    # The dangerous config refuses to start when the operator hasn't opted in.
+    assert base_url_fail_closed("http://thumper.example.com", allow_insecure=False) is True
+
+
+def test_optout_downgrades_to_allowed():
+    # Explicit opt-out lets it start (with a warning) - e.g. an isolated network.
+    assert base_url_fail_closed("http://thumper.example.com", allow_insecure=True) is False
+
+
+@pytest.mark.parametrize("url", ["https://thumper.example.com", "http://localhost:8000"])
+def test_secure_or_loopback_never_fails_closed(url):
+    # A safe BASE_URL starts regardless of the opt-out flag.
+    assert base_url_fail_closed(url, allow_insecure=False) is False
+
+
+def test_app_refuses_to_start_on_insecure_base_url(monkeypatch):
+    from fastapi.testclient import TestClient
+
+    from thumper import config, main
+    monkeypatch.setattr(config, "BASE_URL", "http://thumper.example.com")
+    monkeypatch.setattr(config, "ALLOW_INSECURE_BASE_URL", False)
+    monkeypatch.setattr(main, "init_db", lambda: None)   # no DB side effects
+    with pytest.raises(RuntimeError, match="Refusing to start"):
+        with TestClient(main.app):
+            pass
+
+
+def test_app_starts_with_optout(monkeypatch):
+    from fastapi.testclient import TestClient
+
+    from thumper import config, main
+    monkeypatch.setattr(config, "BASE_URL", "http://thumper.example.com")
+    monkeypatch.setattr(config, "ALLOW_INSECURE_BASE_URL", True)
+    monkeypatch.setattr(main, "init_db", lambda: None)
+    with TestClient(main.app) as c:                       # startup must not raise
+        assert c.get("/healthz").status_code == 200


### PR DESCRIPTION
Closes #75. `config.insecure_base_url()` + a startup SECURITY warning when `BASE_URL` is plaintext `http://` to a non-loopback host (MITM→root-RCE); `http://localhost` stays quiet. Documents the TLS/TOFU trust model in `docs/architecture.md`.

Note: touches `main.py` lifespan — conflicts at merge time with #22 and #24 (trivial).