### PR TITLE
Add test for the `<PageTitle>` component

### DIFF
--- a/ui/src/components/PageTitle.test.tsx
+++ b/ui/src/components/PageTitle.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import PageTitle from "./PageTitle.tsx";
+import "@testing-library/jest-dom/vitest";
+
+describe("<PageTitle> component", () => {
+  const unknownTitles = [
+    "",
+    " ",
+    "  ",
+  ];
+
+  const titles = [
+    "1",
+    "x",
+    "Lorem",
+    "Lorem Ipsum",
+    " Lorem Ipsum",
+    "Lorem Ipsum ",
+    " Lorem Ipsum ",
+  ];
+
+  it.each(unknownTitles)("renders title of app if page title is unknown", (title) => {
+    const {getByText} = render(<PageTitle title={title} />);
+    expect(getByText("Thumper")).toBeInTheDocument();
+  });
+
+  it.each(titles)("renders expected title of a page", (title) => {
+    const {getByText} = render(<PageTitle title={title} />);
+    expect(getByText(title.trim() + " · Thumper")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
# Main goal of the PR
As mentioned in the title, test for the `<PageTitle>` component.
# How to verify
## Run the command
```shell
cd ui && npm install && npm run test
```
## Expected result
```
 Test Files  1 passed (1)
      Tests  10 passed (10)
   Start at  20:04:16
   Duration  603ms (transform 21ms, setup 0ms, import 108ms, tests 22ms, environment 394ms)
```
# Related PRs
- https://github.com/jestasecurity/thumper/pull/156
- https://github.com/jestasecurity/thumper/pull/157