### PR TITLE
docs: document THUMPER_ALLOWED_HOOK_CIDRS and THUMPER_SECRET_KEY env …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,12 @@ THUMPER_INSTALL_TOKEN=dev-install-token
 
 # Dashboard auto-refresh interval in seconds. 0 disables.
 THUMPER_DASHBOARD_REFRESH=60
+# Comma-separated CIDRs/IPs allowed as outbound integration targets,
+# exempting them from the SSRF guard (e.g. an internal Splunk/Loki host).
+# THUMPER_ALLOWED_HOOK_CIDRS=10.0.0.0/8,192.168.1.50
+
+# Secret used to derive a Fernet key for encrypting integration credentials
+# at rest. If unset, secrets are stored in plaintext (a startup warning fires).
+# Generate a strong random value for production.
+# THUMPER_SECRET_KEY=
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,6 +91,8 @@ All options overridable via environment:
 | `THUMPER_AGENT_PATH` | `./agent/thumper_agent.sh` | Agent script to serve |
 | `THUMPER_PLUGINS_DIR` | `./plugins` | Plugin discovery root |
 | `THUMPER_DASHBOARD_REFRESH` | `60` | Auto-refresh interval (seconds, 0 = off) |
+| `THUMPER_ALLOWED_HOOK_CIDRS` | _(unset)_ | Comma-separated CIDRs/IPs exempted from the SSRF guard for outbound integration targets |
+| `THUMPER_SECRET_KEY` | _(unset)_ | Encrypts integration credentials at rest (Fernet); unset stores them in plaintext |
 
 ## Security & trust model
 


### PR DESCRIPTION
Closes #110

Adds documentation for THUMPER_ALLOWED_HOOK_CIDRS and THUMPER_SECRET_KEY to docs/architecture.md and .env.example, matching the existing format. Defaults and behavior cross-checked against server/thumper/config.py.

Docs-only change — no code touched, so no test impact.