### PR TITLE
docs: add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+## [0.1.0]
+
+Initial release: control-plane server, endpoint agent, dashboard UI, and the plugin system.
+
+### Added
+
+- **Server**: FastAPI control plane with SQLite/Postgres/MySQL support via SQLAlchemy + Alembic,
+  and signed tripwire-trigger callbacks with replay protection.
+- **Agent**: standalone Bash endpoint agent (`agent/thumper_agent.sh`, curl + openssl only, no
+  Python dependency) that plants honeytoken files and reports reads back to the server.
+- **UI**: React/Vite dashboard for creating tripwires, managing the enrolled endpoint fleet, and
+  viewing the live alert feed.
+- **Honeytoken types**: five built-in types — `aws`, `github`, `gcp`, `azure`, `ssh`. Each
+  generated with a realistic-but-non-functional credential shape.
+- **Alert plugins**: generic webhook, Splunk (HEC), Loki.
+- **Deploy plugins**: SSH (direct) and MDM (Jamf Pro).
+- **Deployment**: single Docker image (`docker compose up --build`) and a Helm chart for
+  Kubernetes (`deploy/helm/thumper`).
+
+[Unreleased]: https://github.com/jestasecurity/thumper/compare/v0.0.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
-## [0.1.0]
+## [0.1.0] - unreleased
 
 Initial release: control-plane server, endpoint agent, dashboard UI, and the plugin system.
 
@@ -32,3 +32,4 @@ Initial release: control-plane server, endpoint agent, dashboard UI, and the plu
   Kubernetes (`deploy/helm/thumper`).
 
 [Unreleased]: https://github.com/jestasecurity/thumper/compare/v0.0.0...HEAD
+[0.1.0]: https://github.com/jestasecurity/thumper/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@
 3. For UI work: `cd ui && npm install && npm run dev`.
 4. For plugins, see [docs/plugins.md](docs/plugins.md).
 5. For honeytoken types, see [docs/tokens.md](docs/tokens.md).
+6. If your change is user-facing, add a one-line entry under `## [Unreleased]` in [CHANGELOG.md](CHANGELOG.md).
 
 Report security vulnerabilities privately - see [SECURITY.md](SECURITY.md).
 


### PR DESCRIPTION
Adds `CHANGELOG.md` at the repo root following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.

- `CHANGELOG.md` with an `[Unreleased]` section (Added/Changed/Fixed headings) and a `0.1.0` entry summarizing the server, agent, UI, and plugin system. No release date — `0.1.0` hasn't been tagged yet, only `v0.0.0` has a published release.
- One-line note added to `CONTRIBUTING.md` asking contributors to log user-facing changes under `[Unreleased]`.

Closes #169