### PR TITLE
Add commit signing requirement to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,10 @@
 # Contributing
 
 1. Fork the repo, create a branch, open a PR against `main`.
-2. Run `pip install -e ".[dev]"` and make sure `pytest -v` passes before submitting.
-3. For UI work: `cd ui && npm install && npm run dev`.
-4. For plugins, see [docs/plugins.md](docs/plugins.md).
+2. **Sign your commits** (GPG or SSH). Unsigned commits will not be merged. See [GitHub's guide](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for setup.
+3. Run `pip install -e ".[dev]"` and make sure `pytest -v` passes before submitting.
+4. For UI work: `cd ui && npm install && npm run dev`.
+5. For plugins, see [docs/plugins.md](docs/plugins.md).
 
 Report security vulnerabilities privately - see [SECURITY.md](SECURITY.md).
 


### PR DESCRIPTION
## Summary
- Adds a commit signing requirement (GPG or SSH) as step 2 in CONTRIBUTING.md
- Links to GitHub's signing setup guide
- Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)