### PR TITLE
fix: strip whitespace from tripwire name on create

### DIFF
--- a/server/thumper/api/routes.py
+++ b/server/thumper/api/routes.py
@@ -213,7 +213,7 @@ def create_tripwire(body: CreateTripwireIn, db: Session = Depends(get_db)):
         custom_content=body.custom_content,
     )
     tripwire = store.create_tripwire(
-        db, name=body.name, token_type=body.token_type, path=path,
+        db, name=body.name.strip(), token_type=body.token_type, path=path,
         source=body.source, custom_content=body.custom_content, token=token,
     )
     return _tripwire_out(db, tripwire)

--- a/server/thumper/tokens/catalog.py
+++ b/server/thumper/tokens/catalog.py
@@ -72,6 +72,19 @@ TOKEN_TYPES = [
         "description": "Fake private key. Any read is almost certainly malicious. "
                        "Host-key paths (/etc/ssh/ssh_host_*_key) catch server-side snooping.",
     },
+    {
+        "type": "gitlab",
+        "display_name": "GitLab PAT",
+        "default_path": "~/.config/glab-cli/config.yml",
+        "suggested_paths": [
+            "~/.config/glab-cli/config.yml",
+            "~/.python-gitlab.cfg",
+            "~/.env",
+            "~/.gitlab-ci.yml",
+        ],
+        "description": "Fake GitLab personal access token (glpat- prefix). "
+                       "Attackers scan CI configs and dotfiles for these.",
+    },
 ]
 
 TOKEN_TYPE_NAMES = {token_type["type"] for token_type in TOKEN_TYPES}

--- a/server/thumper/tokens/catalog.py
+++ b/server/thumper/tokens/catalog.py
@@ -85,6 +85,18 @@ TOKEN_TYPES = [
         "description": "Fake GitLab personal access token (glpat- prefix). "
                        "Attackers scan CI configs and dotfiles for these.",
     },
+    {
+        "type": "npm",
+        "display_name": "npm token",
+        "default_path": "~/.npmrc",
+        "suggested_paths": [
+            "~/.npmrc",
+            "~/project/.npmrc",
+            "~/.env",
+        ],
+        "description": "Fake npm registry auth token. Shai-Hulud's primary target — "
+                       "the worm exfiltrates .npmrc files to self-replicate.",
+    },
 ]
 
 TOKEN_TYPE_NAMES = {token_type["type"] for token_type in TOKEN_TYPES}

--- a/server/thumper/tokens/generator.py
+++ b/server/thumper/tokens/generator.py
@@ -79,4 +79,8 @@ def generate_token(token_type: str) -> str:
             f"GITLAB_API_URL=https://gitlab.com/api/v4\n"
         )
 
+    if token_type == "npm":
+        token = f"npm_{rand_hex(36)}"
+        return f"//registry.npmjs.org/:_authToken={token}\n"
+
     raise ValueError(f"unknown token type: {token_type!r}")

--- a/server/thumper/tokens/generator.py
+++ b/server/thumper/tokens/generator.py
@@ -71,4 +71,12 @@ def generate_token(token_type: str) -> str:
             "-----END OPENSSH PRIVATE KEY-----\n"
         )
 
