### PR TITLE
ci: build UI + image in CI, add .dockerignore, fix broken vite8/plugin-react combo (#148)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# Keep the Docker build context to source only. Without this, `COPY ui/ ./`
+# pulls a developer's local ui/node_modules into the image - overriding the
+# clean `npm ci` layer, breaking reproducibility and bloating the image (#148).
+.git
+.github
+.gitignore
+
+# Node / UI build artifacts (rebuilt inside the image)
+**/node_modules
+ui/dist
+**/*.tsbuildinfo
+
+# Python caches / local envs
+**/__pycache__
+**/*.py[cod]
+.venv
+venv/
+.pytest_cache
+*.egg-info
+
+# Local data / secrets / db (never belong in an image)
+data/
+*.db
+*.db-*
+.env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,34 @@ jobs:
 
       - name: Run tests
         run: pytest -v
+
+  ui-build:
+    # The UI was previously unbuilt in CI, so a dependency bump could break
+    # `npm run build` (tsc + vite) with all checks still green (#148).
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "26" # match the Dockerfile's node base
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+
+      - name: Install UI deps
+        run: npm ci
+        working-directory: ui
+
+      - name: Build UI
+        run: npm run build
+        working-directory: ui
+
+  docker-build:
+    # Build the monolith image so base-image bumps and Dockerfile breakage are
+    # caught in CI rather than at deploy time (#148).
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build image
+        run: docker build -t thumper:ci .

--- a/ui/src/css.d.ts
+++ b/ui/src/css.d.ts
@@ -1,0 +1,4 @@
+// Ambient declaration for side-effect CSS imports (e.g. `@fontsource/inter/400.css`
+// and `./styles/app.css` in main.tsx). TypeScript 6 rejects untyped side-effect
+// imports (TS2882) without this; harmless under TS 5. See #144 / #148.
+declare module "*.css";


### PR DESCRIPTION
Closes #148.

## ⚠️ Heads-up: `main` is currently broken
#143 (vite 5→8) merged without #138 (`@vitejs/plugin-react` 4→6). plugin-react 4 only peers `vite <=7`, so **`npm ci` on `main` fails today with ERESOLVE**. This PR fixes it (and the new CI job would have caught it).

## Changes
- **`.github/workflows/ci.yml`** — add a `ui-build` job (`npm ci` + `npm run build`) and a `docker-build` job (`docker build .`). CI previously only ran `pytest`, so UI/Docker breakage passed with green checks (e.g. #144, and the vite/plugin-react conflict above).
- **`ui/package.json` + `package-lock.json`** — bump `@vitejs/plugin-react` to `^6.0.3` (the approved #138 version) and regenerate the lockfile so vite 8 + plugin-react 6 resolve consistently.
- **`.dockerignore`** (new) — without it, `COPY ui/ ./` copied a developer's local `ui/node_modules` into the image, overriding the clean `npm ci` layer (non-reproducible, bloated).
- **`ui/src/css.d.ts`** (new) — `declare module "*.css"` so the side-effect CSS imports type-check under TypeScript 6 (unblocks #144); harmless under TS 5.

## Verification (local)
- `npm ci` ✅ (ERESOLVE gone), `npm run build` ✅ under **TS 5 and TS 6** (TS6 went 5 `TS2882` errors → 0 with `css.d.ts`).
- `docker build .` ✅ exits 0 with a clean context.

## Follow-ups
- **#138** (plugin-react 4→6) is now superseded by this PR — close it once this merges.
- The new `ui-build` / `docker-build` jobs aren't in the branch-protection required checks yet; add them to the ruleset to make them blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)