### PR TITLE
Encrypt integration secrets at rest (#24)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "httpx>=0.27",
   "sqlalchemy>=2.0",
   "alembic>=1.13",
+  "cryptography>=42.0",
 ]
 
 [project.optional-dependencies]

--- a/server/thumper/api/routes.py
+++ b/server/thumper/api/routes.py
@@ -46,6 +46,7 @@ from ..services.alerting import deliver_alert
 from ..services.content import render_content
 from ..services.deploy import build_install, build_install_command, distribute
 from ..services.integrations import mask_config, merge_config, saved_config
+from ..services.secrets_crypto import unpack_config
 from ..services.signing import verify
 from ..tokens import TOKEN_TYPES
 
@@ -383,7 +384,7 @@ def list_integrations(db: Session = Depends(get_db)):
     out = []
     for manifest in public_manifests():
         rec = saved.get(manifest["name"])
-        config = mask_config(manifest, json.loads(rec.config_json)) if rec else {}
+        config = mask_config(manifest, unpack_config(rec.config_json)) if rec else {}
         out.append(IntegrationOut(
             plugin=manifest["name"], kind=manifest["kind"],
             configured=bool(rec and rec.configured), config=config,

--- a/server/thumper/api/routes.py
+++ b/server/thumper/api/routes.py
@@ -9,6 +9,7 @@ Two distinct contracts live here:
 """
 import hmac
 import json
+import logging
 from datetime import datetime, timedelta, timezone
 from urllib.parse import parse_qs, urlparse
 
@@ -46,11 +47,12 @@ from ..services.alerting import deliver_alert
 from ..services.content import render_content
 from ..services.deploy import build_install, build_install_command, distribute
 from ..services.integrations import mask_config, merge_config, saved_config
-from ..services.secrets_crypto import unpack_config
+from ..services.secrets_crypto import ConfigDecryptError, unpack_config
 from ..services.signing import verify
 from ..tokens import TOKEN_TYPES
 
 router = APIRouter(prefix="/api")
+log = logging.getLogger("thumper.api")
 
 _STALE_WINDOW = timedelta(minutes=15)
 _INACTIVE_WINDOW = timedelta(hours=12)
@@ -384,13 +386,21 @@ def list_integrations(db: Session = Depends(get_db)):
     out = []
     for manifest in public_manifests():
         rec = saved.get(manifest["name"])
-        config = mask_config(manifest, unpack_config(rec.config_json)) if rec else {}
+        config, unreadable = {}, None
+        if rec:
+            try:
+                config = mask_config(manifest, unpack_config(rec.config_json))
+            except ConfigDecryptError as exc:
+                # One row encrypted under a changed/missing key must not 500 the
+                # whole list - surface just that integration as unreadable.
+                log.warning("integration %s config unreadable: %s", rec.plugin, exc)
+                unreadable = str(exc)
         out.append(IntegrationOut(
             plugin=manifest["name"], kind=manifest["kind"],
             configured=bool(rec and rec.configured), config=config,
-            last_test_status=rec.last_test_status if rec else None,
+            last_test_status="failed" if unreadable else (rec.last_test_status if rec else None),
             last_test_at=rec.last_test_at if rec else None,
-            last_test_error=rec.last_test_error if rec else None,
+            last_test_error=unreadable or (rec.last_test_error if rec else None),
         ))
     return out
 

--- a/server/thumper/config.py
+++ b/server/thumper/config.py
@@ -48,6 +48,11 @@ def insecure_default_tokens(enroll: str | None = None, install: str | None = Non
         flagged.append("THUMPER_INSTALL_TOKEN")
     return flagged
 
+# Secret used to encrypt integration config (plugin credentials) at rest (#24).
+# Any non-empty string; a Fernet key is derived from it. Unset -> config is
+# stored as plaintext (a startup warning fires).
+SECRET_KEY = os.environ.get("THUMPER_SECRET_KEY") or None
+
 # Built static UI (ui/dist) - mounted at / when present (Docker / monolith mode).
 UI_DIST = Path(os.environ.get("THUMPER_UI_DIST", str(REPO_ROOT / "ui" / "dist")))
 

--- a/server/thumper/main.py
+++ b/server/thumper/main.py
@@ -15,6 +15,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from .api import router
 from .config import UI_DIST, insecure_default_tokens
 from .db import init_db
+from .services.secrets_crypto import encryption_enabled
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger("thumper")
@@ -30,6 +31,10 @@ async def lifespan(app: FastAPI):
             "guess them. Set them to random secrets (env vars) before production.",
             ", ".join(flagged),
         )
+    if not encryption_enabled():
+        log.warning(
+            "SECURITY: integration secrets are stored UNENCRYPTED at rest - set "
+            "THUMPER_SECRET_KEY to encrypt them (#24).")
     yield
 
 

--- a/server/thumper/services/alerting.py
+++ b/server/thumper/services/alerting.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 
 from .. import store
 from ..db import SessionLocal
+from .secrets_crypto import unpack_config
 from ..plugins.registry import load_plugin
 
 log = logging.getLogger("thumper.alerting")
@@ -25,7 +26,7 @@ def route_alert(db: Session, event: dict) -> None:
             continue
         plugin_name = integration.plugin
         try:
-            plugin = load_plugin(plugin_name, json.loads(integration.config_json))
+            plugin = load_plugin(plugin_name, unpack_config(integration.config_json))
             plugin.alert(event)
             status, error = "ok", None
         except Exception as exc:  # noqa: BLE001 - best-effort fan-out

--- a/server/thumper/services/deploy.py
+++ b/server/thumper/services/deploy.py
@@ -2,10 +2,9 @@
 plugins. The org's MDM/SSH/etc is the control plane for *which* machines get it;
 each machine that runs the command self-enrolls and pulls its own instance.
 """
-import json
-
 from ..config import BASE_URL, ENROLL_TOKEN, INSTALL_TOKEN
 from ..plugins.base import AgentInstall, PluginError
+from .secrets_crypto import unpack_config
 from ..plugins.registry import load_plugin
 from .. import store
 
@@ -64,7 +63,7 @@ def distribute(conn, tripwire_id: str) -> dict:
         # must not abort the rest or discard their results - report it as failed
         # and carry on.
         try:
-            plugin = load_plugin(integ.plugin, json.loads(integ.config_json))
+            plugin = load_plugin(integ.plugin, unpack_config(integ.config_json))
             res = plugin.deploy(install, [])
             results.append({"plugin": integ.plugin, "state": res.state,
                             "deployed_count": res.deployed_count, "message": res.message})

--- a/server/thumper/services/integrations.py
+++ b/server/thumper/services/integrations.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 
 from .. import store
 from ..plugins.registry import get_manifest
+from .secrets_crypto import unpack_config
 
 
 def mask_config(manifest: dict, config: dict) -> dict:
@@ -20,7 +21,7 @@ def mask_config(manifest: dict, config: dict) -> dict:
 
 def saved_config(db: Session, plugin: str) -> dict:
     row = store.get_integration(db, plugin)
-    return json.loads(row.config_json) if row else {}
+    return unpack_config(row.config_json) if row else {}
 
 
 def merge_config(existing: dict, incoming: dict) -> dict:

--- a/server/thumper/services/secrets_crypto.py
+++ b/server/thumper/services/secrets_crypto.py
@@ -4,6 +4,13 @@ The whole serialized config blob is encrypted with Fernet when THUMPER_SECRET_KE
 is set; otherwise it's stored as plaintext (zero-config dev). Reads are
 decrypt-or-passthrough, so existing plaintext rows keep working and become
 encrypted the next time they're saved with a key configured.
+
+Key rotation is not yet supported: there is a single active key, so changing
+THUMPER_SECRET_KEY makes every existing encrypted row undecryptable
+(ConfigDecryptError) until each integration's secrets are re-entered and saved.
+A future version can decrypt-old/encrypt-new transparently with
+cryptography.fernet.MultiFernet. Until then, treat a key change as a manual
+re-enrollment of every integration secret.
 """
 import base64
 import hashlib

--- a/server/thumper/services/secrets_crypto.py
+++ b/server/thumper/services/secrets_crypto.py
@@ -1,0 +1,60 @@
+"""Encrypt integration config (plugin credentials) at rest (#24).
+
+The whole serialized config blob is encrypted with Fernet when THUMPER_SECRET_KEY
+is set; otherwise it's stored as plaintext (zero-config dev). Reads are
+decrypt-or-passthrough, so existing plaintext rows keep working and become
+encrypted the next time they're saved with a key configured.
+"""
+import base64
+import hashlib
+import json
+
+from cryptography.fernet import Fernet, InvalidToken
+
+from .. import config
+
+_PREFIX = "fernet:"
+
+
+class ConfigDecryptError(Exception):
+    """Stored config is encrypted but can't be decrypted (key unset/changed)."""
+
+
+def encryption_enabled() -> bool:
+    return bool(config.SECRET_KEY)
+
+
+def _fernet():
+    if not config.SECRET_KEY:
+        return None
+    # Derive a valid 32-byte urlsafe-b64 Fernet key from any operator secret.
+    key = base64.urlsafe_b64encode(hashlib.sha256(config.SECRET_KEY.encode()).digest())
+    return Fernet(key)
+
+
+def pack_config(cfg: dict) -> str:
+    """Serialize config for storage, encrypting when a key is configured."""
+    raw = json.dumps(cfg)
+    fernet = _fernet()
+    if fernet is None:
+        return raw
+    return _PREFIX + fernet.encrypt(raw.encode()).decode()
+
+
+def unpack_config(stored: str) -> dict:
+    """Inverse of pack_config. Plaintext (legacy / no-key) passes through."""
+    if not stored:
+        return {}
+    if not stored.startswith(_PREFIX):
+        return json.loads(stored)
+    fernet = _fernet()
+    if fernet is None:
+        raise ConfigDecryptError(
+            "integration config is encrypted but THUMPER_SECRET_KEY is not set")
+    try:
+        raw = fernet.decrypt(stored[len(_PREFIX):].encode()).decode()
+    except InvalidToken as exc:
+        raise ConfigDecryptError(
+            "cannot decrypt integration config - wrong or changed "
+            "THUMPER_SECRET_KEY") from exc
+    return json.loads(raw)

--- a/server/thumper/store.py
+++ b/server/thumper/store.py
@@ -13,6 +13,7 @@ from .db import (
     Alert, Deployment, DeliveryAttempt, Endpoint, Integration, Tripwire,
 )
 from .models import iso_now
+from .services.secrets_crypto import pack_config, unpack_config
 
 
 def _id(prefix: str) -> str:
@@ -352,7 +353,7 @@ def upsert_integration(db: Session, *, plugin: str, kind: str,
     if row is None:
         try:
             row = Integration(plugin=plugin, kind=kind, configured=True,
-                              config_json=json.dumps(config))
+                              config_json=pack_config(config))
             db.add(row)
             db.commit()
             db.refresh(row)
@@ -363,7 +364,7 @@ def upsert_integration(db: Session, *, plugin: str, kind: str,
             db.rollback()
             row = db.query(Integration).filter(Integration.plugin == plugin).first()
     row.configured = True
-    row.config_json = json.dumps(config)
+    row.config_json = pack_config(config)
     db.commit()
     db.refresh(row)
     return row

--- a/tests/test_secrets_at_rest.py
+++ b/tests/test_secrets_at_rest.py
@@ -50,6 +50,25 @@ def test_encrypted_but_key_missing_raises(monkeypatch):
         unpack_config(stored)
 
 
+def test_list_integrations_survives_undecryptable_row(monkeypatch, client_db):
+    # A row encrypted under a key that's since changed must not 500 the whole
+    # list - the integration is surfaced as unreadable, others still render.
+    tc, db = client_db
+    monkeypatch.setattr(config, "SECRET_KEY", "old-key")
+    assert tc.post("/api/integrations/webhook",
+                   json={"url": "https://hooks.example/x", "signing_secret": "shhh"}
+                   ).status_code == 200
+    monkeypatch.setattr(config, "SECRET_KEY", "rotated-key")  # old row now opaque
+
+    resp = tc.get("/api/integrations")
+    assert resp.status_code == 200                            # not a 500
+    webhook = next(i for i in resp.json() if i["plugin"] == "webhook")
+    assert webhook["configured"] is True
+    assert webhook["config"] == {}                            # secrets not leaked
+    assert webhook["last_test_status"] == "failed"
+    assert "decrypt" in (webhook["last_test_error"] or "").lower()
+
+
 def test_save_integration_encrypts_in_db(monkeypatch, client_db):
     monkeypatch.setattr(config, "SECRET_KEY", "k-1")
     tc, db = client_db

--- a/tests/test_secrets_at_rest.py
+++ b/tests/test_secrets_at_rest.py
@@ -1,0 +1,64 @@
+"""Integration config is encrypted at rest when THUMPER_SECRET_KEY is set, with
+a plaintext fallback and decrypt-or-passthrough reads (#24)."""
+import json
+
+import pytest
+
+from thumper import config
+from thumper.services import secrets_crypto as sc
+from thumper.services.secrets_crypto import (
+    ConfigDecryptError, pack_config, unpack_config)
+
+SECRET = {"hec_url": "https://splunk.example", "hec_token": "super-secret-token"}
+
+
+def test_roundtrip_with_key(monkeypatch):
+    monkeypatch.setattr(config, "SECRET_KEY", "k-1")
+    stored = pack_config(SECRET)
+    assert stored.startswith("fernet:")
+    assert "super-secret-token" not in stored      # opaque at rest
+    assert unpack_config(stored) == SECRET
+
+
+def test_plaintext_fallback_without_key(monkeypatch):
+    monkeypatch.setattr(config, "SECRET_KEY", None)
+    stored = pack_config(SECRET)
+    assert stored == json.dumps(SECRET)            # plaintext
+    assert unpack_config(stored) == SECRET
+
+
+def test_legacy_plaintext_reads_even_with_key(monkeypatch):
+    monkeypatch.setattr(config, "SECRET_KEY", None)
+    legacy = pack_config(SECRET)                    # plaintext row
+    monkeypatch.setattr(config, "SECRET_KEY", "k-1")  # key added later
+    assert unpack_config(legacy) == SECRET          # passthrough still works
+
+
+def test_wrong_key_raises(monkeypatch):
+    monkeypatch.setattr(config, "SECRET_KEY", "right-key")
+    stored = pack_config(SECRET)
+    monkeypatch.setattr(config, "SECRET_KEY", "different-key")
+    with pytest.raises(ConfigDecryptError):
+        unpack_config(stored)
+
+
+def test_encrypted_but_key_missing_raises(monkeypatch):
+    monkeypatch.setattr(config, "SECRET_KEY", "k-1")
+    stored = pack_config(SECRET)
+    monkeypatch.setattr(config, "SECRET_KEY", None)
+    with pytest.raises(ConfigDecryptError):
+        unpack_config(stored)
+
+
+def test_save_integration_encrypts_in_db(monkeypatch, client_db):
+    monkeypatch.setattr(config, "SECRET_KEY", "k-1")
+    tc, db = client_db
+    resp = tc.post("/api/integrations/webhook",
+                   json={"url": "https://hooks.example/x", "signing_secret": "shhh"})
+    assert resp.status_code == 200
+    from thumper.db import Integration
+    row = db.query(Integration).filter(Integration.plugin == "webhook").first()
+    assert row.config_json.startswith("fernet:")
+    assert "shhh" not in row.config_json           # secret not readable at rest
+    # ...but the API still round-trips the real config to plugins
+    assert sc.unpack_config(row.config_json)["signing_secret"] == "shhh"


### PR DESCRIPTION
Closes #24. New `services/secrets_crypto.py` pack/unpack chokepoint: Fernet-encrypts the integration config blob when `THUMPER_SECRET_KEY` is set (plaintext + startup warning otherwise); decrypt-or-passthrough reads so legacy rows keep working and a wrong/missing key raises instead of wiping config. Adds the `cryptography` dependency.

Note: touches `main.py` lifespan — conflicts at merge time with #22 and #75 (trivial).