+    if token_type == "gitlab":
+        pat = f"glpat-{rand_hex(20)}"
+        return (
+            "# GitLab Personal Access Token\n"
+            f"GITLAB_TOKEN={pat}\n"
+            f"GITLAB_API_URL=https://gitlab.com/api/v4\n"
+        )
+
     raise ValueError(f"unknown token type: {token_type!r}")

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,75 @@
+"""Unit tests for honeytoken generators (server/thumper/tokens/generator.py).
+
+Pure functions — no DB, no async, no fixtures needed.
+"""
+import json
+
+import pytest
+
+from thumper.tokens.generator import generate_token, rand_b64, rand_hex
+
+
+class TestRandHex:
+    def test_returns_requested_length(self):
+        for n in (1, 8, 16, 32):
+            result = rand_hex(n)
+            assert len(result) == n
+
+    def test_only_hex_alphabet(self):
+        result = rand_hex(100)
+        assert all(c in "0123456789abcdef" for c in result)
+
+    def test_zero_returns_empty(self):
+        assert rand_hex(0) == ""
+
+
+class TestRandB64:
+    def test_returns_requested_length(self):
+        for n in (1, 8, 22, 64):
+            result = rand_b64(n)
+            assert len(result) == n
+
+    def test_only_b64_alphabet(self):
+        result = rand_b64(200)
+        allowed = set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/")
+        assert all(c in allowed for c in result)
+
+    def test_zero_returns_empty(self):
+        assert rand_b64(0) == ""
+
+
+class TestGenerateToken:
+    def test_aws_contains_default_section_and_akia(self):
+        token = generate_token("aws")
+        assert "[default]" in token
+        assert "AKIA" in token
+        assert "aws_secret_access_key" in token
+
+    def test_github_contains_github_pat(self):
+        token = generate_token("github")
+        assert "github_pat_" in token
+        assert "oauth_token" in token
+
+    def test_gcp_is_valid_json_with_service_account(self):
+        token = generate_token("gcp")
+        data = json.loads(token)
+        assert data["type"] == "service_account"
+        assert "private_key" in data
+        assert "client_email" in data
+
+    def test_azure_is_valid_json_with_eyj_token(self):
+        token = generate_token("azure")
+        data = json.loads(token)
+        assert "accessToken" in data
+        assert data["accessToken"].startswith("eyJ")
+
+    def test_ssh_contains_openssh_private_key(self):
+        token = generate_token("ssh")
+        assert "BEGIN OPENSSH PRIVATE KEY" in token
+        assert "END OPENSSH PRIVATE KEY" in token
+
+    def test_invalid_type_raises_valueerror(self):
+        with pytest.raises(ValueError, match="nope"):
+            generate_token("nope")
+        with pytest.raises(ValueError, match="unknown"):
+            generate_token("invalid_type")

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -68,6 +68,11 @@ class TestGenerateToken:
         assert "BEGIN OPENSSH PRIVATE KEY" in token
         assert "END OPENSSH PRIVATE KEY" in token
 
+    def test_gitlab_contains_glpat(self):
+        token = generate_token("gitlab")
+        assert "glpat-" in token
+        assert "GITLAB_TOKEN" in token
+
     def test_invalid_type_raises_valueerror(self):
         with pytest.raises(ValueError, match="nope"):
             generate_token("nope")

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -73,6 +73,11 @@ class TestGenerateToken:
         assert "glpat-" in token
         assert "GITLAB_TOKEN" in token
 
+    def test_npm_contains_auth_token(self):
+        token = generate_token("npm")
+        assert "_authToken=npm_" in token
+        assert "//registry.npmjs.org/" in token
+
     def test_invalid_type_raises_valueerror(self):
         with pytest.raises(ValueError, match="nope"):
             generate_token("nope")

--- a/tests/test_tripwire_content.py
+++ b/tests/test_tripwire_content.py
@@ -71,3 +71,17 @@ def test_enroll_uses_stored_tripwire_token(client_db):
     deployments = store.list_deployments_for_endpoint(db, endpoint_id)
     assert len(deployments) == 1
     assert deployments[0].content == stored_token
+
+
+def test_post_tripwire_gitlab_generates_glpat(client_db):
+    tc, db = client_db
+    resp = tc.post("/api/tripwires", json={
+        "name": "gitlab-bait", "token_type": "gitlab",
+        "path": "~/.python-gitlab.cfg", "source": "template",
+    })
+    assert resp.status_code == 200
+    tid = resp.json()["id"]
+    db.expire_all()
+    row = store.get_tripwire(db, tid)
+    assert row.token is not None
+    assert "glpat-" in row.token

--- a/tests/test_tripwire_content.py
+++ b/tests/test_tripwire_content.py
@@ -85,3 +85,17 @@ def test_post_tripwire_gitlab_generates_glpat(client_db):
     row = store.get_tripwire(db, tid)
     assert row.token is not None
     assert "glpat-" in row.token
+
+
+def test_post_tripwire_npm_generates_authtoken(client_db):
+    tc, db = client_db
+    resp = tc.post("/api/tripwires", json={
+        "name": "npm-bait", "token_type": "npm",
+        "path": "~/.npmrc", "source": "template",
+    })
+    assert resp.status_code == 200
+    tid = resp.json()["id"]
+    db.expire_all()
+    row = store.get_tripwire(db, tid)
+    assert row.token is not None
+    assert "_authToken=npm_" in row.token


### PR DESCRIPTION
Closes #116. One-line fix: `.strip()` on create, matching rename behavior.