### PR TITLE
Reject control chars in bait paths — close unauth root-RCE vector (#103)

### DIFF
--- a/server/thumper/api/routes.py
+++ b/server/thumper/api/routes.py
@@ -74,6 +74,12 @@ def _validate_bait_path(path: str) -> str:
     p = (path or "").strip()
     if not p:
         raise HTTPException(400, "path is required")
+    # Reject control chars (tab/newline/CR/NUL/…): the path is emitted into the
+    # tab- and newline-framed /agent/deployments protocol, so an embedded
+    # delimiter would forge extra fields/records whose attacker-chosen id is
+    # eval'd by the root agent - an unauthenticated root-RCE primitive (#103).
+    if any(ord(c) < 0x20 or ord(c) == 0x7f for c in p):
+        raise HTTPException(400, "path must not contain control characters")
     if ".." in p.split("/"):
         raise HTTPException(400, "path must not contain '..'")
     # Accept only `~/` (current user's home), NOT `~user/`: the agent's expand_path

--- a/tests/test_tripwire_path_validation.py
+++ b/tests/test_tripwire_path_validation.py
@@ -44,3 +44,18 @@ def test_accepts_absolute_and_home_paths(client, ok):
     resp = _create(client, ok)
     assert resp.status_code == 200
     assert resp.json()["path"] == ok
+
+
+# A tab or newline in the path is injected unescaped into the tab-/newline-framed
+# /agent/deployments protocol, forging extra fields/records whose attacker-chosen
+# id is later eval'd by the root agent → unauth root RCE (#103). Reject any
+# control character at creation, the source of the path.
+@pytest.mark.parametrize("bad", [
+    "/tmp/x\ndp_evil}; reboot; :",   # newline → injects a whole TSV record
+    "/tmp/x\tsecret\tcb",            # tab → shifts/forges fields
+    "/tmp/x\rfoo",                   # carriage return
+    "~/.aws/cred\nx",                # newline in a home-rooted path
+    "/tmp/\x00null",                 # NUL / other control char
+])
+def test_rejects_control_chars_in_path(client, bad):
+    assert _create(client, bad).status_code == 400


### PR DESCRIPTION
Closes #103.

## The vulnerability
A bait `path` is emitted **unescaped** into the tab-/newline-framed `/agent/deployments` protocol (`"\t".join([id, path, secret, …])`, records newline-separated). `_validate_bait_path` only `.strip()`-ed the ends, so an embedded `\t`/`\n` survived:
- a **newline** injects a whole forged TSV record whose first field (the deployment **id**) is attacker-controlled;
- that id flows into `eval "…$vid…"` in the root agent's `verify_planted` → **command execution as root**.

Because the create/assign API is currently unauthenticated (#20), this is an **anonymous → root-RCE** path against managed endpoints.

## The fix
Reject any control character (`ord < 0x20` or `0x7f`) in `_validate_bait_path` — at the path's *source* (tripwire creation) — which breaks the injection chain (a path can no longer carry a TSV delimiter).

## Tests (TDD)
Added `test_rejects_control_chars_in_path` (tab, newline, CR, NUL, control-char in a home path) — written first, watched fail, then fixed. Full suite: **255 passed, 1 skipped**.

## Follow-up (separate PR)
Defense-in-depth: have the agent validate each deployment id matches `^dp_[0-9a-f]+$` before any `eval`. Deferred to avoid conflicting with the in-flight sensor refactor (#100/#123).

🤖 Generated with [Claude Code](https://claude.com/claude-code)