### PR TITLE
docs: point Docs link to jesta.ai/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <p align="center">
   <a href="https://jesta.ai/thumper">Website</a>
   &nbsp;·&nbsp;
-  <a href="https://docs.jesta.ai"><strong>Docs</strong></a>
+  <a href="https://jesta.ai/docs"><strong>Docs</strong></a>
   &nbsp;·&nbsp;
   <a href="docs/architecture.md">Get started »</a>
 </p>


### PR DESCRIPTION
The docs moved from the `docs.jesta.ai` subdomain to the `jesta.ai/docs` subpath (Mintlify, now served behind a Cloudflare Worker on the main domain). This updates the README "Docs" link.

- `https://docs.jesta.ai` → `https://jesta.ai/docs`

Both work today (the old subdomain 301-redirects to the subpath), but the README should point at the canonical URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #92.
