### PR TITLE
Fix #16: Fake installation output

### DIFF
--- a/server/thumper/api/routes.py
+++ b/server/thumper/api/routes.py
@@ -513,10 +513,18 @@ curl -fsSL "$SERVER/api/agent/thumper_agent.sh" -o "$DIR/thumper_agent.sh"
 chmod +x "$DIR/thumper_agent.sh"
 # Start watching in the background. Runs as root (for fs_usage); the agent plants
 # bait in the real user's home and chowns it to that user.
-nohup sh "$DIR/thumper_agent.sh" run \\
-  --server "$SERVER" --enroll-token "$ENROLL_TOKEN" {tw_args} \\
+nohup sh "$DIR/thumper_agent.sh" run \
+  --server "$SERVER" --enroll-token "$ENROLL_TOKEN" {tw_args} \
   --heartbeat 60 --state-file "$DIR/agent.json" >"$DIR/agent.log" 2>&1 &
-echo "thumper: agent installed in $DIR and watching (logs: $DIR/agent.log)"
+# The agent may exit immediately if another instance is already running.
+# Wait briefly and verify it is alive before reporting success.
+sleep 1
+if kill -0 $! 2>/dev/null; then
+  echo "thumper: agent installed in $DIR and watching (logs: $DIR/agent.log)"
+else
+  echo "thumper: agent exited immediately; check $DIR/agent.log" >&2
+  exit 1
+fi
 """
     return PlainTextResponse(script, media_type="text/x-shellscript")
 

--- a/server/thumper/api/routes.py
+++ b/server/thumper/api/routes.py
@@ -513,8 +513,8 @@ curl -fsSL "$SERVER/api/agent/thumper_agent.sh" -o "$DIR/thumper_agent.sh"
 chmod +x "$DIR/thumper_agent.sh"
 # Start watching in the background. Runs as root (for fs_usage); the agent plants
 # bait in the real user's home and chowns it to that user.
-nohup sh "$DIR/thumper_agent.sh" run \
-  --server "$SERVER" --enroll-token "$ENROLL_TOKEN" {tw_args} \
+nohup sh "$DIR/thumper_agent.sh" run \\
+  --server "$SERVER" --enroll-token "$ENROLL_TOKEN" {tw_args} \\
   --heartbeat 60 --state-file "$DIR/agent.json" >"$DIR/agent.log" 2>&1 &
 # The agent may exit immediately if another instance is already running.
 # Wait briefly and verify it is alive before reporting success.


### PR DESCRIPTION
Fixes #16

Added a liveness check to the install script in `server/thumper/api/routes.py:519-527` so it detects when the agent exits immediately (e.g., due to another instance already running) and prints a clear failure message instead of falsely reporting success.

Local tests pass.

---
This change was prepared with AI assistance under human direction and review.