### PR TITLE
FIFO named-pipe bait sensor (replaces fs_usage)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,14 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    # macOS is included so the FIFO read sensor (macOS-only; #100) actually runs
+    # in CI - the FIFO tests are skipif!=Darwin, so ubuntu alone never exercises
+    # them. Linux covers inotify/atime; macOS covers the FIFO path.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Lint
         run: ruff check .
 
-  test:
+  test-matrix:
     # macOS is included so the FIFO read sensor (macOS-only; #100) actually runs
     # in CI - the FIFO tests are skipif!=Darwin, so ubuntu alone never exercises
     # them. Linux covers inotify/atime; macOS covers the FIFO path.
@@ -41,3 +41,19 @@ jobs:
 
       - name: Run tests
         run: pytest -v
+
+  # Aggregate gate with a stable name. Branch protection requires the check
+  # "test"; the OS matrix above emits per-leg names ("test-matrix (ubuntu-latest)"
+  # etc.), so this single job is what the ruleset keys on. It stays green only
+  # when every matrix leg passes, and the name is invariant to matrix changes.
+  test:
+    needs: [test-matrix]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require all matrix legs to pass
+        run: |
+          if [ "${{ needs.test-matrix.result }}" != "success" ]; then
+            echo "one or more test-matrix legs failed: ${{ needs.test-matrix.result }}"
+            exit 1
+          fi

--- a/agent/thumper_agent.sh
+++ b/agent/thumper_agent.sh
@@ -556,9 +556,22 @@ plant_all() {  # plant every current deployment; sets `planted`
     done
 }
 
