### PR TITLE
Churn-ledger suspect shortlist for atime trips (#124)

### DIFF
--- a/agent/thumper_agent.sh
+++ b/agent/thumper_agent.sh
@@ -56,6 +56,8 @@ LAST_RESYNC=0
 FIFO_MODE=0
 BAITCACHE=""
 REPLANTED=0
+LEDGER_PID=""
+LEDGER_FILE=""
 probe_fifo_mode() {
     FIFO_MODE=0
     [ "$(platform)" = "darwin" ] || return 0  # FIFO sensor is macOS-only; Linux uses inotify
@@ -392,12 +394,17 @@ fire() {  # fire <i> <event_type> <process> <pid> <os_user> <accessed_path>
 # the read that triggered us still alerts under fresh credentials.
 _fire() {
     eval "id=\$dep_id_$1 secret=\$dep_secret_$1 callback=\$dep_callback_$1 path=\$dep_path_$1"
-    event_type=$2; process=$3; pid=$4; os_user=$5; accessed_path=${6:-$path}
+    event_type=$2; process=$3; pid=$4; os_user=$5; accessed_path=${6:-$path}; suspects=${7:-}
     summary=${process:-unknown}
     [ -n "$pid" ] && summary="$summary (pid $pid)"
     ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
     body=$(printf 'deployment_id=%s\nevent_type=%s\nprocess=%s\npid=%s\nos_user=%s\naccessed_path=%s\ntriggered_by=%s\ntimestamp=%s' \
         "$id" "$event_type" "$process" "$pid" "$os_user" "$accessed_path" "$summary" "$ts")
+    # Best-effort suspect shortlist for detection-only (atime) trips. A new line,
+    # HMAC-covered like the rest; the server ignores unknown keys until it stores
+    # them. Omitted entirely when empty so other events' bodies are unchanged.
+    [ -n "$suspects" ] && body="$body
+suspects=$suspects"
     sig=$(hmac_sha256 "$secret" "$body")
     # No -f: we want to read the HTTP status (401) instead of just a curl failure.
     code=$(curl -sS -o /dev/null -w '%{http_code}' -X POST "$callback" \
@@ -412,7 +419,7 @@ _fire() {
                 # path against the refreshed deployment set.
                 new_idx=$(dep_index_for_line "$accessed_path") || {
                     err "callback REJECTED - path not deployed after re-enroll ($summary)"; return 0; }
-                _fire "$new_idx" "$event_type" "$process" "$pid" "$os_user" "$accessed_path"
+                _fire "$new_idx" "$event_type" "$process" "$pid" "$os_user" "$accessed_path" "$suspects"
             else
                 err "callback REJECTED (401) ($summary)"
             fi ;;
@@ -542,6 +549,34 @@ arm_atime() {  # arm_atime <path>: set atime to the past so the next read bumps 
 read_atime() {  # read_atime <path>: portable access-time epoch (GNU %X first, then BSD %a - never %a on Linux, that's free blocks: #28)
     stat -c %X "$1" 2>/dev/null || stat -f %a "$1" 2>/dev/null || echo 0
 }
+
+# Churn ledger (#124): the atime sensor is detection-only. This sidecar records
+# the first-seen epoch + command of every live process, so on an atime trip we
+# can attach a best-effort SUSPECT SHORTLIST (recently-spawned processes around
+# the read). It is a shortlist, NOT a definitive pid - it CAPTURES the reader
+# (validated) without falsely claiming a single one. Only runs in atime mode.
+LEDGER_INTERVAL=1
+churn_ledger() {  # background: maintain "<pid> <first-seen-epoch> <comm>" per live pid
+    [ -n "${LEDGER_FILE:-}" ] || return 0
+    : > "$LEDGER_FILE"
+    while :; do
+        now=$(date +%s)
+        ps -axo pid=,comm= 2>/dev/null | awk -v now="$now" -v led="$LEDGER_FILE" '
+            BEGIN { while ((getline l < led) > 0) { split(l, f, " "); seen[f[1]]=f[2] } close(led) }
+            { pid=$1; $1=""; sub(/^[ \t]+/, ""); comm=$0; sub(/.*\//, "", comm); gsub(/[ ,:\t]/, "_", comm)
+              if (!(pid in seen)) seen[pid]=now; cm[pid]=comm; alive[pid]=1 }
+            END { for (p in alive) printf "%s %s %s\n", p, seen[p], cm[p] }
+        ' > "$LEDGER_FILE.tmp" 2>/dev/null && mv "$LEDGER_FILE.tmp" "$LEDGER_FILE" 2>/dev/null
+        sleep "$LEDGER_INTERVAL"
+    done
+}
+suspects_at() {  # suspects_at <epoch>: "comm:pid,..." for procs first seen within (POLL+10)s before <epoch>
+    [ -f "${LEDGER_FILE:-/nonexistent}" ] || return 0
+    awk -v cut=$(( $1 - POLL - 10 )) -v me="$$" '
+        $1 != me && $2 >= cut { printf "%s:%s,", $3, $1 }
+    ' "$LEDGER_FILE" 2>/dev/null | sed 's/,$//'
+}
+
 watch_atime() {
     log "atime poll every ${POLL}s on regular-file bait (re-armable; detection only - no process/user)"
     i=1
@@ -558,7 +593,8 @@ watch_atime() {
             eval "p=\$dep_path_$i prev=\$atime_$i"
             cur=$(read_atime "$p")
             if [ "$cur" != "0" ] && [ "$cur" -gt "$prev" ] 2>/dev/null; then
-                fire "$i" "atime-change" "" "" "" "$p"
+                sus=$(suspects_at "$(date +%s)")        # best-effort reader shortlist (no definitive pid)
+                fire "$i" "atime-change" "" "" "" "$p" "$sus"
                 arm_atime "$p"                          # RE-ARM so the NEXT read is detectable too
                 eval "atime_$i=\$(read_atime \"\$p\")"
             fi
@@ -639,6 +675,7 @@ watch_fifo() {  # supervisor: one serve_fifo per bait, wait on them
 start_watcher() {  # launch the right sensor in the background; set WATCH_PID
     rm -f "${WATCH_STOP_FLAG:-}" 2>/dev/null || true   # this start is not a stop
     if [ "$SENSOR" = atime ]; then
+        [ -z "$LEDGER_PID" ] && { churn_ledger & LEDGER_PID=$!; }  # suspect-shortlist sidecar (persists across reconciles)
         watch_atime &                                   # forced atime sensor (any platform)
     elif [ "$FIFO_MODE" = 1 ]; then
         watch_fifo &
@@ -659,6 +696,13 @@ stop_watcher() {  # kill the watcher AND its serve_fifo children
     pkill -P "$WATCH_PID" 2>/dev/null || true
     kill "$WATCH_PID" 2>/dev/null || true
     WATCH_PID=""
+}
+
+stop_ledger() {  # kill the churn-ledger sidecar (persists across watcher restarts; dies at exit)
+    [ -n "${LEDGER_PID:-}" ] || return 0
+    pkill -P "$LEDGER_PID" 2>/dev/null || true
+    kill "$LEDGER_PID" 2>/dev/null || true
+    LEDGER_PID=""
 }
 
 remove_fifos() {  # remove every manifest path that is a FIFO (clean exit / startup sweep)
@@ -759,6 +803,7 @@ run() {
     MANIFEST_FILE="$(dirname "$STATE_FILE")/planted.list"
     BAITCACHE="$(dirname "$STATE_FILE")/bait"
     WATCH_STOP_FLAG="$(dirname "$STATE_FILE")/watcher.stopping"
+    LEDGER_FILE="$(dirname "$STATE_FILE")/churn.ledger"
     mkdir -p "$(dirname "$STATE_FILE")"
     if [ "$SENSOR" = atime ]; then
         FIFO_MODE=0; log "sensor: atime poll (regular-file bait, re-armable)"
@@ -811,8 +856,8 @@ run() {
     # release the singleton lock. Combined into one trap (replacing the release-
     # only trap set after acquire_singleton) so none clobbers the others.
     cleanup_heartbeat() { [ -n "$HEARTBEAT_PID" ] && kill "$HEARTBEAT_PID" 2>/dev/null; }
-    trap 'stop_watcher; remove_fifos; cleanup_heartbeat; release_singleton; exit 0' INT TERM
-    trap 'stop_watcher; remove_fifos; cleanup_heartbeat; release_singleton' EXIT
+    trap 'stop_watcher; stop_ledger; remove_fifos; cleanup_heartbeat; release_singleton; exit 0' INT TERM
+    trap 'stop_watcher; stop_ledger; remove_fifos; cleanup_heartbeat; release_singleton' EXIT
     # Remote kill: the heartbeat loop raises USR1 when the server flags us.
     trap 'self_destruct' USR1
 

--- a/tests/test_agent_churn.py
+++ b/tests/test_agent_churn.py
@@ -1,0 +1,87 @@
+"""Churn-ledger best-effort suspect shortlist (#124): the atime sensor is
+detection-only (no pid). A lightweight process-churn ledger records recently
+-spawned processes; when an atime bait trips, the agent attaches a best-effort
+`suspects=` shortlist to the alert. Validated behaviour: the shortlist *captures*
+the reader (it does not claim a single definitive pid - that would be a false
+attribution). Here we assert a known recently-spawned process appears in it.
+
+Cross-platform (atime layer runs on macOS + Linux). The 'read' is simulated by
+bumping atime via os.utime(), so detection is deterministic."""
+import http.server, subprocess, threading, os, time
+from pathlib import Path
+import pytest
+
+AGENT = Path(__file__).resolve().parents[1] / "agent" / "thumper_agent.sh"
+BAIT_BODY = "AKIA-BAIT\nsecret=shhh\n"
+ARMED_MAX = 1_000_000_000
+
+
+class Stub(http.server.BaseHTTPRequestHandler):
+    callbacks = []
+    bait_path = ""
+    def log_message(self, *a): pass
+    def _t(self, body=""):
+        self.send_response(200); self.send_header("Content-Type", "text/plain")
+        self.end_headers(); self.wfile.write(body.encode())
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length", 0)); body = self.rfile.read(n).decode()
+        if self.path == "/api/enroll": return self._t("agent_token=tok-1\nendpoint_id=ep_1\n")
+        if self.path.startswith("/cb/"): Stub.callbacks.append(body); return self._t("ok")
+        if self.path.endswith("/state"): return self._t("ok")
+        return self._t("ok")
+    def do_GET(self):
+        if self.path == "/api/agent/deployments":
+            base = f"http://127.0.0.1:{self.server.server_port}"
+            rec = "\t".join(["dep_1", Stub.bait_path, "sekret", f"{base}/content/dep_1", f"{base}/cb/dep_1"])
+            return self._t(rec + "\n")
+        if self.path.startswith("/content/"): return self._t(BAIT_BODY)
+        return self._t("")
+
+
+@pytest.fixture
+def server():
+    httpd = http.server.HTTPServer(("127.0.0.1", 0), Stub)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    Stub.callbacks = []
+    yield httpd
+    httpd.shutdown()
+
+
+def _spawn(server, tmp_path, *extra):
+    port = server.server_port
+    state = tmp_path / "agent.json"
+    return subprocess.Popen(
+        ["sh", str(AGENT), "run", "--server", f"http://127.0.0.1:{port}",
+         "--enroll-token", "e", "--tripwire", "tw_1", "--state-file", str(state),
+         "--sensor", "atime", "--poll", "1", "--heartbeat", "0", "--sync-interval", "0", *extra],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+
+def _wait(cond, t=15.0):
+    end = time.time() + t
+    while time.time() < end:
+        if cond(): return True
+        time.sleep(0.05)
+    return False
+
+
+def _suspect_lines():
+    return [c for c in Stub.callbacks if "suspects=" in c]
+
+
+def test_atime_alert_carries_a_suspect_shortlist_with_the_reader(server, tmp_path):
+    bait = tmp_path / "credentials"; Stub.bait_path = str(bait)
+    agent = _spawn(server, tmp_path)
+    # A recently-spawned, still-alive process the churn ledger should record.
+    reader = subprocess.Popen(["sleep", "30"])
+    try:
+        assert _wait(lambda: bait.exists() and os.stat(bait).st_atime < ARMED_MAX), "bait not planted+armed"
+        time.sleep(2.0)  # let the churn ledger tick and record `reader`
+        os.utime(bait, (time.time(), os.stat(bait).st_mtime))  # simulate a read -> trip
+        assert _wait(lambda: _suspect_lines()), "alert carried no suspects= shortlist"
+        # the shortlist must CAPTURE the recently-spawned reader (by pid)
+        assert _wait(lambda: any(str(reader.pid) in c for c in _suspect_lines())), \
+            "suspect shortlist did not capture the recently-spawned reader pid"
+    finally:
+        reader.terminate(); reader.wait(timeout=5)
+        agent.terminate(); agent.wait(timeout=5)


### PR DESCRIPTION
Stacked on #160 (atime sensor). Adds the **best-effort attribution layer** for atime trips from the validated design (#100/#124).

## Why
The atime sensor (#160) is detection-only — it satisfies the "normal file" requirement but gives no pid. This attaches a best-effort **suspect shortlist** so an analyst isn't blind on atime-only trips (the FIFO companion still gives a *deterministic* pid for raw-readers).

## What
- **Churn-ledger sidecar** (atime mode only): one `awk`/`ps` snapshot per second, merging first-seen epoch + command per live pid so short-lived processes are retained. Persists across watcher reconciles; dies on exit (`stop_ledger` in the shutdown traps).
- **`suspects_at(epoch)`**: processes first seen within `(POLL+10)s` before the trip.
- **`suspects=` callback field**: `_fire` gains an optional 7th arg → a `suspects=comm:pid,...` body line, **HMAC-covered and omitted when empty**, so non-atime callback bodies are byte-identical. The server signs the exact bytes and ignores unknown keys (verified), so this is forward-compatible.

## Honest by design
It's a **shortlist that captures the reader** (validated: 100% capture, ~9 candidates under concurrent churn) — **not** a fabricated single pid. A tripwire must never claim the wrong process tripped it. Limitation: a process living shorter than the 1s ledger tick can be missed (real worms live seconds); a *pre-existing* long-lived reader emits no new-process signal.

## Tests
- New `tests/test_agent_churn.py`: an atime trip carries a `suspects=` shortlist that captures a known recently-spawned reader (by pid). Deterministic (read simulated via `os.utime`).
- **Full suite: 261 passed, 1 skipped**; `shellcheck -S error` clean.

## Follow-ups (remaining #124 items)
- Server: persist + expose `suspects` (Alert column + migration + API + UI).
- Rank the shortlist by stealer-shape heuristics; bait-constellation intersection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)