### PR TITLE
Redact credentials from stored/logged integration errors (#33)

### DIFF
--- a/server/thumper/api/routes.py
+++ b/server/thumper/api/routes.py
@@ -45,7 +45,7 @@ from ..plugins.registry import get_manifest, load_plugin, public_manifests
 from ..services.alerting import deliver_alert
 from ..services.content import render_content
 from ..services.deploy import build_install, build_install_command, distribute
-from ..services.integrations import mask_config, merge_config, saved_config
+from ..services.integrations import mask_config, merge_config, redact_secrets, saved_config
 from ..services.signing import verify
 from ..tokens import TOKEN_TYPES
 
@@ -423,7 +423,9 @@ def test_integration(plugin: str, db: Session = Depends(get_db)):
     try:
         load_plugin(plugin, cfg).test()
     except Exception as exc:  # noqa: BLE001 - surface any failure as a test result
-        error = str(exc)[:500] or exc.__class__.__name__
+        # Redact credentials (e.g. a token-bearing webhook URL) the exception may
+        # echo, before storing/returning it (#33).
+        error = redact_secrets(str(exc)[:500], cfg) or exc.__class__.__name__
         store.set_integration_test_result(db, plugin=plugin, status="failed", error=error)
         return IntegrationTestResult(ok=False, error=error, tested_at=iso_now())
     store.set_integration_test_result(db, plugin=plugin, status="ok", error=None)

--- a/server/thumper/services/alerting.py
+++ b/server/thumper/services/alerting.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session
 from .. import store
 from ..db import SessionLocal
 from ..plugins.registry import load_plugin
+from .integrations import redact_secrets
 
 log = logging.getLogger("thumper.alerting")
 
@@ -24,13 +25,17 @@ def route_alert(db: Session, event: dict) -> None:
         if integration.kind != "alert" or not integration.configured:
             continue
         plugin_name = integration.plugin
+        cfg = json.loads(integration.config_json)
         try:
-            plugin = load_plugin(plugin_name, json.loads(integration.config_json))
+            plugin = load_plugin(plugin_name, cfg)
             plugin.alert(event)
             status, error = "ok", None
         except Exception as exc:  # noqa: BLE001 - best-effort fan-out
-            log.warning("alert plugin %s failed: %s", plugin_name, exc)
-            status, error = "failed", str(exc)
+            # The exception (e.g. an httpx error) can echo the webhook URL, which
+            # embeds the token - redact before it hits the log or the row (#33).
+            error = redact_secrets(str(exc), cfg)
+            log.warning("alert plugin %s failed: %s", plugin_name, error)
+            status = "failed"
         try:
             store.record_delivery(db, alert_id=alert_id, plugin=plugin_name,
                                   status=status, error=error)

--- a/server/thumper/services/alerting.py
+++ b/server/thumper/services/alerting.py
@@ -25,6 +25,11 @@ def route_alert(db: Session, event: dict) -> None:
         if integration.kind != "alert" or not integration.configured:
             continue
         plugin_name = integration.plugin
+        # MERGE NOTE (#85 encrypt-at-rest): when that lands, this must become
+        # `cfg = unpack_config(integration.config_json)` - json.loads on an
+        # encrypted "fernet:" blob is wrong, and redact_secrets below depends on
+        # cfg holding the real, decrypted values. Whichever of #33/#85 merges
+        # second must reconcile to unpack_config here.
         cfg = json.loads(integration.config_json)
         try:
             plugin = load_plugin(plugin_name, cfg)

--- a/server/thumper/services/integrations.py
+++ b/server/thumper/services/integrations.py
@@ -27,3 +27,18 @@ def merge_config(existing: dict, incoming: dict) -> dict:
     """Apply non-empty incoming values over existing. Blank secret fields left
     untouched so re-saving a form without re-typing secrets doesn't wipe them."""
     return {**existing, **{k: v for k, v in incoming.items() if v not in (None, "")}}
+
+
+def redact_secrets(text: str, config: dict) -> str:
+    """Strip credential material from an error string before it's stored/logged.
+    Replaces each non-trivial config value (tokens, and full URLs that may embed
+    a token in their path/query, e.g. a Slack webhook) with a placeholder (#33).
+    Over-redaction is acceptable - never leak a secret into a delivery error."""
+    if not text:
+        return text
+    # Longest first so a URL containing a token redacts as one unit.
+    for value in sorted((v for v in config.values() if isinstance(v, str)),
+                        key=len, reverse=True):
+        if len(value) >= 6:
+            text = text.replace(value, "•••")
+    return text

--- a/server/thumper/services/integrations.py
+++ b/server/thumper/services/integrations.py
@@ -33,7 +33,14 @@ def redact_secrets(text: str, config: dict) -> str:
     """Strip credential material from an error string before it's stored/logged.
     Replaces each non-trivial config value (tokens, and full URLs that may embed
     a token in their path/query, e.g. a Slack webhook) with a placeholder (#33).
-    Over-redaction is acceptable - never leak a secret into a delivery error."""
+    Over-redaction is acceptable - never leak a secret into a delivery error.
+
+    Matching is verbatim only, not encoding-aware: it catches the secret exactly
+    as configured (the documented case - httpx echoes the URL as given), but not
+    transformed forms (percent-/JSON-/basic-auth-encoded), where a layer has
+    re-encoded the value. The residual risk is under-redaction of an encoded
+    secret; fine for the current threat model, but worth knowing before relying
+    on this for anything that round-trips the value through another encoder."""
     if not text:
         return text
     # Longest first so a URL containing a token redacts as one unit.

--- a/tests/test_error_redaction.py
+++ b/tests/test_error_redaction.py
@@ -1,0 +1,56 @@
+"""Credential material must not leak into stored/returned integration errors —
+the webhook URL embeds its token (#33)."""
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from thumper import store
+from thumper.api import routes
+from thumper.db import Base, get_db
+from thumper.main import app
+from thumper.services.integrations import redact_secrets
+
+SECRET_URL = "https://hooks.slack.com/services/T00/B00/superSecretToken123"
+
+
+@pytest.fixture
+def client_db():
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False},
+                           poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    db = sessionmaker(bind=engine)()
+    app.dependency_overrides[get_db] = lambda: db
+    yield TestClient(app), db
+    del app.dependency_overrides[get_db]
+    db.close()
+
+
+def test_redact_secrets_removes_url_and_token():
+    text = f"connect to {SECRET_URL} failed"
+    out = redact_secrets(text, {"url": SECRET_URL})
+    assert "superSecretToken123" not in out
+    assert SECRET_URL not in out
+    assert "•••" in out
+
+
+def test_redact_keeps_short_values():
+    # short/boolean-ish values aren't redacted (avoid mangling normal text)
+    assert redact_secrets("port 443 ok", {"port": "443"}) == "port 443 ok"
+
+
+def test_test_endpoint_error_is_redacted(client_db, monkeypatch):
+    tc, db = client_db
+    tc.post("/api/integrations/webhook", json={"url": SECRET_URL})
+
+    class Boom:
+        def test(self):
+            raise RuntimeError(f"POST {SECRET_URL} -> connection refused")
+
+    monkeypatch.setattr(routes, "load_plugin", lambda name, cfg: Boom())
+    resp = tc.post("/api/integrations/webhook/test")
+    assert resp.status_code == 200
+    assert "superSecretToken123" not in resp.json()["error"]
+    stored = store.get_integration(db, "webhook").last_test_error
+    assert "superSecretToken123" not in stored


### PR DESCRIPTION
Closes #33. A failed webhook/alert request can echo the webhook URL — which embeds the token — into the delivery error, the integration-test result, and the log. Adds `redact_secrets()` and applies it at all three points so secret values never persist or get logged. Unit + endpoint tests.