### PR TITLE
Log successful agent heartbeats

### DIFF
--- a/agent/thumper_agent.sh
+++ b/agent/thumper_agent.sh
@@ -392,6 +392,7 @@ heartbeat_loop() {
             kill -USR1 "$MAIN_PID" 2>/dev/null
             return
         fi
+        log "heartbeat succeeded"
     done
 }
 

--- a/tests/test_agent_live_sync.py
+++ b/tests/test_agent_live_sync.py
@@ -231,6 +231,20 @@ def test_heartbeat_recovers_token_after_reset(agent):
         "heartbeat did not recover the rotated token from the state file"
 
 
+def test_heartbeat_success_is_logged(agent):
+    keep = agent["keep"]
+    agent["set"]([{"id": "dep_keep", "path": keep}])
+    proc = agent["start"]("--sync-interval", "1", "--heartbeat", "1")
+    assert _wait_until(lambda: Path(keep).exists()), "initial bait not planted"
+
+    before = _StubHandler.heartbeats_ok
+    assert _wait_until(lambda: _StubHandler.heartbeats_ok > before), "no heartbeat sent"
+
+    proc.send_signal(signal.SIGTERM)
+    stdout, stderr = proc.communicate(timeout=5)
+    assert "heartbeat succeeded" in stdout + stderr
+
+
 def test_verify_replants_a_deleted_bait(agent):
     keep = agent["keep"]
     agent["set"]([{"id": "dep_keep", "path": keep}])


### PR DESCRIPTION
## Summary
- Log a `heartbeat succeeded` line after the agent receives a normal heartbeat response.
- Add a real-agent regression test that waits for a successful heartbeat and verifies the success log is emitted.

Fixes #17.

## Tests
- `uv run --extra dev pytest tests/test_agent_live_sync.py::test_heartbeat_success_is_logged -q`
- `uv run --extra dev pytest tests/test_agent_live_sync.py tests/test_heartbeat.py -q`
- `sh -n agent/thumper_agent.sh`
- `uv run python -m compileall server tests`
- `git diff --check`
- `uv run --extra dev pytest -q`