### PR TITLE
ci: add Dependabot + CodeQL static analysis (#60)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+# Dependabot keeps the project's dependencies patched (#60). One entry per
+# ecosystem present in the repo: the Python server (pip/pyproject), the React UI
+# (npm), the GitHub Actions we pin, and the runtime Docker base image.
+# Patch/minor bumps are grouped to keep PR volume sane; majors stay separate so
+# breaking changes get their own review.
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      python-minor-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "npm"
+    directory: "/ui"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      ui-minor-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,3 @@
-# Dependabot keeps the project's dependencies patched (#60). One entry per
-# ecosystem present in the repo: the Python server (pip/pyproject), the React UI
-# (npm), the GitHub Actions we pin, and the runtime Docker base image.
-# Patch/minor bumps are grouped to keep PR volume sane; majors stay separate so
-# breaking changes get their own review.
 version: 2
 updates:
   - package-ecosystem: "pip"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,9 +1,3 @@
-# Static code analysis (#60): GitHub CodeQL over the Python server and the
-# TypeScript/React UI. Runs on pushes/PRs to main and weekly, so regressions and
-# newly-disclosed query results surface in the Security tab. `security-extended`
-# is used deliberately - this is a security product, so deeper security coverage
-# is worth the extra query time. Python and JS/TS need no build step (CodeQL
-# analyzes the source directly).
 name: CodeQL
 
 on:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+# Static code analysis (#60): GitHub CodeQL over the Python server and the
+# TypeScript/React UI. Runs on pushes/PRs to main and weekly, so regressions and
+# newly-disclosed query results surface in the Security tab. `security-extended`
+# is used deliberately - this is a security product, so deeper security coverage
+# is worth the extra query time. Python and JS/TS need no build step (CodeQL
+# analyzes the source directly).
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "30 5 * * 1" # Mondays 05:30 UTC
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["python", "javascript-typescript"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Closes #60.

## What

- **`.github/dependabot.yml`** — weekly dependency updates for all four ecosystems present in the repo:
  - `pip` (server, `/pyproject.toml`)
  - `npm` (UI, `/ui`)
  - `github-actions` (the workflows we pin)
  - `docker` (runtime base image)
  
  Minor/patch updates are grouped per-ecosystem to keep PR volume manageable; majors stay separate so breaking changes get their own review. `open-pull-requests-limit: 5` per ecosystem.

- **`.github/workflows/codeql.yml`** — CodeQL static analysis over Python and TypeScript/React, on push/PR to `main` and weekly. Uses `security-extended` queries (deeper security coverage, fitting for a security product); results surface in the **Security** tab. Python and JS/TS need no build step.

## Notes

- CodeQL is free for public repos; no setup beyond this workflow.
- This also addresses the floating-dependency / supply-chain hardening point raised during the recent security review (no lockfile-pinning automation existed).

## Verification

- Both YAML files parse; Dependabot covers exactly `{pip, npm, github-actions, docker}`; CodeQL matrix is `[python, javascript-typescript]` with `security-events: write`.
- CodeQL/Dependabot themselves run on GitHub once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)