-# attribute <fifo> : best-effort set of globals process/pid/os_user. Real
-# implementation lands in the attribution task; default is "unknown".
-attribute() { pid=""; process=""; os_user=""; return 0; }
+# attribute <fifo> : best-effort set globals pid/process/os_user to the reader's.
+# lsof <path> does NOT report FIFO openers on macOS; full-scan and match by inode.
+attribute() {  # attribute <fifo> ; best-effort set globals pid/process/os_user
+    pid=""; process=""; os_user=""
+    command -v lsof >/dev/null 2>&1 || return 0
+    ino=$(stat -f %i "$1" 2>/dev/null || stat -c %i "$1" 2>/dev/null) || return 0
+    [ -n "$ino" ] || return 0
+    # Full scan: pick the process whose fd on THIS inode is open for READ (4r) and
+    # is not our serve subshell ($$). Inode matched as a standalone field so a
+    # blank DEVICE column can't shift parsing.
+    pid=$(lsof -nP 2>/dev/null | awk -v ino="$ino" -v me="$$" '
+        index($0,"FIFO") && $2!=me && $4 ~ /r$/ && $0 ~ ("(^|[ \t])" ino "([ \t]|$)") { print $2; exit }')
+    [ -n "$pid" ] || { pid=""; return 0; }
+    process=$(ps -o comm= -p "$pid" 2>/dev/null | sed 's#.*/##' | tr -d ' ')
+    os_user=$(user_of_pid "$pid")
+}
 
 serve_fifo() {  # serve_fifo <i> - serve one bait FIFO forever; a read = a hit
     eval "fifo=\$dep_path_$1 id=\$dep_id_$1"

--- a/agent/thumper_agent.sh
+++ b/agent/thumper_agent.sh
@@ -39,7 +39,7 @@ set -eu
 DEFAULT_STATE="$HOME/.thumper/agent.json"
 READ_OPS="open read RdData pread readlink mmap"
 # macOS background daemons that legitimately touch files (indexing/backup/security).
-NOISE_PROCS="fs_usage sh bash thumper_agent curl mds mds_stores mdworker mdworker_shared mdbulkimport mdflagwriter mdsync fseventsd backupd tccd syspolicyd XProtect XprotectService quicklookd Spotlight mdiagnosticd"
+NOISE_PROCS="sh bash thumper_agent curl mds mds_stores mdworker mdworker_shared mdbulkimport mdflagwriter mdsync fseventsd backupd tccd syspolicyd XProtect XprotectService quicklookd Spotlight mdiagnosticd"
 DEBOUNCE_SECS=3
 REPLANT_MAX=3   # max re-plant attempts per deployment before giving up (verify pass)
 # After a callback is rejected with 401 (server no longer knows this deployment -
@@ -322,7 +322,7 @@ plant() {  # plant <i>
             rm -f "$cf"; err "failed to fetch bait for $id"; report_plant "$id" failed; return 1
         fi
         chmod 600 "$cf" 2>/dev/null || true
-        [ -p "$path" ] && rm -f "$path"          # replace our own stale FIFO on re-plant
+        { [ -p "$path" ] || [ -f "$path" ]; } && rm -f "$path"  # replace our own stale bait on re-plant
         if ! mkfifo "$path" 2>/dev/null; then
             rm -f "$cf"; err "mkfifo failed at $path - skipping $id"; report_plant "$id" failed; return 1
         fi
@@ -472,48 +472,12 @@ dep_index_for_line() {  # echo the deployment index whose path appears in the li
 is_read_op() { for op in $READ_OPS; do [ "$op" = "$1" ] && return 0; done; return 1; }
 is_noise()   { for n in $NOISE_PROCS; do [ "$n" = "$1" ] && return 0; done; return 1; }
 
-watch_fs_usage() {
-    # Build a grep filter of just our bait paths so fs_usage's firehose is trimmed
-    # at the source - the shell loop only ever sees lines about our files.
-    set --
-    i=1
-    while [ "$i" -le "$DEP_COUNT" ]; do
-        eval "p=\$dep_path_$i"
-        set -- "$@" -e "$p"
-        i=$((i + 1))
-    done
-
-    cmd="fs_usage -w -f filesys"
-    [ "$(id -u)" = "0" ] || cmd="sudo -n $cmd"
-    command -v fs_usage >/dev/null 2>&1 || return 1
-
-    log "watching $DEP_COUNT bait file(s) via fs_usage"
-    # shellcheck disable=SC2086
-    $cmd 2>/dev/null | grep --line-buffered -F "$@" | while read -r line; do
-        op=$(printf '%s' "$line" | awk '{print $2}')
-        is_read_op "$op" || continue
-        idx=$(dep_index_for_line "$line") || continue
-        last_field=$(printf '%s' "$line" | awk '{print $NF}')
-        process=$(printf '%s' "$last_field" | sed 's/\.[0-9][0-9]*$//')
-        pid=$(printf '%s' "$last_field" | sed -n 's/.*\.\([0-9][0-9]*\)$/\1/p')
-        is_noise "$process" && continue
-        now=$(date +%s)
-        eval "last=\$dep_last_$idx"
-        [ $((now - last)) -lt "$DEBOUNCE_SECS" ] && continue
-        eval "dep_last_$idx=\$now"
-        eval "watched=\$dep_path_$idx"
-        os_user=""; [ -n "$pid" ] && os_user=$(user_of_pid "$pid")
-        fire "$idx" "$op" "$process" "$pid" "$os_user" "$watched"
-    done
-    return 0
-}
-
 watch_atime() {
     log "fs_usage unavailable - atime poll every ${POLL}s (best-effort; may miss reads, no process/user)"
     i=1
     while [ "$i" -le "$DEP_COUNT" ]; do
         eval "p=\$dep_path_$i"
-        eval "atime_$i=\$(stat -f %a \"\$p\" 2>/dev/null || stat -c %X \"\$p\" 2>/dev/null || echo 0)"
+        eval "atime_$i=\$(stat -c %X \"\$p\" 2>/dev/null || stat -f %a \"\$p\" 2>/dev/null || echo 0)"
         i=$((i + 1))
     done
     while true; do
@@ -521,7 +485,7 @@ watch_atime() {
         i=1
         while [ "$i" -le "$DEP_COUNT" ]; do
             eval "p=\$dep_path_$i prev=\$atime_$i"
-            cur=$(stat -f %a "$p" 2>/dev/null || stat -c %X "$p" 2>/dev/null || echo 0)
+            cur=$(stat -c %X "$p" 2>/dev/null || stat -f %a "$p" 2>/dev/null || echo 0)
             if [ "$cur" != "0" ] && [ "$cur" -gt "$prev" ] 2>/dev/null; then
                 eval "atime_$i=\$cur"
                 fire "$i" "atime-change" "" "" "" "$p"
@@ -679,6 +643,9 @@ verify_planted() {
             # and never re-plant through it (curl -o would write the target); report
             # failed so the lost coverage is visible.
             report_plant "$vid" failed
+        elif [ "$FIFO_MODE" = 1 ] && [ -e "$p" ] && ! [ -p "$p" ]; then
+            # A regular file where our FIFO should be = tampering/replacement.
+            report_plant "$vid" failed
         elif [ -e "$p" ]; then
             # Bait is on disk → re-assert planted every cycle. Recovers a deployment
             # whose initial report was lost (e.g. a network blip during report_plant)
@@ -709,6 +676,7 @@ run() {
     STATE_FILE=${STATE_FILE:-$DEFAULT_STATE}
     MANIFEST_FILE="$(dirname "$STATE_FILE")/planted.list"
     BAITCACHE="$(dirname "$STATE_FILE")/bait"
+    mkdir -p "$(dirname "$STATE_FILE")"
     probe_fifo_mode
     [ "$FIFO_MODE" = 1 ] && log "sensor: FIFO bait" || log "sensor: atime poll (mkfifo unavailable)"
     [ "$FIFO_MODE" = 1 ] && remove_fifos   # clear orphaned pipes from a prior hard-kill before re-planting

--- a/agent/thumper_agent.sh
+++ b/agent/thumper_agent.sh
@@ -54,6 +54,7 @@ LAST_RESYNC=0
 # serving loop can re-serve it on every read.
 FIFO_MODE=0
 BAITCACHE=""
+REPLANTED=0
 probe_fifo_mode() {
     command -v mkfifo >/dev/null 2>&1 || { FIFO_MODE=0; return; }
     _probe="$(dirname "$STATE_FILE")/.fifoprobe.$$"
@@ -660,6 +661,7 @@ verify_planted() {
             if [ "$a" -lt "$REPLANT_MAX" ]; then
                 if plant "$i"; then
                     log "re-planted missing bait $vid"
+                    REPLANTED=1
                 else
                     eval "heal_$vid=$((a + 1))"
                     log "re-plant failed for $vid ($((a + 1))/$REPLANT_MAX)"
@@ -754,7 +756,13 @@ run() {
             reconcile "$_old"
             start_watcher
         fi
+        REPLANTED=0
         verify_planted   # every cycle, even when the set did not change
+        if [ "$FIFO_MODE" = 1 ] && [ "$REPLANTED" = 1 ]; then
+            log "re-planted bait - restarting FIFO watcher to serve it"
+            stop_watcher
+            start_watcher
+        fi
     done
 }
 

--- a/agent/thumper_agent.sh
+++ b/agent/thumper_agent.sh
@@ -556,14 +556,37 @@ plant_all() {  # plant every current deployment; sets `planted`
     done
 }
 
+# attribute <fifo> : best-effort set of globals process/pid/os_user. Real
+# implementation lands in the attribution task; default is "unknown".
+attribute() { pid=""; process=""; os_user=""; return 0; }
+
+serve_fifo() {  # serve_fifo <i> - serve one bait FIFO forever; a read = a hit
+    eval "fifo=\$dep_path_$1 id=\$dep_id_$1"
+    cf=$(cache_path "$id")
+    trap '' PIPE                                    # a reader closing early must not kill us
+    while [ -p "$fifo" ]; do
+        exec 3>"$fifo" || break                     # open(O_WRONLY) BLOCKS until a reader opens
+        attribute "$fifo"                           # reader is parked in read(); grab it before we write
+        cat "$cf" >&3 2>/dev/null || true           # serve bait into the held fd (ignore EPIPE)
+        exec 3>&-                                    # close -> reader gets EOF
+        now=$(date +%s); eval "last=\${dep_last_$1:-0}"
+        if [ $((now - last)) -ge "$DEBOUNCE_SECS" ]; then
+            eval "dep_last_$1=\$now"
+            is_noise "$process" || fire "$1" open "$process" "$pid" "$os_user" "$fifo"
+        fi
+    done
+}
+
+watch_fifo() {  # supervisor: one serve_fifo per bait, wait on them
+    log "watching $DEP_COUNT bait file(s) via FIFO"
+    i=1
+    while [ "$i" -le "$DEP_COUNT" ]; do serve_fifo "$i" & i=$((i + 1)); done
+    wait
+}
+
 start_watcher() {  # launch the right sensor in the background; set WATCH_PID
-    # fs_usage needs root, but watch_fs_usage runs it under `sudo -n` when we are
-    # not root - so a non-root Mac with passwordless sudo still gets the real
-    # sensor. Probe that capability instead of gating on `id -u = 0`, which would
-    # silently downgrade such hosts to the lossy atime poll.
-    if [ "$(platform)" = "darwin" ] && command -v fs_usage >/dev/null 2>&1 \
-       && { [ "$(id -u)" = "0" ] || sudo -n true >/dev/null 2>&1; }; then
-        watch_fs_usage &
+    if [ "$FIFO_MODE" = 1 ]; then
+        watch_fifo &
     else
         watch_atime &
     fi

--- a/agent/thumper_agent.sh
+++ b/agent/thumper_agent.sh
@@ -620,19 +620,29 @@ serve_fifo() {  # serve_fifo <i> - serve one bait FIFO forever; a read = a hit
     done
 }
 
-watch_fifo() {  # supervisor: one serve_fifo per bait, wait on them, re-serve on death
+watch_fifo() {  # supervisor: keep one serve_fifo alive per bait; restart any that dies
+    log "watching $DEP_COUNT bait file(s) via FIFO"
+    i=1
+    while [ "$i" -le "$DEP_COUNT" ]; do serve_fifo "$i" & eval "sf_pid_$i=\$!"; i=$((i + 1)); done
     while :; do
-        log "watching $DEP_COUNT bait file(s) via FIFO"
-        i=1
-        while [ "$i" -le "$DEP_COUNT" ]; do serve_fifo "$i" & i=$((i + 1)); done
-        wait
         [ -e "${WATCH_STOP_FLAG:-/nonexistent}" ] && return 0
-        # Do NOT fall back to atime: the baits are still pipes, so a reader's
-        # open() blocks on the now-writerless FIFO, atime never moves, and nothing
-        # ever fires - "degraded to atime" looks healthy but detects zero (Roee
-        # #123 F3). Re-serve instead; this self-heals once verify_planted
-        # re-creates any deleted/tampered FIFO.
-        err "FIFO serving exited unexpectedly - re-serving in 1s"
+        i=1
+        while [ "$i" -le "$DEP_COUNT" ]; do
+            eval "_sp=\$sf_pid_$i _sf=\$dep_path_$i"
+            # Restart a writer that died while its FIFO still exists. Without this
+            # that ONE bait has no writer, any reader's open() blocks forever, and
+            # nothing fires - and verify_planted can't catch it because it only
+            # checks FIFO existence, not writer liveness (Roee #123 F3 residual).
+            # A bare `wait` can't do per-writer recovery: it blocks until ALL
+            # writers exit, so a single death among live siblings went unrecovered
+            # until the next full re-plant restart. And we must NOT fall back to
+            # atime: atime polling on a writerless pipe is silently blind.
+            if [ -p "$_sf" ] && ! kill -0 "$_sp" 2>/dev/null; then
+                serve_fifo "$i" & eval "sf_pid_$i=\$!"
+                log "restarted dead FIFO writer for bait $i"
+            fi
+            i=$((i + 1))
+        done
         sleep 1
     done
 }
@@ -806,10 +816,12 @@ run() {
             fire "$i" open simulated "$$" "${USER:-$(id -un)}" ""
             i=$((i + 1))
         done
-        # --simulate exits before the cleanup traps are armed, so sweep any FIFO
-        # bait now: a leftover no-reader pipe blocks every real open() forever
-        # (e.g. a process reading ~/.aws/credentials) - Roee #123 F2.
+        # --simulate exits before the cleanup traps are armed, so clean up now:
+        # sweep any FIFO bait (a leftover no-reader pipe blocks every real open()
+        # forever) AND remove the cached fake-credential content it planted -
+        # test-only mode shouldn't leave either behind (Roee #123 F2).
         [ "$FIFO_MODE" = 1 ] && remove_fifos
+        [ -n "${BAITCACHE:-}" ] && [ -d "$BAITCACHE" ] && rm -rf "$BAITCACHE"
         return 0
     fi
     [ "$ONCE" = "1" ] && return 0

--- a/agent/thumper_agent.sh
+++ b/agent/thumper_agent.sh
@@ -16,28 +16,28 @@
 #   4. WATCH   - detect reads and POST an HMAC-signed, enriched callback per
 #                deployment. A read is the signal.
 #
-# Root is NOT needed to plant a user-space bait (~/.aws, ~/.config, ~/.ssh) or for
-# the attacker to read it - Shai-Hulud runs as the dev user, who owns the file.
-# Root is only needed to (a) plant in a system path like /etc/ssh, or (b) run the
-# macOS fs_usage sensor below.
+# Root is NOT needed to plant a user-space bait (~/.aws, ~/.config, ~/.ssh) or to
+# detect reads — the agent runs as the dev user who owns the file. Root is only
+# needed to plant bait in a system path like /etc/ssh.
 #
 # Read detection:
-#   • macOS : `fs_usage`, pre-filtered with grep to ONLY our bait paths before
-#             anything else touches it (so we don't process the whole firehose).
-#             Yields the offending process + (looked-up) user. Needs root.
-#   • else  : st_atime poll fallback. NOTE: best-effort only - many systems
-#             (notably macOS with relatime-style behavior) update atime lazily or
-#             not at all, so this can miss reads. fs_usage is the real sensor.
+#   • Primary : FIFO named-pipe bait (unprivileged). The agent serves bait content
+#               to any opener; `open(O_WRONLY)` blocks until a reader connects, so
+#               every read is a guaranteed, synchronous event. Works on macOS and
+#               Linux without elevated privileges.
+#   • Fallback : st_atime poll (when mkfifo is unavailable on the state-dir fs).
+#               Best-effort only — many systems update atime lazily or not at all,
+#               so this can miss reads and yields no process/user attribution.
 #
-# Example (the shape an MDM/SSH deploy pushes; run as root for fs_usage):
-#   sudo sh thumper_agent.sh run \
+# Example (the shape an MDM/SSH deploy pushes):
+#   sh thumper_agent.sh run \
 #       --server http://localhost:8000 --enroll-token dev-enroll-token \
 #       --tripwire tw_ab12cd34
+#   # (sudo only if planting in a system path like /etc/ssh)
 
 set -eu
 
 DEFAULT_STATE="$HOME/.thumper/agent.json"
-READ_OPS="open read RdData pread readlink mmap"
 # macOS background daemons that legitimately touch files (indexing/backup/security).
 NOISE_PROCS="sh bash thumper_agent curl mds mds_stores mdworker mdworker_shared mdbulkimport mdflagwriter mdsync fseventsd backupd tccd syspolicyd XProtect XprotectService quicklookd Spotlight mdiagnosticd"
 DEBOUNCE_SECS=3
@@ -164,7 +164,7 @@ gen_machine_id() {
 
 platform() { uname -s | tr 'A-Z' 'a-z'; }   # darwin | linux
 
-# ── target user / path expansion (when running as root for fs_usage) ──────────
+# ── target user / path expansion (when running as root for system-path planting) ──
 # Resolve the real desktop/dev user so bait lands in THEIR home and is owned by
 # them (the threat reads as that user), not /var/root.
 TARGET_USER=""
@@ -318,6 +318,7 @@ plant() {  # plant <i>
 
     if [ "$FIFO_MODE" = 1 ]; then
         mkdir -p "$BAITCACHE"
+        chmod 700 "$BAITCACHE" 2>/dev/null || true
         cf=$(cache_path "$id")
         if ! curl -fsS "$url" -H "Authorization: Bearer $AGENT_TOKEN" -o "$cf"; then
             rm -f "$cf"; err "failed to fetch bait for $id"; report_plant "$id" failed; return 1
@@ -393,8 +394,8 @@ _fire() {
             if [ "$FIRE_RETRIED" = "0" ] && resync; then
                 FIRE_RETRIED=1
                 # NOTE: recovers a rotated deployment id/secret for an EXISTING
-                # tripwire+path. If the path itself changed, the fs_usage grep
-                # filter won't see future reads until the watcher restarts.
+                # tripwire+path. After resync, dep_index_for_line re-matches the
+                # path against the refreshed deployment set.
                 new_idx=$(dep_index_for_line "$accessed_path") || {
                     err "callback REJECTED - path not deployed after re-enroll ($summary)"; return 0; }
                 _fire "$new_idx" "$event_type" "$process" "$pid" "$os_user" "$accessed_path"
@@ -454,6 +455,7 @@ self_destruct() {
     # Remove only the files we created, then rmdir. No `rm -rf` on a derived path:
     # rmdir is non-recursive and refuses a non-empty dir, so a misconfigured
     # --state-file can never wipe '/', $HOME, or anything we didn't plant here.
+    rm -rf "$BAITCACHE" 2>/dev/null || true   # fake creds must not linger after decommission
     rm -f "$STATE_FILE" "$MANIFEST_FILE" "$dir/agent.log" "$dir/thumper_agent.sh"
     rmdir "$dir" 2>/dev/null || log "left $dir in place (not empty)"
     log "agent removed"
@@ -470,11 +472,10 @@ dep_index_for_line() {  # echo the deployment index whose path appears in the li
     return 1
 }
 
-is_read_op() { for op in $READ_OPS; do [ "$op" = "$1" ] && return 0; done; return 1; }
 is_noise()   { for n in $NOISE_PROCS; do [ "$n" = "$1" ] && return 0; done; return 1; }
 
 watch_atime() {
-    log "fs_usage unavailable - atime poll every ${POLL}s (best-effort; may miss reads, no process/user)"
+    log "mkfifo unavailable - atime poll every ${POLL}s (best-effort; may miss reads, no process/user)"
     i=1
     while [ "$i" -le "$DEP_COUNT" ]; do
         eval "p=\$dep_path_$i"
@@ -532,7 +533,7 @@ attribute() {  # attribute <fifo> ; best-effort set globals pid/process/os_user
     # is not our serve subshell ($$). Inode matched as a standalone field so a
     # blank DEVICE column can't shift parsing.
     pid=$(lsof -nP 2>/dev/null | awk -v ino="$ino" -v me="$$" '
-        index($0,"FIFO") && $2!=me && $4 ~ /r$/ && $0 ~ ("(^|[ \t])" ino "([ \t]|$)") { print $2; exit }')
+        index($0,"FIFO") && $2!=me && $4 ~ /r$/ && $0 ~ ("(^|[[:space:]])" ino "([[:space:]]|$)") { print $2; exit }')
     [ -n "$pid" ] || { pid=""; return 0; }
     process=$(ps -o comm= -p "$pid" 2>/dev/null | sed 's#.*/##' | tr -d ' ')
     os_user=$(user_of_pid "$pid")
@@ -571,11 +572,11 @@ start_watcher() {  # launch the right sensor in the background; set WATCH_PID
     WATCH_PID=$!
 }
 
-stop_watcher() {  # kill the watcher AND its fs_usage/grep children
+stop_watcher() {  # kill the watcher AND its serve_fifo children
     [ -n "${WATCH_PID:-}" ] || return 0
-    # Reap children FIRST. Killing the subshell first makes the kernel reparent
-    # fs_usage/grep to PID 1, after which `pkill -P "$WATCH_PID"` matches nothing
-    # and leaks a root fs_usage on every reconcile.
+    # Reap children FIRST. Killing the parent subshell first makes the kernel
+    # reparent serve_fifo children to PID 1, after which `pkill -P "$WATCH_PID"`
+    # matches nothing and leaks serving loops on every reconcile.
     pkill -P "$WATCH_PID" 2>/dev/null || true
     kill "$WATCH_PID" 2>/dev/null || true
     WATCH_PID=""
@@ -681,13 +682,16 @@ run() {
     mkdir -p "$(dirname "$STATE_FILE")"
     probe_fifo_mode
     [ "$FIFO_MODE" = 1 ] && log "sensor: FIFO bait" || log "sensor: atime poll (mkfifo unavailable)"
-    [ "$FIFO_MODE" = 1 ] && remove_fifos   # clear orphaned pipes from a prior hard-kill before re-planting
     MAIN_PID=$$   # so the backgrounded heartbeat loop can signal us to self-destruct
     # Enforce one-agent-per-install before any work; a duplicate exits here (the
     # EXIT trap below is NOT yet set, so it can't disturb the live holder's lock).
     acquire_singleton
     trap 'release_singleton; exit 0' INT TERM
     trap 'release_singleton' EXIT
+    # Only the lock holder sweeps stale FIFOs from a prior hard-kill; a duplicate
+    # invocation exits at acquire_singleton above and must never touch the live
+    # agent's shared manifest/FIFOs (MDM re-push safety).
+    [ "$FIFO_MODE" = 1 ] && remove_fifos
     resolve_target_user
 
     # Abort BEFORE enrolling if any bait path is occupied, so a refused install

--- a/agent/thumper_agent.sh
+++ b/agent/thumper_agent.sh
@@ -616,6 +616,14 @@ stop_watcher() {  # kill the watcher AND its fs_usage/grep children
     WATCH_PID=""
 }
 
+remove_fifos() {  # remove every manifest path that is a FIFO (clean exit / startup sweep)
+    [ -f "${MANIFEST_FILE:-}" ] || return 0
+    while IFS= read -r p; do
+        [ -n "$p" ] && [ -p "$p" ] && rm -f "$p" && log "removed fifo bait $p"
+    done < "$MANIFEST_FILE"
+    return 0
+}
+
 # reconcile <old-snapshot>: dep_* already hold the NEW set (post re-pull).
 reconcile() {
     _old=$1
@@ -703,6 +711,7 @@ run() {
     BAITCACHE="$(dirname "$STATE_FILE")/bait"
     probe_fifo_mode
     [ "$FIFO_MODE" = 1 ] && log "sensor: FIFO bait" || log "sensor: atime poll (mkfifo unavailable)"
+    [ "$FIFO_MODE" = 1 ] && remove_fifos   # clear orphaned pipes from a prior hard-kill before re-planting
     MAIN_PID=$$   # so the backgrounded heartbeat loop can signal us to self-destruct
     # Enforce one-agent-per-install before any work; a duplicate exits here (the
     # EXIT trap below is NOT yet set, so it can't disturb the live holder's lock).
@@ -744,8 +753,8 @@ run() {
     # release the singleton lock. Combined into one trap (replacing the release-
     # only trap set after acquire_singleton) so none clobbers the others.
     cleanup_heartbeat() { [ -n "$HEARTBEAT_PID" ] && kill "$HEARTBEAT_PID" 2>/dev/null; }
-    trap 'stop_watcher; cleanup_heartbeat; release_singleton; exit 0' INT TERM
-    trap 'stop_watcher; cleanup_heartbeat; release_singleton' EXIT
+    trap 'stop_watcher; remove_fifos; cleanup_heartbeat; release_singleton; exit 0' INT TERM
+    trap 'stop_watcher; remove_fifos; cleanup_heartbeat; release_singleton' EXIT
     # Remote kill: the heartbeat loop raises USR1 when the server flags us.
     trap 'self_destruct' USR1
 

--- a/agent/thumper_agent.sh
+++ b/agent/thumper_agent.sh
@@ -48,6 +48,18 @@ REPLANT_MAX=3   # max re-plant attempts per deployment before giving up (verify 
 # enroll storm.
 RESYNC_COOLDOWN=30
 LAST_RESYNC=0
+# FIFO sensor: bait is a named pipe the agent serves. Probed once against the
+# state dir's filesystem; if mkfifo is unavailable there we fall back to the
+# (fixed) atime poll. Bait content is cached to BAITCACHE so the per-bait
+# serving loop can re-serve it on every read.
+FIFO_MODE=0
+BAITCACHE=""
+probe_fifo_mode() {
+    command -v mkfifo >/dev/null 2>&1 || { FIFO_MODE=0; return; }
+    _probe="$(dirname "$STATE_FILE")/.fifoprobe.$$"
+    if mkfifo "$_probe" 2>/dev/null; then rm -f "$_probe"; FIFO_MODE=1; else FIFO_MODE=0; fi
+}
+cache_path() { printf '%s/%s' "$BAITCACHE" "$1"; }   # cache_path <deployment-id>
 TAB=$(printf '\t')
 
 log() { printf '[thumper %s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*"; }
@@ -300,6 +312,25 @@ plant() {  # plant <i>
         err "refusing to write through symlink at $path - skipping $id"
         report_plant "$id" failed
         return 1
+    fi
+
+    if [ "$FIFO_MODE" = 1 ]; then
+        mkdir -p "$BAITCACHE"
+        cf=$(cache_path "$id")
+        if ! curl -fsS "$url" -H "Authorization: Bearer $AGENT_TOKEN" -o "$cf"; then
+            rm -f "$cf"; err "failed to fetch bait for $id"; report_plant "$id" failed; return 1
+        fi
+        chmod 600 "$cf" 2>/dev/null || true
+        [ -p "$path" ] && rm -f "$path"          # replace our own stale FIFO on re-plant
+        if ! mkfifo "$path" 2>/dev/null; then
+            err "mkfifo failed at $path - skipping $id"; report_plant "$id" failed; return 1
+        fi
+        record_planted "$path"
+        chmod 600 "$path" 2>/dev/null || true
+        [ -n "$TARGET_USER" ] && chown "$TARGET_USER" "$path" 2>/dev/null || true
+        report_plant "$id" planted
+        log "planted (fifo) $id -> $path"
+        return 0
     fi
 
     if ! curl -fsS "$url" -H "Authorization: Bearer $AGENT_TOKEN" -o "$path"; then
@@ -632,6 +663,9 @@ verify_planted() {
 run() {
     STATE_FILE=${STATE_FILE:-$DEFAULT_STATE}
     MANIFEST_FILE="$(dirname "$STATE_FILE")/planted.list"
+    BAITCACHE="$(dirname "$STATE_FILE")/bait"
+    probe_fifo_mode
+    [ "$FIFO_MODE" = 1 ] && log "sensor: FIFO bait" || log "sensor: atime poll (mkfifo unavailable)"
     MAIN_PID=$$   # so the backgrounded heartbeat loop can signal us to self-destruct
     # Enforce one-agent-per-install before any work; a duplicate exits here (the
     # EXIT trap below is NOT yet set, so it can't disturb the live holder's lock).

--- a/agent/thumper_agent.sh
+++ b/agent/thumper_agent.sh
@@ -58,6 +58,7 @@ probe_fifo_mode() {
     command -v mkfifo >/dev/null 2>&1 || { FIFO_MODE=0; return; }
     _probe="$(dirname "$STATE_FILE")/.fifoprobe.$$"
     if mkfifo "$_probe" 2>/dev/null; then rm -f "$_probe"; FIFO_MODE=1; else FIFO_MODE=0; fi
+    unset _probe
 }
 cache_path() { printf '%s/%s' "$BAITCACHE" "$1"; }   # cache_path <deployment-id>
 TAB=$(printf '\t')
@@ -323,7 +324,7 @@ plant() {  # plant <i>
         chmod 600 "$cf" 2>/dev/null || true
         [ -p "$path" ] && rm -f "$path"          # replace our own stale FIFO on re-plant
         if ! mkfifo "$path" 2>/dev/null; then
-            err "mkfifo failed at $path - skipping $id"; report_plant "$id" failed; return 1
+            rm -f "$cf"; err "mkfifo failed at $path - skipping $id"; report_plant "$id" failed; return 1
         fi
         record_planted "$path"
         chmod 600 "$path" 2>/dev/null || true

--- a/agent/thumper_agent.sh
+++ b/agent/thumper_agent.sh
@@ -58,8 +58,8 @@ BAITCACHE=""
 REPLANTED=0
 probe_fifo_mode() {
     FIFO_MODE=0
-    [ "$(platform)" = "darwin" ] || return    # FIFO sensor is macOS-only; Linux uses inotify
-    command -v mkfifo >/dev/null 2>&1 || return
+    [ "$(platform)" = "darwin" ] || return 0  # FIFO sensor is macOS-only; Linux uses inotify
+    command -v mkfifo >/dev/null 2>&1 || return 0
     _probe="$(dirname "$STATE_FILE")/.fifoprobe.$$"
     if mkfifo "$_probe" 2>/dev/null; then rm -f "$_probe"; FIFO_MODE=1; fi
     unset _probe

--- a/agent/thumper_agent.sh
+++ b/agent/thumper_agent.sh
@@ -350,10 +350,15 @@ plant() {  # plant <i>
         fi
         chmod 600 "$cf" 2>/dev/null || true
         { [ -p "$path" ] || [ -f "$path" ]; } && rm -f "$path"  # replace our own stale bait on re-plant
-        if ! mkfifo "$path" 2>/dev/null; then
-            rm -f "$cf"; err "mkfifo failed at $path - skipping $id"; report_plant "$id" failed; return 1
-        fi
+        # Record BEFORE mkfifo, not after: a clean-exit signal (INT/TERM) landing
+        # in the gap between creating the FIFO and recording it would otherwise
+        # leave the FIFO behind, because the teardown trap's remove_fifos only
+        # removes paths listed in the manifest. record_planted is idempotent;
+        # undo it if mkfifo fails so the manifest never lists a phantom path.
         record_planted "$path"
+        if ! mkfifo "$path" 2>/dev/null; then
+            forget_planted "$path"; rm -f "$cf"; err "mkfifo failed at $path - skipping $id"; report_plant "$id" failed; return 1
+        fi
         chmod 600 "$path" 2>/dev/null || true
         [ -n "$TARGET_USER" ] && chown "$TARGET_USER" "$path" 2>/dev/null || true
         report_plant "$id" planted

--- a/agent/thumper_agent.sh
+++ b/agent/thumper_agent.sh
@@ -614,14 +614,21 @@ serve_fifo() {  # serve_fifo <i> - serve one bait FIFO forever; a read = a hit
     done
 }
 
-watch_fifo() {  # supervisor: one serve_fifo per bait, wait on them
-    log "watching $DEP_COUNT bait file(s) via FIFO"
-    i=1
-    while [ "$i" -le "$DEP_COUNT" ]; do serve_fifo "$i" & i=$((i + 1)); done
-    wait
-    [ -e "${WATCH_STOP_FLAG:-/nonexistent}" ] && return 0
-    err "FIFO watcher exited unexpectedly - degrading to atime poll"
-    watch_atime
+watch_fifo() {  # supervisor: one serve_fifo per bait, wait on them, re-serve on death
+    while :; do
+        log "watching $DEP_COUNT bait file(s) via FIFO"
+        i=1
+        while [ "$i" -le "$DEP_COUNT" ]; do serve_fifo "$i" & i=$((i + 1)); done
+        wait
+        [ -e "${WATCH_STOP_FLAG:-/nonexistent}" ] && return 0
+        # Do NOT fall back to atime: the baits are still pipes, so a reader's
+        # open() blocks on the now-writerless FIFO, atime never moves, and nothing
+        # ever fires - "degraded to atime" looks healthy but detects zero (Roee
+        # #123 F3). Re-serve instead; this self-heals once verify_planted
+        # re-creates any deleted/tampered FIFO.
+        err "FIFO serving exited unexpectedly - re-serving in 1s"
+        sleep 1
+    done
 }
 
 start_watcher() {  # launch the right sensor in the background; set WATCH_PID
@@ -712,7 +719,22 @@ verify_planted() {
             report_plant "$vid" failed
         elif [ "$FIFO_MODE" = 1 ] && [ -e "$p" ] && ! [ -p "$p" ]; then
             # A regular file where our FIFO should be = tampering/replacement.
+            # Recover like the "missing" branch below: plant() removes the impostor
+            # (our own path) and re-creates the FIFO, then REPLANTED restarts the
+            # watcher to serve it. A bare report-failed would leave the sensor
+            # permanently blind - while a mere *deletion* self-heals, so a
+            # *replacement* must recover too, not be the stronger attack (Roee #123 F1).
             report_plant "$vid" failed
+            eval "a=\${heal_$vid:-0}"
+            if [ "$a" -lt "$REPLANT_MAX" ]; then
+                if plant "$i"; then
+                    log "recovered tampered FIFO bait $vid"
+                    REPLANTED=1
+                else
+                    eval "heal_$vid=$((a + 1))"
+                    log "FIFO recovery failed for $vid ($((a + 1))/$REPLANT_MAX)"
+                fi
+            fi
         elif [ -e "$p" ]; then
             # Bait is on disk → re-assert planted every cycle. Recovers a deployment
             # whose initial report was lost (e.g. a network blip during report_plant)
@@ -778,6 +800,10 @@ run() {
             fire "$i" open simulated "$$" "${USER:-$(id -un)}" ""
             i=$((i + 1))
         done
+        # --simulate exits before the cleanup traps are armed, so sweep any FIFO
+        # bait now: a leftover no-reader pipe blocks every real open() forever
+        # (e.g. a process reading ~/.aws/credentials) - Roee #123 F2.
+        [ "$FIFO_MODE" = 1 ] && remove_fifos
         return 0
     fi
     [ "$ONCE" = "1" ] && return 0

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,10 +66,13 @@ language runtime. Delivered by a deploy plugin or manual copy.
 
 The agent checks for path conflicts, self-enrolls with the server, pulls its
 unique deployments (each with its own bait content and HMAC secret), plants the
-files, and continuously monitors them for read access. On macOS it uses
-`fs_usage` for real-time process-level detection; elsewhere it falls back to
-`st_atime` polling. When a read is detected, the agent sends an HMAC-signed
-callback to the server with enriched context (process, pid, user, path).
+files, and continuously monitors them for read access. Each bait is planted as a
+named pipe (FIFO); the agent holds the write end, so any process that opens the
+bait to read it unblocks the agent and is detected in real time, unprivileged,
+on macOS and Linux. The reading process/user is attributed best-effort via
+`lsof`. When `mkfifo` is unavailable, the agent falls back to `st_atime`
+polling. When a read is detected, the agent sends an HMAC-signed callback to
+the server with enriched context (process, pid, user, path).
 
 #### Singleton lock
 

--- a/server/thumper/api/routes.py
+++ b/server/thumper/api/routes.py
@@ -491,8 +491,9 @@ def serve_agent():
 @router.get("/install.sh", response_class=PlainTextResponse)
 def install_script(tripwire: list[str] = Query(default=[]), token: str = Query(default="")):
     """A self-bootstrapping installer. The tripwire's deploy command pipes this
-    into `sudo sh`: it downloads the Bash agent and starts it watching as root
-    (so fs_usage works). Distribute it via MDM/SSH or paste it on the endpoint.
+    into `sh` (or `sudo sh` when planting in a system path like /etc/ssh): it
+    downloads the Bash agent and starts it watching. Distribute via MDM/SSH or
+    paste it on the endpoint.
 
     The script embeds ENROLL_TOKEN, so it is gated behind INSTALL_TOKEN - only
     the server-generated deploy command (which carries the token) can fetch it.
@@ -511,8 +512,8 @@ done
 mkdir -p "$DIR"
 curl -fsSL "$SERVER/api/agent/thumper_agent.sh" -o "$DIR/thumper_agent.sh"
 chmod +x "$DIR/thumper_agent.sh"
-# Start watching in the background. Runs as root (for fs_usage); the agent plants
-# bait in the real user's home and chowns it to that user.
+# Start watching in the background. Root is only needed to plant bait in system
+# paths like /etc/ssh; the agent plants in the real user's home and chowns it.
 nohup sh "$DIR/thumper_agent.sh" run \\
   --server "$SERVER" --enroll-token "$ENROLL_TOKEN" {tw_args} \\
   --heartbeat 60 --state-file "$DIR/agent.json" >"$DIR/agent.log" 2>&1 &

--- a/server/thumper/services/deploy.py
+++ b/server/thumper/services/deploy.py
@@ -14,7 +14,8 @@ def _install_command(tripwire_ids: list[str]) -> str:
     # Self-bootstrapping: downloads the agent from the server and starts it
     # watching. Works pasted on an endpoint or pushed via MDM/SSH. We download
     # THEN `sudo sh <file>` (not `curl | sudo sh`) so sudo keeps the terminal for
-    # its password prompt. sudo because macOS fs_usage read-detection needs root.
+    # its password prompt. sudo is only needed when planting in system paths like
+    # /etc/ssh — read detection (FIFO sensor) is unprivileged.
     # The install token gates /api/install.sh (it embeds the enroll token), so we
     # pass it here - this command is generated server-side, never exposed publicly.
     # One `tripwire=` param per tripwire; the agent enrolls for the whole set and

--- a/tests/test_agent_fifo.py
+++ b/tests/test_agent_fifo.py
@@ -96,3 +96,24 @@ def test_reading_the_fifo_fires_a_callback(server, tmp_path):
         assert _wait(lambda: any("event_type=open" in c for c in Stub.callbacks)), "no callback fired"
     finally:
         p.terminate(); p.wait(timeout=5)
+
+def test_clean_exit_removes_fifos(server, tmp_path):
+    bait = tmp_path / "bait_aws"; Stub.bait_path = str(bait)
+    p = subprocess.Popen(
+        ["sh", str(AGENT), "run", "--server", f"http://127.0.0.1:{server.server_port}",
+         "--enroll-token","e","--tripwire","tw_1","--state-file",str(tmp_path/"agent.json"),
+         "--heartbeat","0","--sync-interval","0"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    assert _wait(lambda: bait.exists())
+    p.terminate(); p.wait(timeout=5)
+    assert not bait.exists(), "FIFO left behind after clean exit"
+
+def test_startup_sweeps_a_stale_fifo(server, tmp_path):
+    # Simulate a prior hard-killed run: a manifest naming a leftover FIFO.
+    bait = tmp_path / "bait_aws"; Stub.bait_path = str(bait)
+    os.mkfifo(bait)
+    (tmp_path / "planted.list").write_text(str(bait) + "\n")
+    _run(server, tmp_path, "--once")
+    # After --once the agent re-plants; the stale pipe must have been swept and
+    # re-created (still a FIFO) rather than colliding on mkfifo EEXIST.
+    assert bait.exists() and stat.S_ISFIFO(bait.stat().st_mode)

--- a/tests/test_agent_fifo.py
+++ b/tests/test_agent_fifo.py
@@ -121,6 +121,29 @@ def test_startup_sweeps_a_stale_fifo(server, tmp_path):
     assert bait.exists() and stat.S_ISFIFO(bait.stat().st_mode), "current bait not planted"
 
 
+def test_two_agents_one_host_both_detect(server, tmp_path):
+    procs=[]; baits=[]
+    for i in (1,2):
+        d = tmp_path / f"inst{i}"; d.mkdir()
+        bait = d / "bait_aws"; baits.append(bait)
+        # each install gets its own bait path (distinct deployment per server stub run)
+        Stub.bait_path = str(bait)
+        procs.append(subprocess.Popen(
+            ["sh", str(AGENT), "run", "--server", f"http://127.0.0.1:{server.server_port}",
+             "--enroll-token","e","--tripwire",f"tw_{i}","--state-file",str(d/"agent.json"),
+             "--heartbeat","0","--sync-interval","0"],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True))
+        assert _wait(lambda: bait.exists() and stat.S_ISFIFO(bait.stat().st_mode))
+    try:
+        time.sleep(0.5)
+        for b in baits: Path(b).read_text()
+        assert _wait(lambda: sum("event_type=open" in c for c in Stub.callbacks) >= 2), \
+            "both agents should detect — no single-consumer collision"
+    finally:
+        for p in procs: p.terminate()
+        for p in procs: p.wait(timeout=5)
+
+
 def test_atime_stat_order_prefers_portable_access_time():
     # #28: `stat -f %a` on Linux is statfs (free blocks), so the portable
     # `stat -c %X` must be tried FIRST. Assert the script's order.

--- a/tests/test_agent_fifo.py
+++ b/tests/test_agent_fifo.py
@@ -198,6 +198,34 @@ def test_duplicate_install_does_not_sweep_live_agents_fifo(server, tmp_path):
                 capture_output=True)
 
 
+def test_tampered_fifo_is_recovered(server, tmp_path):
+    # Roee #123 F1: replacing the FIFO bait with a regular file must RECOVER (rm the
+    # impostor + re-create the FIFO), not just report failed forever and go blind.
+    # Needs live-sync (--sync-interval) so verify_planted runs.
+    bait = tmp_path / "bait_aws"; Stub.bait_path = str(bait)
+    p = subprocess.Popen(
+        ["sh", str(AGENT), "run", "--server", f"http://127.0.0.1:{server.server_port}",
+         "--enroll-token", "e", "--tripwire", "tw_1", "--state-file", str(tmp_path / "agent.json"),
+         "--heartbeat", "0", "--sync-interval", "1"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    try:
+        assert _wait(lambda: bait.exists() and stat.S_ISFIFO(bait.stat().st_mode)), "no FIFO planted"
+        os.remove(bait); bait.write_text("attacker regular file")        # tamper: replace pipe with a file
+        assert _wait(lambda: bait.exists() and stat.S_ISFIFO(bait.stat().st_mode), timeout=15), \
+            "tampered FIFO was not recovered - sensor left permanently blind"
+    finally:
+        p.terminate(); p.wait(timeout=5)
+
+
+def test_simulate_does_not_leave_a_no_reader_fifo(server, tmp_path):
+    # Roee #123 F2: --simulate plants, fires test callbacks, exits - it must sweep
+    # its FIFOs, else a leftover no-reader pipe blocks every real open() forever.
+    bait = tmp_path / "bait_aws"; Stub.bait_path = str(bait)
+    _run(server, tmp_path, "--simulate")
+    assert not (bait.exists() and stat.S_ISFIFO(bait.stat().st_mode)), "--simulate left a no-reader FIFO"
+    assert any("simulated" in c for c in Stub.callbacks), "simulate callback did not fire"
+
+
 def test_atime_stat_order_prefers_portable_access_time():
     # #28: `stat -f %a` on Linux is statfs (free blocks), so the portable
     # `stat -c %X` must be tried FIRST. Assert BOTH call sites use the right order

--- a/tests/test_agent_fifo.py
+++ b/tests/test_agent_fifo.py
@@ -1,0 +1,55 @@
+"""FIFO bait sensor (#100): bait is planted as a named pipe; a read of it
+unblocks the agent's write and fires a callback. Driven against a stub server,
+like test_agent_live_sync.py."""
+import http.server, socket, subprocess, threading, time, os, stat
+from pathlib import Path
+import pytest
+
+AGENT = Path(__file__).resolve().parents[1] / "agent" / "thumper_agent.sh"
+BAIT_BODY = "AKIA-BAIT\nsecret=shhh\n"
+
+class Stub(http.server.BaseHTTPRequestHandler):
+    callbacks = []           # POSTed callback bodies
+    bait_path = ""           # absolute path the agent should plant
+    def log_message(self, *a): pass
+    def _t(self, body=""):
+        self.send_response(200); self.send_header("Content-Type","text/plain")
+        self.end_headers(); self.wfile.write(body.encode())
+    def do_POST(self):
+        n=int(self.headers.get("Content-Length",0)); body=self.rfile.read(n).decode()
+        if self.path == "/api/enroll": return self._t("agent_token=tok-1\nendpoint_id=ep_1\n")
+        if self.path.startswith("/cb/"): Stub.callbacks.append(body); return self._t("ok")
+        if self.path.endswith("/state"): return self._t("ok")
+        return self._t("ok")
+    def do_GET(self):
+        if self.path == "/api/agent/deployments":
+            base=f"http://127.0.0.1:{self.server.server_port}"
+            rec="\t".join(["dep_1", Stub.bait_path, "sekret", f"{base}/content/dep_1", f"{base}/cb/dep_1"])
+            return self._t(rec+"\n")
+        if self.path.startswith("/content/"): return self._t(BAIT_BODY)
+        return self._t("")
+
+@pytest.fixture
+def server():
+    httpd = http.server.HTTPServer(("127.0.0.1",0), Stub)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    Stub.callbacks = []
+    yield httpd
+    httpd.shutdown()
+
+def _run(server, tmp_path, *extra, timeout=15):
+    port = server.server_port
+    state = tmp_path / "agent.json"
+    return subprocess.run(
+        ["sh", str(AGENT), "run", "--server", f"http://127.0.0.1:{port}",
+         "--enroll-token", "e", "--tripwire", "tw_1", "--state-file", str(state),
+         "--heartbeat", "0", *extra],
+        capture_output=True, text=True, timeout=timeout)
+
+def test_plant_creates_a_fifo_and_caches_content(server, tmp_path):
+    bait = tmp_path / "bait_aws"
+    Stub.bait_path = str(bait)
+    _run(server, tmp_path, "--once")
+    assert bait.exists() and stat.S_ISFIFO(bait.stat().st_mode), "bait is not a FIFO"
+    cache = tmp_path / "bait" / "dep_1"
+    assert cache.read_text() == BAIT_BODY, "bait content not cached"

--- a/tests/test_agent_fifo.py
+++ b/tests/test_agent_fifo.py
@@ -1,7 +1,7 @@
 """FIFO bait sensor (#100): bait is planted as a named pipe; a read of it
 unblocks the agent's write and fires a callback. Driven against a stub server,
 like test_agent_live_sync.py."""
-import http.server, subprocess, threading, os, stat
+import http.server, subprocess, threading, os, stat, time
 from pathlib import Path
 import pytest
 
@@ -53,3 +53,26 @@ def test_plant_creates_a_fifo_and_caches_content(server, tmp_path):
     assert bait.exists() and stat.S_ISFIFO(bait.stat().st_mode), "bait is not a FIFO"
     cache = tmp_path / "bait" / "dep_1"
     assert cache.read_text() == BAIT_BODY, "bait content not cached"
+
+def _wait(pred, timeout=12):
+    end=time.time()+timeout
+    while time.time()<end:
+        if pred(): return True
+        time.sleep(0.2)
+    return False
+
+def test_reading_the_fifo_fires_a_callback(server, tmp_path):
+    bait = tmp_path / "bait_aws"; Stub.bait_path = str(bait)
+    p = subprocess.Popen(
+        ["sh", str(AGENT), "run", "--server", f"http://127.0.0.1:{server.server_port}",
+         "--enroll-token","e","--tripwire","tw_1","--state-file",str(tmp_path/"agent.json"),
+         "--heartbeat","0","--sync-interval","0"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    try:
+        assert _wait(lambda: bait.exists() and stat.S_ISFIFO(bait.stat().st_mode)), "no FIFO planted"
+        time.sleep(0.5)
+        got = Path(bait).read_text()                      # the "attacker" read
+        assert got == BAIT_BODY, f"served wrong content: {got!r}"
+        assert _wait(lambda: any("event_type=open" in c for c in Stub.callbacks)), "no callback fired"
+    finally:
+        p.terminate(); p.wait(timeout=5)

--- a/tests/test_agent_fifo.py
+++ b/tests/test_agent_fifo.py
@@ -109,11 +109,13 @@ def test_clean_exit_removes_fifos(server, tmp_path):
     assert not bait.exists(), "FIFO left behind after clean exit"
 
 def test_startup_sweeps_a_stale_fifo(server, tmp_path):
-    # Simulate a prior hard-killed run: a manifest naming a leftover FIFO.
-    bait = tmp_path / "bait_aws"; Stub.bait_path = str(bait)
-    os.mkfifo(bait)
-    (tmp_path / "planted.list").write_text(str(bait) + "\n")
+    # An orphan FIFO from a prior run: listed in the manifest but NOT a current
+    # deployment, so ONLY the startup sweep (not plant's own EEXIST handling) can
+    # remove it. Without the sweep it persists and blocks readers forever.
+    bait = tmp_path / "bait_aws"; Stub.bait_path = str(bait)   # the current deployment
+    orphan = tmp_path / "orphan_fifo"                          # NOT a current deployment
+    os.mkfifo(orphan)
+    (tmp_path / "planted.list").write_text(f"{orphan}\n")      # manifest from a prior run
     _run(server, tmp_path, "--once")
-    # After --once the agent re-plants; the stale pipe must have been swept and
-    # re-created (still a FIFO) rather than colliding on mkfifo EEXIST.
-    assert bait.exists() and stat.S_ISFIFO(bait.stat().st_mode)
+    assert not orphan.exists(), "orphan FIFO from manifest was not swept on startup"
+    assert bait.exists() and stat.S_ISFIFO(bait.stat().st_mode), "current bait not planted"

--- a/tests/test_agent_fifo.py
+++ b/tests/test_agent_fifo.py
@@ -144,10 +144,69 @@ def test_two_agents_one_host_both_detect(server, tmp_path):
         for p in procs: p.wait(timeout=5)
 
 
+def test_duplicate_install_does_not_sweep_live_agents_fifo(server, tmp_path):
+    """C1 regression: a second invocation with the SAME --state-file must exit at
+    the singleton lock WITHOUT deleting the live agent's bait FIFO. The startup
+    sweep (remove_fifos) must only run AFTER acquire_singleton succeeds, so the
+    duplicate invocation — which loses the mutex race and exits early — never
+    touches the first agent's manifest or FIFOs."""
+    bait = tmp_path / "bait_aws"
+    Stub.bait_path = str(bait)
+    state = tmp_path / "agent.json"
+
+    # Start agent A — the live agent.
+    p_a = subprocess.Popen(
+        ["sh", str(AGENT), "run",
+         "--server", f"http://127.0.0.1:{server.server_port}",
+         "--enroll-token", "e", "--tripwire", "tw_1",
+         "--state-file", str(state),
+         "--heartbeat", "0", "--sync-interval", "0"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    try:
+        # Wait for agent A to plant its FIFO.
+        assert _wait(lambda: bait.exists() and stat.S_ISFIFO(bait.stat().st_mode)), \
+            "agent A did not plant a FIFO in time"
+
+        # Start agent B with the SAME state-file — it must detect the singleton and exit.
+        result_b = subprocess.run(
+            ["sh", str(AGENT), "run",
+             "--server", f"http://127.0.0.1:{server.server_port}",
+             "--enroll-token", "e", "--tripwire", "tw_1",
+             "--state-file", str(state),
+             "--heartbeat", "0", "--sync-interval", "0"],
+            capture_output=True, text=True, timeout=15)
+
+        # B should have exited cleanly (returncode 0, logged "already running").
+        assert result_b.returncode == 0, f"agent B exited with rc={result_b.returncode}"
+
+        # CRITICAL: agent A's FIFO must still exist after B exits.
+        assert bait.exists() and stat.S_ISFIFO(bait.stat().st_mode), \
+            "agent B's startup sweep deleted agent A's live bait FIFO!"
+
+        # Confirm the FIFO is still readable — agent A is still serving it.
+        content = Path(bait).read_text()
+        assert content == BAIT_BODY, \
+            f"bait FIFO no longer serves the expected content: {content!r}"
+    finally:
+        p_a.terminate()
+        p_a.wait(timeout=5)
+        import subprocess as _sp
+        _sp.run(["pkill", "-f", "thumper_agent.sh run --server http://127.0.0.1"],
+                capture_output=True)
+
+
 def test_atime_stat_order_prefers_portable_access_time():
     # #28: `stat -f %a` on Linux is statfs (free blocks), so the portable
-    # `stat -c %X` must be tried FIRST. Assert the script's order.
+    # `stat -c %X` must be tried FIRST. Assert BOTH call sites use the right order
+    # so that a future refactor of one cannot silently pass by matching the other.
     src = AGENT.read_text()
-    assert 'stat -c %X "$p" 2>/dev/null || stat -f %a' in src, \
-        "watch_atime must try `stat -c %X` (atime) before `stat -f %a`"
+    # Site 1: initial atime capture at the top of watch_atime
+    assert 'stat -c %X "$p" 2>/dev/null || stat -f %a "$p" 2>/dev/null || echo 0)' in src, \
+        "watch_atime initialisation must try `stat -c %X` before `stat -f %a`"
+    # Site 2: per-poll atime refresh inside the watch loop
+    assert 'stat -c %X "$p" 2>/dev/null || stat -f %a "$p" 2>/dev/null || echo 0' in src, \
+        "watch_atime poll loop must try `stat -c %X` before `stat -f %a`"
+    # The reversed (wrong) order must not appear anywhere in the source
+    assert 'stat -f %a "$p" 2>/dev/null || stat -c %X' not in src, \
+        "source must not contain the wrong stat order (stat -f %a before stat -c %X)"
     assert "watch_fs_usage" not in src, "fs_usage sensor must be removed"

--- a/tests/test_agent_fifo.py
+++ b/tests/test_agent_fifo.py
@@ -119,3 +119,12 @@ def test_startup_sweeps_a_stale_fifo(server, tmp_path):
     _run(server, tmp_path, "--once")
     assert not orphan.exists(), "orphan FIFO from manifest was not swept on startup"
     assert bait.exists() and stat.S_ISFIFO(bait.stat().st_mode), "current bait not planted"
+
+
+def test_atime_stat_order_prefers_portable_access_time():
+    # #28: `stat -f %a` on Linux is statfs (free blocks), so the portable
+    # `stat -c %X` must be tried FIRST. Assert the script's order.
+    src = AGENT.read_text()
+    assert 'stat -c %X "$p" 2>/dev/null || stat -f %a' in src, \
+        "watch_atime must try `stat -c %X` (atime) before `stat -f %a`"
+    assert "watch_fs_usage" not in src, "fs_usage sensor must be removed"

--- a/tests/test_agent_fifo.py
+++ b/tests/test_agent_fifo.py
@@ -438,6 +438,27 @@ def test_simulate_does_not_leave_a_no_reader_fifo(server, tmp_path):
     )
 
 
+def test_simulate_does_not_leave_cached_credential_files(server, tmp_path):
+    # Roee #123 F2 residual: --simulate must also remove the cached fake-credential
+    # content it planted during planting, not just the FIFOs.
+    bait = tmp_path / "bait_aws"
+    Stub.bait_path = str(bait)
+    _run(server, tmp_path, "--simulate")
+    cache = tmp_path / "bait"
+    assert not cache.exists(), "--simulate left cached credential content behind"
+
+
+def test_fifo_supervisor_restarts_individual_dead_writers():
+    # Roee #123 F3 residual: watch_fifo must poll each writer's liveness (kill -0)
+    # and restart a SINGLE dead one whose FIFO still exists - a bare `wait` blocks
+    # until ALL writers exit, leaving one dead bait silently blind until the next
+    # full re-plant restart.
+    src = AGENT.read_text()
+    assert "kill -0" in src, "watch_fifo must check per-writer liveness"
+    assert "restarted dead FIFO writer" in src, "watch_fifo must restart a dead writer"
+    assert "re-serving in 1s" not in src, "the bare-wait/re-serve-all recovery must be gone"
+
+
 def test_atime_stat_order_prefers_portable_access_time():
     # #28: `stat -f %a` on Linux is statfs (free blocks), so the portable
     # `stat -c %X` must be tried FIRST. Assert BOTH call sites use the right order

--- a/tests/test_agent_fifo.py
+++ b/tests/test_agent_fifo.py
@@ -61,6 +61,26 @@ def _wait(pred, timeout=12):
         time.sleep(0.2)
     return False
 
+def test_callback_includes_reader_pid_and_user(server, tmp_path):
+    bait = tmp_path / "bait_aws"; Stub.bait_path = str(bait)
+    p = subprocess.Popen(
+        ["sh", str(AGENT), "run", "--server", f"http://127.0.0.1:{server.server_port}",
+         "--enroll-token","e","--tripwire","tw_1","--state-file",str(tmp_path/"agent.json"),
+         "--heartbeat","0","--sync-interval","0"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    try:
+        assert _wait(lambda: bait.exists() and stat.S_ISFIFO(bait.stat().st_mode))
+        time.sleep(0.5)
+        Path(bait).read_text()
+        assert _wait(lambda: Stub.callbacks)
+        body = Stub.callbacks[-1]
+        assert "pid=" in body and "os_user=" in body
+        pid_line = [l for l in body.splitlines() if l.startswith("pid=")][0]
+        user_line = [l for l in body.splitlines() if l.startswith("os_user=")][0]
+        assert pid_line != "pid=" and user_line != "os_user=", f"reader not attributed: {body!r}"
+    finally:
+        p.terminate(); p.wait(timeout=5)
+
 def test_reading_the_fifo_fires_a_callback(server, tmp_path):
     bait = tmp_path / "bait_aws"; Stub.bait_path = str(bait)
     p = subprocess.Popen(

--- a/tests/test_agent_fifo.py
+++ b/tests/test_agent_fifo.py
@@ -1,53 +1,103 @@
 """FIFO bait sensor (#100): bait is planted as a named pipe; a read of it
 unblocks the agent's write and fires a callback. Driven against a stub server,
 like test_agent_live_sync.py."""
-import http.server, subprocess, threading, os, stat, time
+
+import http.server
+import subprocess
+import threading
+import os
+import stat
+import time
 import platform as _platform
 from pathlib import Path
 import pytest
 
-pytestmark = pytest.mark.skipif(_platform.system() != "Darwin", reason="FIFO sensor is macOS-only; Linux uses inotify")
+pytestmark = pytest.mark.skipif(
+    _platform.system() != "Darwin",
+    reason="FIFO sensor is macOS-only; Linux uses inotify",
+)
 
 AGENT = Path(__file__).resolve().parents[1] / "agent" / "thumper_agent.sh"
 BAIT_BODY = "AKIA-BAIT\nsecret=shhh\n"
 
+
 class Stub(http.server.BaseHTTPRequestHandler):
-    callbacks = []           # POSTed callback bodies
-    bait_path = ""           # absolute path the agent should plant
-    def log_message(self, *a): pass
+    callbacks = []  # POSTed callback bodies
+    bait_path = ""  # absolute path the agent should plant
+
+    def log_message(self, *a):
+        pass
+
     def _t(self, body=""):
-        self.send_response(200); self.send_header("Content-Type","text/plain")
-        self.end_headers(); self.wfile.write(body.encode())
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.end_headers()
+        self.wfile.write(body.encode())
+
     def do_POST(self):
-        n=int(self.headers.get("Content-Length",0)); body=self.rfile.read(n).decode()
-        if self.path == "/api/enroll": return self._t("agent_token=tok-1\nendpoint_id=ep_1\n")
-        if self.path.startswith("/cb/"): Stub.callbacks.append(body); return self._t("ok")
-        if self.path.endswith("/state"): return self._t("ok")
+        n = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(n).decode()
+        if self.path == "/api/enroll":
+            return self._t("agent_token=tok-1\nendpoint_id=ep_1\n")
+        if self.path.startswith("/cb/"):
+            Stub.callbacks.append(body)
+            return self._t("ok")
+        if self.path.endswith("/state"):
+            return self._t("ok")
         return self._t("ok")
+
     def do_GET(self):
         if self.path == "/api/agent/deployments":
-            base=f"http://127.0.0.1:{self.server.server_port}"
-            rec="\t".join(["dep_1", Stub.bait_path, "sekret", f"{base}/content/dep_1", f"{base}/cb/dep_1"])
-            return self._t(rec+"\n")
-        if self.path.startswith("/content/"): return self._t(BAIT_BODY)
+            base = f"http://127.0.0.1:{self.server.server_port}"
+            rec = "\t".join(
+                [
+                    "dep_1",
+                    Stub.bait_path,
+                    "sekret",
+                    f"{base}/content/dep_1",
+                    f"{base}/cb/dep_1",
+                ]
+            )
+            return self._t(rec + "\n")
+        if self.path.startswith("/content/"):
+            return self._t(BAIT_BODY)
         return self._t("")
+
 
 @pytest.fixture
 def server():
-    httpd = http.server.HTTPServer(("127.0.0.1",0), Stub)
+    httpd = http.server.HTTPServer(("127.0.0.1", 0), Stub)
     threading.Thread(target=httpd.serve_forever, daemon=True).start()
     Stub.callbacks = []
     yield httpd
     httpd.shutdown()
 
+
 def _run(server, tmp_path, *extra, timeout=15):
     port = server.server_port
     state = tmp_path / "agent.json"
     return subprocess.run(
-        ["sh", str(AGENT), "run", "--server", f"http://127.0.0.1:{port}",
-         "--enroll-token", "e", "--tripwire", "tw_1", "--state-file", str(state),
-         "--heartbeat", "0", *extra],
-        capture_output=True, text=True, timeout=timeout)
+        [
+            "sh",
+            str(AGENT),
+            "run",
+            "--server",
+            f"http://127.0.0.1:{port}",
+            "--enroll-token",
+            "e",
+            "--tripwire",
+            "tw_1",
+            "--state-file",
+            str(state),
+            "--heartbeat",
+            "0",
+            *extra,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
 
 def test_plant_creates_a_fifo_and_caches_content(server, tmp_path):
     bait = tmp_path / "bait_aws"
@@ -57,20 +107,41 @@ def test_plant_creates_a_fifo_and_caches_content(server, tmp_path):
     cache = tmp_path / "bait" / "dep_1"
     assert cache.read_text() == BAIT_BODY, "bait content not cached"
 
+
 def _wait(pred, timeout=12):
-    end=time.time()+timeout
-    while time.time()<end:
-        if pred(): return True
+    end = time.time() + timeout
+    while time.time() < end:
+        if pred():
+            return True
         time.sleep(0.2)
     return False
 
+
 def test_callback_includes_reader_pid_and_user(server, tmp_path):
-    bait = tmp_path / "bait_aws"; Stub.bait_path = str(bait)
+    bait = tmp_path / "bait_aws"
+    Stub.bait_path = str(bait)
     p = subprocess.Popen(
-        ["sh", str(AGENT), "run", "--server", f"http://127.0.0.1:{server.server_port}",
-         "--enroll-token","e","--tripwire","tw_1","--state-file",str(tmp_path/"agent.json"),
-         "--heartbeat","0","--sync-interval","0"],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        [
+            "sh",
+            str(AGENT),
+            "run",
+            "--server",
+            f"http://127.0.0.1:{server.server_port}",
+            "--enroll-token",
+            "e",
+            "--tripwire",
+            "tw_1",
+            "--state-file",
+            str(tmp_path / "agent.json"),
+            "--heartbeat",
+            "0",
+            "--sync-interval",
+            "0",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
     try:
         assert _wait(lambda: bait.exists() and stat.S_ISFIFO(bait.stat().st_mode))
         time.sleep(0.5)
@@ -78,73 +149,150 @@ def test_callback_includes_reader_pid_and_user(server, tmp_path):
         assert _wait(lambda: Stub.callbacks)
         body = Stub.callbacks[-1]
         assert "pid=" in body and "os_user=" in body
-        pid_line = [l for l in body.splitlines() if l.startswith("pid=")][0]
-        user_line = [l for l in body.splitlines() if l.startswith("os_user=")][0]
-        assert pid_line != "pid=" and user_line != "os_user=", f"reader not attributed: {body!r}"
+        pid_line = [ln for ln in body.splitlines() if ln.startswith("pid=")][0]
+        user_line = [ln for ln in body.splitlines() if ln.startswith("os_user=")][0]
+        assert pid_line != "pid=" and user_line != "os_user=", (
+            f"reader not attributed: {body!r}"
+        )
     finally:
-        p.terminate(); p.wait(timeout=5)
+        p.terminate()
+        p.wait(timeout=5)
+
 
 def test_reading_the_fifo_fires_a_callback(server, tmp_path):
-    bait = tmp_path / "bait_aws"; Stub.bait_path = str(bait)
+    bait = tmp_path / "bait_aws"
+    Stub.bait_path = str(bait)
     p = subprocess.Popen(
-        ["sh", str(AGENT), "run", "--server", f"http://127.0.0.1:{server.server_port}",
-         "--enroll-token","e","--tripwire","tw_1","--state-file",str(tmp_path/"agent.json"),
-         "--heartbeat","0","--sync-interval","0"],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        [
+            "sh",
+            str(AGENT),
+            "run",
+            "--server",
+            f"http://127.0.0.1:{server.server_port}",
+            "--enroll-token",
+            "e",
+            "--tripwire",
+            "tw_1",
+            "--state-file",
+            str(tmp_path / "agent.json"),
+            "--heartbeat",
+            "0",
+            "--sync-interval",
+            "0",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
     try:
-        assert _wait(lambda: bait.exists() and stat.S_ISFIFO(bait.stat().st_mode)), "no FIFO planted"
+        assert _wait(lambda: bait.exists() and stat.S_ISFIFO(bait.stat().st_mode)), (
+            "no FIFO planted"
+        )
         time.sleep(0.5)
-        got = Path(bait).read_text()                      # the "attacker" read
+        got = Path(bait).read_text()  # the "attacker" read
         assert got == BAIT_BODY, f"served wrong content: {got!r}"
-        assert _wait(lambda: any("event_type=open" in c for c in Stub.callbacks)), "no callback fired"
+        assert _wait(lambda: any("event_type=open" in c for c in Stub.callbacks)), (
+            "no callback fired"
+        )
     finally:
-        p.terminate(); p.wait(timeout=5)
+        p.terminate()
+        p.wait(timeout=5)
+
 
 def test_clean_exit_removes_fifos(server, tmp_path):
-    bait = tmp_path / "bait_aws"; Stub.bait_path = str(bait)
+    bait = tmp_path / "bait_aws"
+    Stub.bait_path = str(bait)
     p = subprocess.Popen(
-        ["sh", str(AGENT), "run", "--server", f"http://127.0.0.1:{server.server_port}",
-         "--enroll-token","e","--tripwire","tw_1","--state-file",str(tmp_path/"agent.json"),
-         "--heartbeat","0","--sync-interval","0"],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        [
+            "sh",
+            str(AGENT),
+            "run",
+            "--server",
+            f"http://127.0.0.1:{server.server_port}",
+            "--enroll-token",
+            "e",
+            "--tripwire",
+            "tw_1",
+            "--state-file",
+            str(tmp_path / "agent.json"),
+            "--heartbeat",
+            "0",
+            "--sync-interval",
+            "0",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
     assert _wait(lambda: bait.exists())
-    p.terminate(); p.wait(timeout=5)
+    p.terminate()
+    p.wait(timeout=5)
     assert not bait.exists(), "FIFO left behind after clean exit"
+
 
 def test_startup_sweeps_a_stale_fifo(server, tmp_path):
     # An orphan FIFO from a prior run: listed in the manifest but NOT a current
     # deployment, so ONLY the startup sweep (not plant's own EEXIST handling) can
     # remove it. Without the sweep it persists and blocks readers forever.
-    bait = tmp_path / "bait_aws"; Stub.bait_path = str(bait)   # the current deployment
-    orphan = tmp_path / "orphan_fifo"                          # NOT a current deployment
+    bait = tmp_path / "bait_aws"
+    Stub.bait_path = str(bait)  # the current deployment
+    orphan = tmp_path / "orphan_fifo"  # NOT a current deployment
     os.mkfifo(orphan)
-    (tmp_path / "planted.list").write_text(f"{orphan}\n")      # manifest from a prior run
+    (tmp_path / "planted.list").write_text(f"{orphan}\n")  # manifest from a prior run
     _run(server, tmp_path, "--once")
     assert not orphan.exists(), "orphan FIFO from manifest was not swept on startup"
-    assert bait.exists() and stat.S_ISFIFO(bait.stat().st_mode), "current bait not planted"
+    assert bait.exists() and stat.S_ISFIFO(bait.stat().st_mode), (
+        "current bait not planted"
+    )
 
 
 def test_two_agents_one_host_both_detect(server, tmp_path):
-    procs=[]; baits=[]
-    for i in (1,2):
-        d = tmp_path / f"inst{i}"; d.mkdir()
-        bait = d / "bait_aws"; baits.append(bait)
+    procs = []
+    baits = []
+    for i in (1, 2):
+        d = tmp_path / f"inst{i}"
+        d.mkdir()
+        bait = d / "bait_aws"
+        baits.append(bait)
         # each install gets its own bait path (distinct deployment per server stub run)
         Stub.bait_path = str(bait)
-        procs.append(subprocess.Popen(
-            ["sh", str(AGENT), "run", "--server", f"http://127.0.0.1:{server.server_port}",
-             "--enroll-token","e","--tripwire",f"tw_{i}","--state-file",str(d/"agent.json"),
-             "--heartbeat","0","--sync-interval","0"],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True))
+        procs.append(
+            subprocess.Popen(
+                [
+                    "sh",
+                    str(AGENT),
+                    "run",
+                    "--server",
+                    f"http://127.0.0.1:{server.server_port}",
+                    "--enroll-token",
+                    "e",
+                    "--tripwire",
+                    f"tw_{i}",
+                    "--state-file",
+                    str(d / "agent.json"),
+                    "--heartbeat",
+                    "0",
+                    "--sync-interval",
+                    "0",
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        )
         assert _wait(lambda: bait.exists() and stat.S_ISFIFO(bait.stat().st_mode))
     try:
         time.sleep(0.5)
-        for b in baits: Path(b).read_text()
-        assert _wait(lambda: sum("event_type=open" in c for c in Stub.callbacks) >= 2), \
-            "both agents should detect — no single-consumer collision"
+        for b in baits:
+            Path(b).read_text()
+        assert _wait(
+            lambda: sum("event_type=open" in c for c in Stub.callbacks) >= 2
+        ), "both agents should detect — no single-consumer collision"
     finally:
-        for p in procs: p.terminate()
-        for p in procs: p.wait(timeout=5)
+        for p in procs:
+            p.terminate()
+        for p in procs:
+            p.wait(timeout=5)
 
 
 def test_duplicate_install_does_not_sweep_live_agents_fifo(server, tmp_path):
@@ -159,71 +307,135 @@ def test_duplicate_install_does_not_sweep_live_agents_fifo(server, tmp_path):
 
     # Start agent A — the live agent.
     p_a = subprocess.Popen(
-        ["sh", str(AGENT), "run",
-         "--server", f"http://127.0.0.1:{server.server_port}",
-         "--enroll-token", "e", "--tripwire", "tw_1",
-         "--state-file", str(state),
-         "--heartbeat", "0", "--sync-interval", "0"],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        [
+            "sh",
+            str(AGENT),
+            "run",
+            "--server",
+            f"http://127.0.0.1:{server.server_port}",
+            "--enroll-token",
+            "e",
+            "--tripwire",
+            "tw_1",
+            "--state-file",
+            str(state),
+            "--heartbeat",
+            "0",
+            "--sync-interval",
+            "0",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
     try:
         # Wait for agent A to plant its FIFO.
-        assert _wait(lambda: bait.exists() and stat.S_ISFIFO(bait.stat().st_mode)), \
+        assert _wait(lambda: bait.exists() and stat.S_ISFIFO(bait.stat().st_mode)), (
             "agent A did not plant a FIFO in time"
+        )
 
         # Start agent B with the SAME state-file — it must detect the singleton and exit.
         result_b = subprocess.run(
-            ["sh", str(AGENT), "run",
-             "--server", f"http://127.0.0.1:{server.server_port}",
-             "--enroll-token", "e", "--tripwire", "tw_1",
-             "--state-file", str(state),
-             "--heartbeat", "0", "--sync-interval", "0"],
-            capture_output=True, text=True, timeout=15)
+            [
+                "sh",
+                str(AGENT),
+                "run",
+                "--server",
+                f"http://127.0.0.1:{server.server_port}",
+                "--enroll-token",
+                "e",
+                "--tripwire",
+                "tw_1",
+                "--state-file",
+                str(state),
+                "--heartbeat",
+                "0",
+                "--sync-interval",
+                "0",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
 
         # B should have exited cleanly (returncode 0, logged "already running").
         assert result_b.returncode == 0, f"agent B exited with rc={result_b.returncode}"
 
         # CRITICAL: agent A's FIFO must still exist after B exits.
-        assert bait.exists() and stat.S_ISFIFO(bait.stat().st_mode), \
+        assert bait.exists() and stat.S_ISFIFO(bait.stat().st_mode), (
             "agent B's startup sweep deleted agent A's live bait FIFO!"
+        )
 
         # Confirm the FIFO is still readable — agent A is still serving it.
         content = Path(bait).read_text()
-        assert content == BAIT_BODY, \
+        assert content == BAIT_BODY, (
             f"bait FIFO no longer serves the expected content: {content!r}"
+        )
     finally:
         p_a.terminate()
         p_a.wait(timeout=5)
         import subprocess as _sp
-        _sp.run(["pkill", "-f", "thumper_agent.sh run --server http://127.0.0.1"],
-                capture_output=True)
+
+        _sp.run(
+            ["pkill", "-f", "thumper_agent.sh run --server http://127.0.0.1"],
+            capture_output=True,
+        )
 
 
 def test_tampered_fifo_is_recovered(server, tmp_path):
     # Roee #123 F1: replacing the FIFO bait with a regular file must RECOVER (rm the
     # impostor + re-create the FIFO), not just report failed forever and go blind.
     # Needs live-sync (--sync-interval) so verify_planted runs.
-    bait = tmp_path / "bait_aws"; Stub.bait_path = str(bait)
+    bait = tmp_path / "bait_aws"
+    Stub.bait_path = str(bait)
     p = subprocess.Popen(
-        ["sh", str(AGENT), "run", "--server", f"http://127.0.0.1:{server.server_port}",
-         "--enroll-token", "e", "--tripwire", "tw_1", "--state-file", str(tmp_path / "agent.json"),
-         "--heartbeat", "0", "--sync-interval", "1"],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        [
+            "sh",
+            str(AGENT),
+            "run",
+            "--server",
+            f"http://127.0.0.1:{server.server_port}",
+            "--enroll-token",
+            "e",
+            "--tripwire",
+            "tw_1",
+            "--state-file",
+            str(tmp_path / "agent.json"),
+            "--heartbeat",
+            "0",
+            "--sync-interval",
+            "1",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
     try:
-        assert _wait(lambda: bait.exists() and stat.S_ISFIFO(bait.stat().st_mode)), "no FIFO planted"
-        os.remove(bait); bait.write_text("attacker regular file")        # tamper: replace pipe with a file
-        assert _wait(lambda: bait.exists() and stat.S_ISFIFO(bait.stat().st_mode), timeout=15), \
-            "tampered FIFO was not recovered - sensor left permanently blind"
+        assert _wait(lambda: bait.exists() and stat.S_ISFIFO(bait.stat().st_mode)), (
+            "no FIFO planted"
+        )
+        os.remove(bait)
+        bait.write_text("attacker regular file")  # tamper: replace pipe with a file
+        assert _wait(
+            lambda: bait.exists() and stat.S_ISFIFO(bait.stat().st_mode), timeout=15
+        ), "tampered FIFO was not recovered - sensor left permanently blind"
     finally:
-        p.terminate(); p.wait(timeout=5)
+        p.terminate()
+        p.wait(timeout=5)
 
 
 def test_simulate_does_not_leave_a_no_reader_fifo(server, tmp_path):
     # Roee #123 F2: --simulate plants, fires test callbacks, exits - it must sweep
     # its FIFOs, else a leftover no-reader pipe blocks every real open() forever.
-    bait = tmp_path / "bait_aws"; Stub.bait_path = str(bait)
+    bait = tmp_path / "bait_aws"
+    Stub.bait_path = str(bait)
     _run(server, tmp_path, "--simulate")
-    assert not (bait.exists() and stat.S_ISFIFO(bait.stat().st_mode)), "--simulate left a no-reader FIFO"
-    assert any("simulated" in c for c in Stub.callbacks), "simulate callback did not fire"
+    assert not (bait.exists() and stat.S_ISFIFO(bait.stat().st_mode)), (
+        "--simulate left a no-reader FIFO"
+    )
+    assert any("simulated" in c for c in Stub.callbacks), (
+        "simulate callback did not fire"
+    )
 
 
 def test_atime_stat_order_prefers_portable_access_time():
@@ -232,12 +444,15 @@ def test_atime_stat_order_prefers_portable_access_time():
     # so that a future refactor of one cannot silently pass by matching the other.
     src = AGENT.read_text()
     # Site 1: initial atime capture at the top of watch_atime
-    assert 'stat -c %X "$p" 2>/dev/null || stat -f %a "$p" 2>/dev/null || echo 0)' in src, \
-        "watch_atime initialisation must try `stat -c %X` before `stat -f %a`"
+    assert (
+        'stat -c %X "$p" 2>/dev/null || stat -f %a "$p" 2>/dev/null || echo 0)' in src
+    ), "watch_atime initialisation must try `stat -c %X` before `stat -f %a`"
     # Site 2: per-poll atime refresh inside the watch loop
-    assert 'stat -c %X "$p" 2>/dev/null || stat -f %a "$p" 2>/dev/null || echo 0' in src, \
-        "watch_atime poll loop must try `stat -c %X` before `stat -f %a`"
+    assert (
+        'stat -c %X "$p" 2>/dev/null || stat -f %a "$p" 2>/dev/null || echo 0' in src
+    ), "watch_atime poll loop must try `stat -c %X` before `stat -f %a`"
     # The reversed (wrong) order must not appear anywhere in the source
-    assert 'stat -f %a "$p" 2>/dev/null || stat -c %X' not in src, \
+    assert 'stat -f %a "$p" 2>/dev/null || stat -c %X' not in src, (
         "source must not contain the wrong stat order (stat -f %a before stat -c %X)"
+    )
     assert "watch_fs_usage" not in src, "fs_usage sensor must be removed"

--- a/tests/test_agent_fifo.py
+++ b/tests/test_agent_fifo.py
@@ -1,7 +1,7 @@
 """FIFO bait sensor (#100): bait is planted as a named pipe; a read of it
 unblocks the agent's write and fires a callback. Driven against a stub server,
 like test_agent_live_sync.py."""
-import http.server, socket, subprocess, threading, time, os, stat
+import http.server, subprocess, threading, os, stat
 from pathlib import Path
 import pytest
 

--- a/tests/test_agent_plant.py
+++ b/tests/test_agent_plant.py
@@ -144,6 +144,10 @@ def test_refreshes_its_own_bait(agent):
     (path,) = configure("bait_target")
 
     assert run().returncode == 0
+    # In FIFO mode the planted path is a named pipe; open() on a FIFO blocks
+    # until a writer appears, so write_text() would deadlock. Remove the pipe
+    # first, then place a regular file to simulate stale/rotated bait.
+    Path(path).unlink()
     Path(path).write_text("stale-bait")  # simulate server-side rotation
     assert run().returncode == 0
     assert stat.S_ISFIFO(Path(path).stat().st_mode), "bait not planted as FIFO"

--- a/tests/test_agent_plant.py
+++ b/tests/test_agent_plant.py
@@ -10,6 +10,7 @@ does not start watching - rather than skipping one file and continuing.
 """
 
 import http.server
+import stat
 import subprocess
 import threading
 from pathlib import Path
@@ -133,8 +134,8 @@ def test_plants_all_when_no_conflicts(agent):
 
     assert result.returncode == 0
     assert "/api/enroll" in _StubHandler.seen, "did not enroll on a clean install"
-    assert Path(a).read_text() == BAIT_BODY
-    assert Path(b).read_text() == BAIT_BODY
+    assert stat.S_ISFIFO(Path(a).stat().st_mode), "bait not planted as FIFO"
+    assert stat.S_ISFIFO(Path(b).stat().st_mode), "bait not planted as FIFO"
 
 
 def test_refreshes_its_own_bait(agent):
@@ -145,7 +146,7 @@ def test_refreshes_its_own_bait(agent):
     assert run().returncode == 0
     Path(path).write_text("stale-bait")  # simulate server-side rotation
     assert run().returncode == 0
-    assert Path(path).read_text() == BAIT_BODY
+    assert stat.S_ISFIFO(Path(path).stat().st_mode), "bait not planted as FIFO"
 
 
 def test_force_overwrites_occupied_path(agent):
@@ -157,4 +158,4 @@ def test_force_overwrites_occupied_path(agent):
     result = run("--force")
 
     assert result.returncode == 0
-    assert Path(path).read_text() == BAIT_BODY
+    assert stat.S_ISFIFO(Path(path).stat().st_mode), "bait not planted as FIFO"

--- a/tests/test_agent_state_report.py
+++ b/tests/test_agent_state_report.py
@@ -2,6 +2,7 @@
 leftover. Drives the real agent against a stub that can fail one content fetch
 and records state reports."""
 import http.server
+import stat
 import subprocess
 import threading
 from pathlib import Path
@@ -89,7 +90,7 @@ def test_reports_planted_for_good_and_failed_for_bad(agent):
 
     assert _Stub.states.get("dp_good") == "planted"
     assert _Stub.states.get("dp_bad") == "failed"
-    assert Path(good).read_text() == BAIT, "dp_good file not written despite planted state"
+    assert stat.S_ISFIFO(Path(good).stat().st_mode), "dp_good not planted as FIFO"
 
 
 def test_force_curl_failure_leaves_no_leftover(agent):


### PR DESCRIPTION
Replaces the macOS `fs_usage` read sensor with **FIFO (named-pipe) bait**: each bait is a named pipe the agent serves, so any read unblocks the agent and fires a callback — unprivileged, cross-platform, no kdebug.

## Why
`fs_usage` is a single-consumer kdebug tool — two agents (or Instruments) on one host knock each other's sensor offline (#94/#95). Per-bait FIFOs share no sensor, so they coexist.

## What
- Plant bait as a FIFO + cache content; serve per-bait via a supervisor loop.
- Best-effort reader pid/user attribution via an `lsof` inode scan.
- Remove FIFOs on clean exit + sweep stale pipes on startup (only after acquiring the singleton lock).
- Remove `fs_usage`; fix the atime fallback (#28: try `stat -c %X` before `stat -f %a`); FIFO-aware verify.

## Verified
33 agent tests pass — incl. two-agents-one-host detection and duplicate-install safety; shellcheck clean. `readFileSync`/`existsSync` drain a FIFO (the common stealer path); accepted blind spots (statSync-guard worm, mmap, scan-only discovery) are documented — `eslogger` deferred as a follow-up.

Part of #100 (sensor epic — stays open until the full series lands). Relates to #28. Addresses #94, #95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Validated (2026-06-26)
Empirically confirmed on macOS 26.5.1:
- **FIFO pid attribution is deterministic: 8/8.** Correctness fix folded in: `lsof -t <path>` does **not** match FIFOs (returns nothing) — attribution must scan full `lsof` output by **inode/realpath** (the inode scan this PR uses), excluding the agent's own pid, while the reader is parked in `read()`.
- FIFO covers raw-readers (the Shai-Hulud case) with an exact pid. The accepted blind spots (statSync-guard / mmap / scan-only) and the "normal file" requirement are addressed by a follow-up **atime regular-file primary layer + churn-ledger shortlist** — see #100 (update) and #124; out of scope for this PR.

