### PR TITLE
fix: rename Instances to Tripwires on Endpoints page

### DIFF
--- a/ui/src/pages/Endpoints.tsx
+++ b/ui/src/pages/Endpoints.tsx
@@ -33,7 +33,7 @@ export default function Endpoints() {
                   <th>Platform</th>
                   <th>Enrolled</th>
                   <th>Last seen</th>
-                  <th>Instances</th>
+                  <th>Tripwires</th>
                   <th>Triggers</th>
                   <th>Status</th>
                 </tr>


### PR DESCRIPTION
Closes #50