### PR TITLE
CLI re-run registers a new tripwire with the running agent (#12)

### DIFF
--- a/agent/thumper_agent.sh
+++ b/agent/thumper_agent.sh
@@ -103,6 +103,19 @@ lock_holder_alive() {
         && ps -p "$oldpid" -o command= 2>/dev/null | grep -q thumper_agent
 }
 
+# Another agent already watches this install location (the singleton). Don't start
+# a second watcher - instead register our tripwire(s) with the server so the
+# running agent plants them on its next live-sync (#12). Enroll is idempotent
+# (same machine_id -> same endpoint + token), so this is safe even for an
+# accidental identical re-run.
+register_with_running_agent() {
+    log "another agent is already running (pid $oldpid); registering tripwires for it"
+    [ "$FORCE" = 1 ] || preflight_paths || exit 1
+    do_enroll || { err "enroll failed"; exit 1; }
+    log "registered; the running agent will plant on its next sync (<=${SYNC_INTERVAL}s)"
+    exit 0
+}
+
 acquire_singleton() {
     LOCK_DIR="$(dirname "$STATE_FILE")/agent.lock"
     mkdir -p "$(dirname "$LOCK_DIR")"             # ensure the state dir exists
@@ -113,8 +126,7 @@ acquire_singleton() {
             return 0
         fi
         if lock_holder_alive; then
-            log "another agent is already running (pid $oldpid); exiting"
-            exit 0
+            register_with_running_agent
         fi
         err "clearing stale lock (holder '${oldpid:-?}' is not a live agent)"
         rm -rf "$LOCK_DIR"
@@ -124,8 +136,7 @@ acquire_singleton() {
     # Sustained contention: a peer keeps winning the mkdir. Defer to it if it's a
     # live agent rather than killing a legitimately-needed start.
     if lock_holder_alive; then
-        log "another agent is already running (pid $oldpid); exiting"
-        exit 0
+        register_with_running_agent
     fi
     err "could not acquire singleton lock"; exit 1
 }

--- a/tests/test_agent_singleton.py
+++ b/tests/test_agent_singleton.py
@@ -94,15 +94,18 @@ def agent(tmp_path):
         httpd.shutdown()
 
 
-def test_second_agent_exits_without_enrolling(agent):
-    """A live agent holds the lock; a second start exits 0 and never enrolls."""
+def test_second_agent_registers_but_does_not_watch(agent):
+    """A live agent holds the lock; a second start REGISTERS its tripwires with the
+    server (so the running agent live-syncs them, #12) but does NOT become a second
+    watcher or take the lock."""
     holder = agent["fake_holder"]("thumper_agent.sh")
     agent["write_lock"](holder)
 
     result = agent["run"]()
 
     assert result.returncode == 0
-    assert "/api/enroll" not in _StubHandler.seen, "second agent enrolled - not a singleton"
+    assert "/api/enroll" in _StubHandler.seen, "second start should register its tripwires"
+    assert "/api/agent/deployments" not in _StubHandler.seen, "second start must not become a watcher"
     assert "already running" in (result.stdout + result.stderr).lower()
     # the live holder's lock is untouched
     assert (agent["lock_dir"] / "pid").read_text().strip() == str(holder)
@@ -144,7 +147,9 @@ def test_initializing_holder_is_not_reclaimed(agent):
     result = agent["run"]()
 
     assert result.returncode == 0
-    assert "/api/enroll" not in _StubHandler.seen, "reclaimed an initializing holder's lock"
+    # Deferred to the initializing holder (didn't steal its lock); it registers
+    # rather than reclaiming - the lock still belongs to the holder.
+    assert "/api/agent/deployments" not in _StubHandler.seen, "reclaimed an initializing holder's lock"
     assert "already running" in (result.stdout + result.stderr).lower()
     assert (agent["lock_dir"] / "pid").read_text().strip() == str(holder)
 


### PR DESCRIPTION
The singleton made a CLI re-run a silent no-op, so you couldn't add a tripwire to a box already running an agent.

Now, when the lock is held by a live agent, the re-run registers its tripwire(s) with the server (preflight + idempotent enroll) and exits 0. The incumbent agent picks them up on its next live-sync (≤ `--sync-interval`) and plants them. Only the watcher stays singleton-gated.

Tests updated to the new registers-but-doesn't-watch behavior.

Closes #12.