### PR TITLE
Deployment badge reflects endpoint liveness (#27)

### DIFF
--- a/server/thumper/api/routes.py
+++ b/server/thumper/api/routes.py
@@ -99,6 +99,12 @@ def _tripwire_out(db, tripwire, *, deployed_count=None, triggered_count=None) ->
 
 def _deployment_out(db, deployment) -> DeploymentOut:
     endpoint = store.get_endpoint(db, deployment.endpoint_id)
+    if endpoint is None:
+        endpoint_status = "inactive"
+    elif endpoint.decommission_requested_at:
+        endpoint_status = "decommissioning"
+    else:
+        endpoint_status = _endpoint_status(endpoint.last_seen)
     return DeploymentOut(
         id=deployment.id, tripwire_id=deployment.tripwire_id,
         endpoint_id=deployment.endpoint_id,
@@ -106,6 +112,7 @@ def _deployment_out(db, deployment) -> DeploymentOut:
         state=deployment.state, created_at=deployment.created_at,
         last_triggered=deployment.last_triggered,
         triggered_count=store.count_alerts_for_deployment(db, deployment.id),
+        endpoint_status=endpoint_status,
     )
 
 

--- a/server/thumper/api/routes.py
+++ b/server/thumper/api/routes.py
@@ -83,6 +83,17 @@ def _endpoint_status(last_seen: str | None) -> str:
     return "inactive"
 
 
+def _endpoint_status_full(endpoint) -> str:
+    """Liveness status for an endpoint, including the decommissioning override and
+    the missing-endpoint case. Single source of truth so _endpoint_out and
+    _deployment_out can't drift if a new status is ever added."""
+    if endpoint is None:
+        return "inactive"
+    if endpoint.decommission_requested_at:
+        return "decommissioning"
+    return _endpoint_status(endpoint.last_seen)
+
+
 def _tripwire_out(db, tripwire, *, deployed_count=None, triggered_count=None) -> TripwireOut:
     if deployed_count is None:
         deployed_count = len(store.list_deployments_for_tripwire(db, tripwire.id))
@@ -99,12 +110,7 @@ def _tripwire_out(db, tripwire, *, deployed_count=None, triggered_count=None) ->
 
 def _deployment_out(db, deployment) -> DeploymentOut:
     endpoint = store.get_endpoint(db, deployment.endpoint_id)
-    if endpoint is None:
-        endpoint_status = "inactive"
-    elif endpoint.decommission_requested_at:
-        endpoint_status = "decommissioning"
-    else:
-        endpoint_status = _endpoint_status(endpoint.last_seen)
+    endpoint_status = _endpoint_status_full(endpoint)
     return DeploymentOut(
         id=deployment.id, tripwire_id=deployment.tripwire_id,
         endpoint_id=deployment.endpoint_id,
@@ -125,8 +131,7 @@ def _endpoint_out(db, endpoint, *, deployment_count=None, triggered_count=None) 
     return EndpointOut(
         id=endpoint_id, hostname=endpoint.hostname, platform=endpoint.platform,
         enrolled_at=endpoint.enrolled_at, last_seen=endpoint.last_seen,
-        status="decommissioning" if endpoint.decommission_requested_at
-        else _endpoint_status(endpoint.last_seen),
+        status=_endpoint_status_full(endpoint),
         deployment_count=deployment_count,
         triggered_count=triggered_count,
     )

--- a/server/thumper/models.py
+++ b/server/thumper/models.py
@@ -52,6 +52,7 @@ class DeploymentOut(BaseModel):
     created_at: str
     last_triggered: Optional[str] = None
     triggered_count: int
+    endpoint_status: str = "inactive"   # online | stale | inactive | decommissioning
 
 
 class InstallSpecOut(BaseModel):

--- a/tests/test_deployment_liveness.py
+++ b/tests/test_deployment_liveness.py
@@ -28,9 +28,12 @@ def _ago(**kw):
     return (datetime.now(timezone.utc) - timedelta(**kw)).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def _seed(db, last_seen):
-    db.add(Endpoint(id="ep_1", hostname="h", platform="linux", machine_id="m1",
-                    agent_token="t", enrolled_at="2026-01-01T00:00:00Z", last_seen=last_seen))
+def _seed(db, last_seen, *, decommission_requested_at=None, with_endpoint=True):
+    if with_endpoint:
+        db.add(Endpoint(id="ep_1", hostname="h", platform="linux", machine_id="m1",
+                        agent_token="t", enrolled_at="2026-01-01T00:00:00Z",
+                        last_seen=last_seen,
+                        decommission_requested_at=decommission_requested_at))
     db.add(Deployment(id="dp_1", tripwire_id="tw_1", endpoint_id="ep_1", path="/x",
                       content="b", hmac_secret="s", state="planted",
                       created_at="2026-01-01T00:00:00Z"))
@@ -60,3 +63,19 @@ def test_planted_on_stale_endpoint(client_db):
     tc, db = client_db
     tid = _seed(db, _ago(hours=1))
     assert _endpoint_status_in_detail(tc, tid) == "stale"
+
+
+def test_planted_on_decommissioning_endpoint(client_db):
+    # A pending decommission overrides liveness: even a freshly-seen endpoint
+    # reads as "decommissioning", not "online".
+    tc, db = client_db
+    tid = _seed(db, _ago(minutes=2), decommission_requested_at=_ago(minutes=1))
+    assert _endpoint_status_in_detail(tc, tid) == "decommissioning"
+
+
+def test_planted_on_missing_endpoint(client_db):
+    # Deployment outlived its endpoint (host removed): no endpoint row -> inactive,
+    # not a 500.
+    tc, db = client_db
+    tid = _seed(db, None, with_endpoint=False)
+    assert _endpoint_status_in_detail(tc, tid) == "inactive"

--- a/tests/test_deployment_liveness.py
+++ b/tests/test_deployment_liveness.py
@@ -1,0 +1,62 @@
+"""A deployment should surface its endpoint's liveness, so the UI can stop showing
+green 'planted' for an endpoint that's gone stale/offline (#27)."""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from thumper.db import Base, Deployment, Endpoint, get_db
+from thumper.main import app
+
+
+@pytest.fixture
+def client_db():
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False},
+                           poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    db = sessionmaker(bind=engine)()
+    app.dependency_overrides[get_db] = lambda: db
+    yield TestClient(app), db
+    del app.dependency_overrides[get_db]
+    db.close()
+
+
+def _ago(**kw):
+    return (datetime.now(timezone.utc) - timedelta(**kw)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _seed(db, last_seen):
+    db.add(Endpoint(id="ep_1", hostname="h", platform="linux", machine_id="m1",
+                    agent_token="t", enrolled_at="2026-01-01T00:00:00Z", last_seen=last_seen))
+    db.add(Deployment(id="dp_1", tripwire_id="tw_1", endpoint_id="ep_1", path="/x",
+                      content="b", hmac_secret="s", state="planted",
+                      created_at="2026-01-01T00:00:00Z"))
+    # tripwire row so the detail endpoint resolves
+    from thumper import store
+    db.add  # noqa
+    store.create_tripwire(db, name="t", token_type="aws", path="/x", token="x")
+    # point the deployment at the real tripwire id
+    tw = store.list_tripwires(db)[0]
+    db.query(Deployment).filter(Deployment.id == "dp_1").update({"tripwire_id": tw.id})
+    db.commit()
+    return tw.id
+
+
+def _endpoint_status_in_detail(tc, tid):
+    body = tc.get(f"/api/tripwires/{tid}").json()
+    return body["deployments"][0]["endpoint_status"]
+
+
+def test_planted_on_online_endpoint(client_db):
+    tc, db = client_db
+    tid = _seed(db, _ago(minutes=2))
+    assert _endpoint_status_in_detail(tc, tid) == "online"
+
+
+def test_planted_on_stale_endpoint(client_db):
+    tc, db = client_db
+    tid = _seed(db, _ago(hours=1))
+    assert _endpoint_status_in_detail(tc, tid) == "stale"

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -49,6 +49,7 @@ export interface Deployment {
   created_at: string;
   last_triggered: string | null;
   triggered_count: number;
+  endpoint_status: EndpointStatus;
 }
 
 /** What the operator distributes (via MDM/SSH/etc) to put this tripwire on

--- a/ui/src/components/ui.tsx
+++ b/ui/src/components/ui.tsx
@@ -48,11 +48,21 @@ export function TripwireBadge({ deployed, triggered }: { deployed: number; trigg
 }
 
 /** Per-endpoint instance status. */
-export function DeployBadge({ state, triggered }: { state: DeploymentState; triggered?: number }) {
+export function DeployBadge({ state, triggered, endpointStatus }:
+  { state: DeploymentState; triggered?: number; endpointStatus?: EndpointStatus }) {
   if (triggered && triggered > 0) {
     return (
       <span className="badge triggered">
         <span className="dot" /> {triggered} triggered
+      </span>
+    );
+  }
+  // Planted bait on an offline endpoint isn't really "covered" - the agent may no
+  // longer be watching. Mute it (amber) instead of healthy green (#27).
+  if (state === "planted" && endpointStatus && endpointStatus !== "online") {
+    return (
+      <span className="badge pending" title="endpoint offline - bait may not be watched">
+        <span className="dot" /> planted · offline
       </span>
     );
   }

--- a/ui/src/pages/EndpointDetail.tsx
+++ b/ui/src/pages/EndpointDetail.tsx
@@ -159,7 +159,7 @@ export default function EndpointDetail() {
                     <td className="path">{d.id}</td>
                     <td className="muted">{timeAgo(d.created_at)}</td>
                     <td className="muted">{d.last_triggered ? timeAgo(d.last_triggered) : "-"}</td>
-                    <td><DeployBadge state={d.state} triggered={d.triggered_count} /></td>
+                    <td><DeployBadge state={d.state} triggered={d.triggered_count} endpointStatus={d.endpoint_status} /></td>
                     <td>
                       <button
                         className="btn-icon danger"

--- a/ui/src/pages/TripwireDetail.tsx
+++ b/ui/src/pages/TripwireDetail.tsx
@@ -147,7 +147,7 @@ export default function TripwireDetail() {
                     <td className="muted">
                       {d.last_triggered ? timeAgo(d.last_triggered) : "-"}
                     </td>
-                    <td><DeployBadge state={d.state} triggered={d.triggered_count} /></td>
+                    <td><DeployBadge state={d.state} triggered={d.triggered_count} endpointStatus={d.endpoint_status} /></td>
                   </tr>
                 ))}
               </tbody>


### PR DESCRIPTION
Closes #27. A deployment kept showing green 'planted' even when its endpoint went stale/offline. `DeploymentOut` now carries `endpoint_status`; `DeployBadge` mutes a planted bait to amber 'planted · offline' when the endpoint isn't online. Backend TDD (online vs stale) + UI build.