### PR TITLE
docs: add .editorconfig for consistent editor formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.{ts,tsx,js,jsx,json,yml,yaml,css}]
+indent_size = 2
+
+[*.sh]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -11,9 +11,11 @@ indent_style = space
 indent_size = 4
 
 [*.{ts,tsx,js,jsx,json,yml,yaml,css}]
+indent_style = space
 indent_size = 2
 
 [*.sh]
+indent_style = space
 indent_size = 4
 
 [*.md]


### PR DESCRIPTION
Closes #113

Adds `.editorconfig` at the repo root covering Python, TypeScript, JavaScript, JSON, YAML, CSS, shell, and Markdown. Matches existing code style, no files reformatted.