### PR TITLE
Normalize agent callback timestamp to canonical UTC (#31)

### DIFF
--- a/server/thumper/api/routes.py
+++ b/server/thumper/api/routes.py
@@ -685,7 +685,11 @@ async def trigger(request: Request, background: BackgroundTasks,
         pid=int(pid) if pid and str(pid).isdigit() else None,
         os_user=data.get("os_user"),
         event_type=data.get("event_type"),
-        timestamp=data.get("timestamp"),
+        # Store a canonical UTC timestamp, not the agent's raw string: the 24h
+        # count and list ordering compare timestamps as strings, so offset /
+        # fractional-second formats would break them (#31). `ts` is already parsed
+        # and validated above.
+        timestamp=ts.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         triggered_by=data.get("triggered_by"),
     )
     # Only a pending deployment becomes planted. A failed one stays failed.

--- a/tests/test_alert_timestamp_normalize.py
+++ b/tests/test_alert_timestamp_normalize.py
@@ -44,3 +44,28 @@ def test_callback_timestamp_is_normalized(client_db, monkeypatch):
 
     stored = db.query(Alert).filter(Alert.deployment_id == "dp_1").first().timestamp
     assert stored == now.strftime("%Y-%m-%dT%H:%M:%SZ"), f"not normalized: {stored!r}"
+
+
+def test_callback_timestamp_offset_is_converted_not_relabeled(client_db, monkeypatch):
+    # A non-zero offset is the case that actually distinguishes correct tz
+    # conversion (.astimezone) from just relabeling the wall-clock as UTC
+    # (.replace(tzinfo=utc), wrong). Same instant as now, written in a +05:00
+    # zone -> wall-clock is 5h ahead; the stored UTC hour must be shifted back.
+    tc, db = client_db
+    db.add(Deployment(id="dp_1", tripwire_id="tw_1", endpoint_id="ep_1", path="/x",
+                      content="b", hmac_secret="s", state="planted",
+                      created_at="2026-01-01T00:00:00Z"))
+    db.commit()
+    monkeypatch.setattr("thumper.api.routes.deliver_alert", lambda e: None)
+
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    # Same moment as `now`, expressed with a +05:00 offset (wall-clock = now + 5h).
+    offset_ts = (now + timedelta(hours=5)).strftime("%Y-%m-%dT%H:%M:%S") + "+05:00"
+    body = f"deployment_id=dp_1\nprocess=cat\ntimestamp={offset_ts}".encode()
+    resp = tc.post("/api/trigger", content=body,
+                   headers={"X-Thumper-Signature": sign("s", body)})
+    assert resp.status_code == 200
+
+    stored = db.query(Alert).filter(Alert.deployment_id == "dp_1").first().timestamp
+    # Correct: converted back to now (UTC). A relabel would have stored now+5h.
+    assert stored == now.strftime("%Y-%m-%dT%H:%M:%SZ"), f"offset not converted: {stored!r}"

--- a/tests/test_alert_timestamp_normalize.py
+++ b/tests/test_alert_timestamp_normalize.py
@@ -1,0 +1,46 @@
+"""The server must normalize the agent callback timestamp to a canonical UTC
+form before storing, so 24h counts (string compare) and list ordering don't
+break on offset/fractional formats (#31)."""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from thumper.db import Alert, Base, Deployment, get_db
+from thumper.main import app
+from thumper.services.signing import sign
+
+
+@pytest.fixture
+def client_db():
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False},
+                           poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    db = sessionmaker(bind=engine)()
+    app.dependency_overrides[get_db] = lambda: db
+    yield TestClient(app), db
+    del app.dependency_overrides[get_db]
+    db.close()
+
+
+def test_callback_timestamp_is_normalized(client_db, monkeypatch):
+    tc, db = client_db
+    db.add(Deployment(id="dp_1", tripwire_id="tw_1", endpoint_id="ep_1", path="/x",
+                      content="b", hmac_secret="s", state="planted",
+                      created_at="2026-01-01T00:00:00Z"))
+    db.commit()
+    monkeypatch.setattr("thumper.api.routes.deliver_alert", lambda e: None)
+
+    # Fresh, but in a non-canonical format: explicit +00:00 offset + fractional secs.
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    weird = now.strftime("%Y-%m-%dT%H:%M:%S") + ".500+00:00"
+    body = f"deployment_id=dp_1\nprocess=cat\ntimestamp={weird}".encode()
+    resp = tc.post("/api/trigger", content=body,
+                   headers={"X-Thumper-Signature": sign("s", body)})
+    assert resp.status_code == 200
+
+    stored = db.query(Alert).filter(Alert.deployment_id == "dp_1").first().timestamp
+    assert stored == now.strftime("%Y-%m-%dT%H:%M:%SZ"), f"not normalized: {stored!r}"


### PR DESCRIPTION
Closes #31. The `/trigger` handler stored the agent's raw timestamp string; the 24h count and list ordering compare timestamps as strings, so offset/fractional formats broke them. Store the already-parsed ts as `%Y-%m-%dT%H:%M:%SZ`. TDD: a non-canonical (offset+fractional) input asserts a canonical stored value.