### PR TITLE
Linux read sensor via inotify (#7)

### DIFF
--- a/agent/thumper_agent.sh
+++ b/agent/thumper_agent.sh
@@ -486,7 +486,12 @@ watch_inotify() {
         i=$((i + 1))
     done
     log "watching $DEP_COUNT bait file(s) via inotify (path-only; no process/user)"
-    inotifywait -m -q -e access --format '%w' -- "$@" 2>/dev/null | while read -r path; do
+    # Do NOT swallow inotifywait's stderr: if it can't start, or dies at runtime
+    # (e.g. fs.inotify.max_user_watches exhaustion), we want that in the log. A
+    # silently-dark sensor looks exactly like "no one touched the bait", which is
+    # the worst possible failure for a tripwire. -q already keeps normal startup
+    # quiet, so only real errors reach the log here.
+    inotifywait -m -q -e access --format '%w' -- "$@" | while read -r path; do
         idx=""
         j=1
         while [ "$j" -le "$DEP_COUNT" ]; do
@@ -501,7 +506,13 @@ watch_inotify() {
         eval "dep_last_$idx=\$now"
         fire "$idx" "access" "" "" "" "$path"
     done
-    return 0
+    # Reached only when inotifywait exited on its own. If the stop was deliberate
+    # (reconcile/shutdown set the flag), stay quiet - stop_watcher is tearing this
+    # subshell down anyway. Otherwise the real sensor just died: say so loudly and
+    # degrade to the atime poll so we keep *some* coverage rather than going blind.
+    [ -e "${WATCH_STOP_FLAG:-/nonexistent}" ] && return 0
+    err "inotify watcher exited unexpectedly - degrading to atime poll"
+    watch_atime
 }
 
 watch_atime() {
@@ -557,6 +568,7 @@ start_watcher() {  # launch the right sensor in the background; set WATCH_PID
     # not root - so a non-root Mac with passwordless sudo still gets the real
     # sensor. Probe that capability instead of gating on `id -u = 0`, which would
     # silently downgrade such hosts to the lossy atime poll.
+    rm -f "${WATCH_STOP_FLAG:-}" 2>/dev/null || true   # this start is not a stop
     if [ "$(platform)" = "darwin" ] && command -v fs_usage >/dev/null 2>&1 \
        && { [ "$(id -u)" = "0" ] || sudo -n true >/dev/null 2>&1; }; then
         watch_fs_usage &
@@ -570,6 +582,7 @@ start_watcher() {  # launch the right sensor in the background; set WATCH_PID
 
 stop_watcher() {  # kill the watcher AND its fs_usage/grep children
     [ -n "${WATCH_PID:-}" ] || return 0
+    : > "${WATCH_STOP_FLAG:-/dev/null}" 2>/dev/null || true  # mark stop deliberate
     # Reap children FIRST. Killing the subshell first makes the kernel reparent
     # fs_usage/grep to PID 1, after which `pkill -P "$WATCH_PID"` matches nothing
     # and leaks a root fs_usage on every reconcile.
@@ -662,6 +675,9 @@ verify_planted() {
 run() {
     STATE_FILE=${STATE_FILE:-$DEFAULT_STATE}
     MANIFEST_FILE="$(dirname "$STATE_FILE")/planted.list"
+    # Marker that a watcher stop was deliberate (reconcile/shutdown), so a sensor
+    # exiting then can stay quiet instead of crying "sensor died / falling back".
+    WATCH_STOP_FLAG="$(dirname "$STATE_FILE")/watcher.stopping"
     MAIN_PID=$$   # so the backgrounded heartbeat loop can signal us to self-destruct
     # Enforce one-agent-per-install before any work; a duplicate exits here (the
     # EXIT trap below is NOT yet set, so it can't disturb the live holder's lock).

--- a/agent/thumper_agent.sh
+++ b/agent/thumper_agent.sh
@@ -25,9 +25,12 @@
 #   • macOS : `fs_usage`, pre-filtered with grep to ONLY our bait paths before
 #             anything else touches it (so we don't process the whole firehose).
 #             Yields the offending process + (looked-up) user. Needs root.
+#   • Linux : `inotifywait` IN_ACCESS on the bait files (reliable, unprivileged).
+#             inotify reports the event but not the accessing process, so alerts
+#             are path-only (no process/pid/user). Needs the inotify-tools package.
 #   • else  : st_atime poll fallback. NOTE: best-effort only - many systems
-#             (notably macOS with relatime-style behavior) update atime lazily or
-#             not at all, so this can miss reads. fs_usage is the real sensor.
+#             update atime lazily or not at all, so this can miss reads. The real
+#             sensors above are preferred; this is the last resort.
 #
 # Example (the shape an MDM/SSH deploy pushes; run as root for fs_usage):
 #   sudo sh thumper_agent.sh run \
@@ -470,6 +473,37 @@ watch_fs_usage() {
     return 0
 }
 
+watch_inotify() {
+    # Linux read sensor: inotify IN_ACCESS fires on read. `%w` is the watched
+    # path. inotify gives no accessing process, so process/pid/user are empty
+    # (path-only alerts, handled like the atime fallback). Works unprivileged.
+    command -v inotifywait >/dev/null 2>&1 || return 1
+    set --
+    i=1
+    while [ "$i" -le "$DEP_COUNT" ]; do
+        eval "p=\$dep_path_$i"
+        set -- "$@" "$p"
+        i=$((i + 1))
+    done
+    log "watching $DEP_COUNT bait file(s) via inotify (path-only; no process/user)"
+    inotifywait -m -q -e access --format '%w' -- "$@" 2>/dev/null | while read -r path; do
+        idx=""
+        j=1
+        while [ "$j" -le "$DEP_COUNT" ]; do
+            eval "wp=\$dep_path_$j"
+            [ "$wp" = "$path" ] && { idx=$j; break; }
+            j=$((j + 1))
+        done
+        [ -n "$idx" ] || continue
+        now=$(date +%s)
+        eval "last=\$dep_last_$idx"
+        [ $((now - last)) -lt "$DEBOUNCE_SECS" ] && continue
+        eval "dep_last_$idx=\$now"
+        fire "$idx" "access" "" "" "" "$path"
+    done
+    return 0
+}
+
 watch_atime() {
     log "fs_usage unavailable - atime poll every ${POLL}s (best-effort; may miss reads, no process/user)"
     i=1
@@ -526,6 +560,8 @@ start_watcher() {  # launch the right sensor in the background; set WATCH_PID
     if [ "$(platform)" = "darwin" ] && command -v fs_usage >/dev/null 2>&1 \
        && { [ "$(id -u)" = "0" ] || sudo -n true >/dev/null 2>&1; }; then
         watch_fs_usage &
+    elif [ "$(platform)" = "linux" ] && command -v inotifywait >/dev/null 2>&1; then
+        watch_inotify &
     else
         watch_atime &
     fi

--- a/server/thumper/api/routes.py
+++ b/server/thumper/api/routes.py
@@ -488,6 +488,18 @@ DIR="${{THUMPER_DIR:-/usr/local/thumper}}"
 for tool in curl openssl; do
   command -v "$tool" >/dev/null 2>&1 || {{ echo "thumper: $tool is required"; exit 1; }}
 done
+# Linux read detection prefers inotify; ensure inotify-tools (every main distro
+# packages it, none preinstall it). Best-effort - the agent falls back to atime
+# polling if this can't run (offline / locked-down host).
+if [ "$(uname -s)" = "Linux" ] && ! command -v inotifywait >/dev/null 2>&1; then
+  ( if command -v apt-get >/dev/null 2>&1; then apt-get update -qq && apt-get install -y inotify-tools;
+    elif command -v dnf >/dev/null 2>&1; then dnf install -y inotify-tools;
+    elif command -v yum >/dev/null 2>&1; then yum install -y inotify-tools;
+    elif command -v zypper >/dev/null 2>&1; then zypper -n install inotify-tools;
+    elif command -v apk >/dev/null 2>&1; then apk add inotify-tools;
+    elif command -v pacman >/dev/null 2>&1; then pacman -Sy --noconfirm inotify-tools;
+    fi ) >/dev/null 2>&1 || echo "thumper: could not install inotify-tools; using atime fallback"
+fi
 mkdir -p "$DIR"
 curl -fsSL "$SERVER/api/agent/thumper_agent.sh" -o "$DIR/thumper_agent.sh"
 chmod +x "$DIR/thumper_agent.sh"

--- a/tests/test_agent_linux_inotify.py
+++ b/tests/test_agent_linux_inotify.py
@@ -1,0 +1,94 @@
+"""Linux read sensor (#7, foundation for CI/CD #3): on Linux with inotifywait,
+the agent watches bait via inotify IN_ACCESS and fires the signed callback.
+
+Runs on any OS by faking `uname` (-> Linux) and `inotifywait` (emits the watched
+path to simulate an access) on PATH, so it exercises the Linux dispatch branch +
+the agent's parse/fire wiring without a real Linux kernel.
+"""
+import http.server
+import os
+import signal
+import subprocess
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+AGENT = Path(__file__).resolve().parents[1] / "agent" / "thumper_agent.sh"
+BAIT_BODY = "BAIT-honeytoken-content"
+
+
+class _Stub(http.server.BaseHTTPRequestHandler):
+    seen = []
+    bait_path = ""
+
+    def log_message(self, *_a):
+        pass
+
+    def _text(self, body):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.end_headers()
+        self.wfile.write(body.encode())
+
+    def do_POST(self):
+        self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        _Stub.seen.append(self.path)
+        self._text("agent_token=tok-123\nendpoint_id=ep_1\n"
+                   if self.path == "/api/enroll" else "ok")
+
+    def do_GET(self):
+        if self.path == "/api/agent/deployments":
+            base = f"http://{self.headers['Host']}"
+            self._text("\t".join(["dep_0", _Stub.bait_path, "secret",
+                                   f"{base}/content/dep_0", f"{base}/cb/dep_0"]) + "\n")
+        elif self.path.startswith("/content/"):
+            self._text(BAIT_BODY)
+        else:
+            self.send_response(404); self.end_headers()
+
+
+def _write(path, body):
+    path.write_text(body)
+    path.chmod(0o755)
+
+
+@pytest.fixture
+def fakes(tmp_path):
+    d = tmp_path / "fakebin"
+    d.mkdir()
+    _write(d / "uname", "#!/bin/sh\necho Linux\n")
+    # Simulate an access: print the watched path(s) (args after --) then stay alive.
+    _write(d / "inotifywait", "#!/bin/sh\npaths=\nwhile [ $# -gt 0 ]; do "
+           "case \"$1\" in --) shift; paths=\"$*\"; break ;; *) shift ;; esac; done\n"
+           "sleep 0.5\nfor p in $paths; do printf '%s\\n' \"$p\"; done\nsleep 30\n")
+    return d
+
+
+def test_inotify_read_fires_callback(tmp_path, fakes):
+    httpd = http.server.HTTPServer(("127.0.0.1", 0), _Stub)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{httpd.server_address[1]}"
+    bait = tmp_path / "bait"               # agent plants it (must not pre-exist)
+    _Stub.bait_path = str(bait)
+    _Stub.seen = []
+
+    env = {**os.environ, "PATH": f"{fakes}:{os.environ['PATH']}"}
+    proc = subprocess.Popen(
+        ["sh", str(AGENT), "run", "--server", base, "--enroll-token", "dev-enroll-token",
+         "--tripwire", "tw", "--state-file", str(tmp_path / "state" / "agent.json"),
+         "--heartbeat", "0", "--sync-interval", "0"],
+        env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    try:
+        deadline = time.time() + 12
+        while time.time() < deadline:
+            if "/cb/dep_0" in _Stub.seen:
+                break
+            time.sleep(0.2)
+        assert "/cb/dep_0" in _Stub.seen, "inotify access did not fire the callback"
+        assert bait.read_text() == BAIT_BODY  # bait was planted
+    finally:
+        proc.send_signal(signal.SIGTERM)
+        proc.wait(timeout=10)
+        httpd.shutdown()

--- a/tests/test_agent_linux_inotify.py
+++ b/tests/test_agent_linux_inotify.py
@@ -92,3 +92,42 @@ def test_inotify_read_fires_callback(tmp_path, fakes):
         proc.send_signal(signal.SIGTERM)
         proc.wait(timeout=10)
         httpd.shutdown()
+
+
+def test_inotify_failure_degrades_to_atime(tmp_path, fakes):
+    # inotifywait that dies immediately (e.g. fs.inotify watch-limit exhaustion)
+    # must NOT leave a silently-dark sensor - the agent logs the failure (stderr
+    # not swallowed) and falls back to the atime poll instead of going blind.
+    _write(fakes / "inotifywait",
+           "#!/bin/sh\necho 'inotifywait: failed to add watch (max_user_watches)' >&2\nexit 1\n")
+    httpd = http.server.HTTPServer(("127.0.0.1", 0), _Stub)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{httpd.server_address[1]}"
+    bait = tmp_path / "bait"
+    _Stub.bait_path = str(bait)
+    _Stub.seen = []
+
+    env = {**os.environ, "PATH": f"{fakes}:{os.environ['PATH']}"}
+    logf = (tmp_path / "agent.out").open("w+")
+    proc = subprocess.Popen(
+        ["sh", str(AGENT), "run", "--server", base, "--enroll-token", "dev-enroll-token",
+         "--tripwire", "tw", "--state-file", str(tmp_path / "state" / "agent.json"),
+         "--heartbeat", "0", "--sync-interval", "0", "--poll", "1"],
+        env=env, stdout=logf, stderr=subprocess.STDOUT, text=True)
+    try:
+        deadline = time.time() + 10
+        text = ""
+        while time.time() < deadline:
+            text = (tmp_path / "agent.out").read_text()
+            if "degrading to atime poll" in text and "atime poll every" in text:
+                break
+            time.sleep(0.2)
+        # The dead sensor is visible (not swallowed) AND we kept some coverage.
+        assert "inotifywait: failed to add watch" in text, "inotifywait stderr was swallowed"
+        assert "inotify watcher exited unexpectedly - degrading to atime poll" in text
+        assert "atime poll every" in text, "did not fall back to the atime poll"
+    finally:
+        proc.send_signal(signal.SIGTERM)
+        proc.wait(timeout=10)
+        httpd.shutdown()
+        logf.close()

--- a/tests/test_install_command.py
+++ b/tests/test_install_command.py
@@ -77,3 +77,16 @@ def test_enroll_with_two_tripwires_materializes_two_deployments(client_db):
     assert resp.status_code == 200
     eid = [ln for ln in resp.text.splitlines() if ln.startswith("endpoint_id=")][0].split("=", 1)[1]
     assert len(store.list_deployments_for_endpoint(db, eid)) == 2
+
+
+def test_install_script_autoinstalls_inotify_tools(client_db):
+    """The bootstrap installer should ensure inotify-tools on Linux across the
+    main package managers, so read detection works without a manual step (#3/#7)."""
+    tc, _ = client_db
+    resp = tc.get("/api/install.sh", params={"token": "dev-install-token", "tripwire": "tw_x"})
+    assert resp.status_code == 200
+    s = resp.text
+    assert "inotify-tools" in s
+    assert 'uname -s' in s          # gated to Linux
+    for pm in ("apt-get", "dnf", "yum", "zypper", "apk", "pacman"):
+        assert pm in s, f"missing package manager {pm}"


### PR DESCRIPTION
Makes the endpoint read-watch model work on Linux (foundation for the CI/CD tripwire #3; supersedes the broken atime fallback #28).

- Agent: new `watch_inotify` using inotify `IN_ACCESS` — reliable, unprivileged, mount-agnostic; dispatched on Linux when `inotifywait` is present (else atime). Path-only alerts (inotify gives no process), handled like the existing fallback.
- Bootstrap `install.sh` auto-installs `inotify-tools` across the main package managers (apt/dnf/yum/zypper/apk/pacman), best-effort — so it works on the main distros out of the box.

Tested with a faked `uname`/`inotifywait` harness (runs on macOS and real Linux CI); full suite green; generated installer passes `sh -n`.

Closes #7. (References #3 and #28 — not closed: the atime fallback bug in #28 remains, and #3 is downstream.)
