### PR TITLE
Gate the management API behind an admin token (#20)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,10 @@ THUMPER_ENROLL_TOKEN=dev-enroll-token
 # Generate a strong random value for production.
 THUMPER_INSTALL_TOKEN=dev-install-token
 
+# Admin token - REQUIRED. Gates the whole management/UI API. Unset = the
+# management API is disabled (503, fail-closed). Generate a strong random value.
+THUMPER_ADMIN_TOKEN=dev-admin-token
+
 # Path to the built UI (ui/dist). Used in Docker / monolith mode.
 # THUMPER_UI_DIST=ui/dist
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,6 +87,7 @@ All options overridable via environment:
 | `THUMPER_ALLOW_INSECURE_BASE_URL` | _(unset)_ | Opt-in to start with a plaintext non-loopback `BASE_URL` (otherwise the server refuses) |
 | `THUMPER_ENROLL_TOKEN` | `dev-enroll-token` | Shared token for agent enrollment |
 | `THUMPER_INSTALL_TOKEN` | `dev-install-token` | Gates `/install.sh` |
+| `THUMPER_ADMIN_TOKEN` | _(unset)_ | **Required** — gates the whole management/UI API; unset = management API disabled (503, fail-closed) |
 | `THUMPER_UI_DIST` | `./ui/dist` | Built SPA location |
 | `THUMPER_AGENT_PATH` | `./agent/thumper_agent.sh` | Agent script to serve |
 | `THUMPER_PLUGINS_DIR` | `./plugins` | Plugin discovery root |
@@ -105,3 +106,12 @@ network MITM can serve a malicious agent and get root on endpoints. The server
 unless `THUMPER_ALLOW_INSECURE_BASE_URL=1` is set to opt in (which downgrades it
 to a startup warning, for a deliberately-isolated network). `http://localhost` is
 fine for development and is never flagged.
+
+**Management API auth.** The whole management/UI API (everything under `/api`
+except the agent-facing `/enroll`, `/install.sh`, `/agent/*`, `/trigger`) is
+gated by a shared admin token. Set `THUMPER_ADMIN_TOKEN` to a random secret;
+clients (the dashboard) send it as `Authorization: Bearer <token>`. This is
+**fail-closed**: with no token set, the management API returns `503` rather than
+serving open — a missing token disables the console instead of exposing it.
+Agent-facing routes keep their own per-purpose tokens (enroll/install/agent/HMAC)
+and are unaffected.

--- a/server/thumper/api/__init__.py
+++ b/server/thumper/api/__init__.py
@@ -1,3 +1,3 @@
-from .routes import router
+from .routes import agent_router, router
 
-__all__ = ["router"]
+__all__ = ["agent_router", "router"]

--- a/server/thumper/api/routes.py
+++ b/server/thumper/api/routes.py
@@ -17,7 +17,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException, 
 from fastapi.responses import PlainTextResponse
 from sqlalchemy.orm import Session
 
-from .. import store
+from .. import config, store
 from ..config import AGENT_PATH, BASE_URL, DASHBOARD_REFRESH, DB_URL, ENROLL_TOKEN, INSTALL_TOKEN
 from ..db import get_db, get_engine
 from ..models import (
@@ -52,7 +52,6 @@ from ..services.signing import verify
 from ..services.ssrf import SsrfError, assert_config_urls_allowed
 from ..tokens import TOKEN_TYPES
 
-router = APIRouter(prefix="/api")
 log = logging.getLogger("thumper.api")
 
 _STALE_WINDOW = timedelta(minutes=15)
@@ -64,6 +63,29 @@ def _token_eq(provided: str, expected: str) -> bool:
     """Constant-time token comparison (avoids a timing side-channel on the shared
     enroll/install tokens)."""
     return hmac.compare_digest(provided, expected)
+
+
+def require_admin(authorization: str = Header(default="")):
+    """Gate the management/UI API on the shared admin token (#20). Fail closed:
+    when THUMPER_ADMIN_TOKEN is unset the management API is DISABLED (503), never
+    served open. Otherwise require `Authorization: Bearer <token>` (constant-time).
+    Agent-facing routes live on `agent_router` and are NOT subject to this."""
+    expected = config.ADMIN_TOKEN
+    if not expected:
+        raise HTTPException(503, "admin API disabled: set THUMPER_ADMIN_TOKEN")
+    provided = authorization[7:] if authorization.startswith("Bearer ") else ""
+    if not _token_eq(provided, expected):
+        raise HTTPException(401, "invalid or missing admin token")
+
+
+# Two routers, both under /api. `router` is the management/UI API and is
+# secure-by-default: every route on it requires the admin token, so a newly
+# added management endpoint is protected automatically. `agent_router` carries
+# the agent-facing endpoints, which authenticate with their own per-purpose
+# tokens (enroll/install/agent/HMAC) and must stay reachable without the admin
+# token - a route is public ONLY by explicitly opting onto agent_router.
+router = APIRouter(prefix="/api", dependencies=[Depends(require_admin)])
+agent_router = APIRouter(prefix="/api")
 
 
 def _validate_bait_path(path: str) -> str:
@@ -510,7 +532,7 @@ def get_settings():
 
 
 # ── agent bootstrap: serve the agent + a self-installing script ──────────────
-@router.get("/agent/thumper_agent.sh", response_class=PlainTextResponse)
+@agent_router.get("/agent/thumper_agent.sh", response_class=PlainTextResponse)
 def serve_agent():
     try:
         return PlainTextResponse(AGENT_PATH.read_text(), media_type="text/x-shellscript")
@@ -518,7 +540,7 @@ def serve_agent():
         raise HTTPException(500, "agent script unavailable on the server")
 
 
-@router.get("/install.sh", response_class=PlainTextResponse)
+@agent_router.get("/install.sh", response_class=PlainTextResponse)
 def install_script(tripwire: list[str] = Query(default=[]), token: str = Query(default="")):
     """A self-bootstrapping installer. The tripwire's deploy command pipes this
     into `sudo sh`: it downloads the Bash agent and starts it watching as root
@@ -577,7 +599,7 @@ fi
 # registering - so a refused install leaves no endpoint in the dashboard. Returns
 # the paths one-per-line and creates nothing; gated by the enroll token like
 # /enroll. (The agent still gets its UNIQUE content/secret only after enroll.)
-@router.post("/agent/tripwire-paths", response_class=PlainTextResponse)
+@agent_router.post("/agent/tripwire-paths", response_class=PlainTextResponse)
 async def agent_tripwire_paths(request: Request, db: Session = Depends(get_db)):
     form = parse_qs((await request.body()).decode("utf-8", "replace"), keep_blank_values=True)
 
@@ -598,7 +620,7 @@ async def agent_tripwire_paths(request: Request, db: Session = Depends(get_db)):
 # ── agent: enroll ────────────────────────────────────────────────────────────
 # Agent endpoints speak plain text (key=value / TSV) so the Bash agent needs no
 # JSON parser. enroll accepts a form-encoded body (curl --data-urlencode).
-@router.post("/enroll", response_class=PlainTextResponse)
+@agent_router.post("/enroll", response_class=PlainTextResponse)
 async def enroll(request: Request, db: Session = Depends(get_db)):
     form = parse_qs((await request.body()).decode("utf-8", "replace"), keep_blank_values=True)
 
@@ -630,7 +652,7 @@ def _authed_endpoint(db, authorization: str):
 
 
 # ── agent: heartbeat (liveness only) ─────────────────────────────────────────
-@router.post("/agent/heartbeat", response_class=PlainTextResponse)
+@agent_router.post("/agent/heartbeat", response_class=PlainTextResponse)
 def agent_heartbeat(authorization: str = Header(default=""),
                     db: Session = Depends(get_db)):
     endpoint = _authed_endpoint(db, authorization)
@@ -643,7 +665,7 @@ def agent_heartbeat(authorization: str = Header(default=""),
     return PlainTextResponse("ok\n")
 
 
-@router.post("/agent/decommissioned", response_class=PlainTextResponse)
+@agent_router.post("/agent/decommissioned", response_class=PlainTextResponse)
 def agent_decommissioned(authorization: str = Header(default=""),
                          db: Session = Depends(get_db)):
     """The agent confirms it has self-destructed; drop its record (and its
@@ -663,7 +685,7 @@ def agent_decommissioned(authorization: str = Header(default=""),
 # ── agent: pull deployments ──────────────────────────────────────────────────
 # One tab-separated record per deployment. Bait `content` is NOT inlined (it can
 # be multi-line) - the agent fetches it raw from the per-deployment content URL.
-@router.get("/agent/deployments", response_class=PlainTextResponse)
+@agent_router.get("/agent/deployments", response_class=PlainTextResponse)
 def agent_deployments(authorization: str = Header(default=""),
                       db: Session = Depends(get_db)):
     endpoint = _authed_endpoint(db, authorization)
@@ -680,7 +702,7 @@ def agent_deployments(authorization: str = Header(default=""),
 
 
 # ── agent: raw bait content for one deployment ───────────────────────────────
-@router.get("/agent/deployments/{deployment_id}/content", response_class=PlainTextResponse)
+@agent_router.get("/agent/deployments/{deployment_id}/content", response_class=PlainTextResponse)
 def agent_deployment_content(deployment_id: str, authorization: str = Header(default=""),
                              db: Session = Depends(get_db)):
     endpoint = _authed_endpoint(db, authorization)
@@ -691,7 +713,7 @@ def agent_deployment_content(deployment_id: str, authorization: str = Header(def
 
 
 # ── agent: report a deployment's plant outcome ───────────────────────────────
-@router.post("/agent/deployments/{deployment_id}/state", response_class=PlainTextResponse)
+@agent_router.post("/agent/deployments/{deployment_id}/state", response_class=PlainTextResponse)
 async def agent_deployment_state(deployment_id: str, request: Request,
                                  authorization: str = Header(default=""),
                                  db: Session = Depends(get_db)):
@@ -718,7 +740,7 @@ def _parse_kv(raw: bytes) -> dict:
     return data
 
 
-@router.post("/trigger")
+@agent_router.post("/trigger")
 async def trigger(request: Request, background: BackgroundTasks,
                   db: Session = Depends(get_db)):
     body = await request.body()

--- a/server/thumper/config.py
+++ b/server/thumper/config.py
@@ -87,6 +87,12 @@ ENROLL_TOKEN = os.environ.get("THUMPER_ENROLL_TOKEN", _DEFAULT_ENROLL_TOKEN)
 _DEFAULT_INSTALL_TOKEN = "dev-install-token"
 INSTALL_TOKEN = os.environ.get("THUMPER_INSTALL_TOKEN", _DEFAULT_INSTALL_TOKEN)
 
+# Admin token gating the whole management/UI API (#20). NO default on purpose:
+# fail closed. When unset, the management API is disabled (503) rather than
+# served open - a dev default would just recreate the no-auth hole. Set
+# THUMPER_ADMIN_TOKEN to a random secret to enable the dashboard/API.
+ADMIN_TOKEN = os.environ.get("THUMPER_ADMIN_TOKEN", "")
+
 
 def insecure_default_tokens(enroll: str | None = None, install: str | None = None) -> list[str]:
     """Names of the shared tokens still set to their built-in dev defaults.

--- a/server/thumper/main.py
+++ b/server/thumper/main.py
@@ -12,7 +12,8 @@ from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
-from .api import router
+from . import config
+from .api import agent_router, router
 from .config import (
     UI_DIST, base_url_fail_closed, insecure_base_url, insecure_default_tokens)
 from .db import init_db
@@ -36,6 +37,11 @@ async def lifespan(app: FastAPI):
         log.warning(
             "SECURITY: integration secrets are stored UNENCRYPTED at rest - set "
             "THUMPER_SECRET_KEY to encrypt them (#24).")
+    if not config.ADMIN_TOKEN:
+        log.warning(
+            "THUMPER_ADMIN_TOKEN is not set - the management/UI API is DISABLED "
+            "(503) until you set it (fail-closed, #20). The dashboard can't load "
+            "without it; set it to a random secret.")
     # MITM on a plaintext non-loopback BASE_URL is agent/bait fetch + callbacks in
     # cleartext -> a malicious agent served to the endpoint -> root RCE. Severe
     # enough to fail closed: refuse to start unless the operator opts in.
@@ -67,7 +73,8 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-app.include_router(router)
+app.include_router(router)        # management/UI API — admin-token gated
+app.include_router(agent_router)  # agent-facing API — own per-purpose tokens
 
 
 @app.get("/healthz")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,18 @@ def _allow_local_integration_hosts(monkeypatch):
     ])
 
 
+@pytest.fixture(autouse=True)
+def _bypass_admin_auth():
+    """Admin-token auth (#20) gates the whole management API. Existing tests
+    exercise other behavior, so bypass the gate by default via a dependency
+    override. The dedicated test_admin_auth.py removes this override to test the
+    real gate."""
+    from thumper.api.routes import require_admin
+    app.dependency_overrides[require_admin] = lambda: None
+    yield
+    app.dependency_overrides.pop(require_admin, None)
+
+
 @pytest.fixture
 def client_db():
     """A TestClient wired to a fresh in-memory SQLite session, yielded together

--- a/tests/test_admin_auth.py
+++ b/tests/test_admin_auth.py
@@ -1,0 +1,64 @@
+"""The management/UI API is gated by the shared admin token (#20), fail-closed
+when THUMPER_ADMIN_TOKEN is unset. Agent-facing routes keep their own tokens and
+are NOT subject to the admin gate.
+
+These tests remove the conftest `_bypass_admin_auth` override so the real
+`require_admin` dependency runs.
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+from thumper import config
+from thumper.api.routes import require_admin
+from thumper.db import Base, get_db
+from thumper.main import app
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+TOKEN = "s3cr3t-admin-token"
+
+
+@pytest.fixture
+def client(monkeypatch):
+    # Real auth: drop the global bypass override for these tests.
+    app.dependency_overrides.pop(require_admin, None)
+    monkeypatch.setattr(config, "ADMIN_TOKEN", TOKEN)
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False},
+                           poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    db = sessionmaker(bind=engine)()
+    app.dependency_overrides[get_db] = lambda: db
+    yield TestClient(app)
+    del app.dependency_overrides[get_db]
+    db.close()
+
+
+def test_management_route_requires_token(client):
+    assert client.get("/api/stats").status_code == 401
+
+
+def test_management_route_rejects_wrong_token(client):
+    r = client.get("/api/stats", headers={"Authorization": "Bearer nope"})
+    assert r.status_code == 401
+
+
+def test_management_route_accepts_correct_token(client):
+    r = client.get("/api/stats", headers={"Authorization": f"Bearer {TOKEN}"})
+    assert r.status_code == 200
+
+
+def test_fail_closed_when_token_unset(client, monkeypatch):
+    # No admin token configured -> management API disabled (503), never open.
+    monkeypatch.setattr(config, "ADMIN_TOKEN", "")
+    assert client.get("/api/stats").status_code == 503
+    # even a "Bearer " request can't reach it
+    assert client.get("/api/stats", headers={"Authorization": "Bearer x"}).status_code == 503
+
+
+def test_agent_route_not_gated_by_admin_token(client):
+    # The agent fetches its own script with no admin token; must stay reachable.
+    r = client.get("/api/agent/thumper_agent.sh")
+    assert r.status_code == 200
+    # and the management gate's 401/503 must NOT apply here
+    assert r.status_code not in (401, 503)

--- a/ui/src/AdminGate.tsx
+++ b/ui/src/AdminGate.tsx
@@ -1,0 +1,42 @@
+import { useState, type ReactNode } from "react";
+import { getAdminToken, setAdminToken } from "./api/auth";
+
+// Token-entry gate for the management console (#20). The server gates every
+// /api management route on THUMPER_ADMIN_TOKEN; the SPA stores the operator's
+// token and sends it as a bearer header (see api/http.ts). No token → this
+// screen; a wrong token gets a 401 which clears it and lands back here.
+export default function AdminGate({ children }: { children: ReactNode }) {
+  const [authed, setAuthed] = useState(() => getAdminToken() !== "");
+  const [value, setValue] = useState("");
+
+  if (authed) return <>{children}</>;
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const t = value.trim();
+    if (!t) return;
+    setAdminToken(t);
+    setAuthed(true);
+  };
+
+  return (
+    <div style={{ minHeight: "100vh", display: "grid", placeItems: "center", padding: "2rem" }}>
+      <form onSubmit={submit} style={{ display: "flex", flexDirection: "column", gap: ".75rem", width: "min(360px, 100%)" }}>
+        <h1 style={{ margin: 0 }}>Thumper</h1>
+        <p style={{ margin: 0, opacity: 0.7 }}>Enter the admin token to access the console.</p>
+        <input
+          type="password"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="Admin token"
+          aria-label="Admin token"
+          autoFocus
+          style={{ padding: ".6rem .75rem", fontSize: "1rem" }}
+        />
+        <button type="submit" disabled={!value.trim()} style={{ padding: ".6rem .75rem" }}>
+          Continue
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -18,6 +18,7 @@ import EndpointDetail from "./pages/EndpointDetail.tsx";
 import Integrations from "./pages/Integrations.tsx";
 import Settings from "./pages/Settings.tsx";
 import NotFound from "./pages/NotFound.tsx";
+import AdminGate from "./AdminGate.tsx";
 
 // How long to show the animated logo after a sidebar toggle, in ms. Tracks the
 // length of the one-thump GIF (ui/public/thumper_gif.gif, ~2.46s) plus a small
@@ -109,6 +110,7 @@ function Sidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () => 
 export default function App() {
   const [collapsed, setCollapsed] = useState(false);
   return (
+    <AdminGate>
     <div className={`app ${collapsed ? "collapsed" : ""}`}>
       <Sidebar collapsed={collapsed} onToggle={() => setCollapsed((c) => !c)} />
       <main className="main">
@@ -125,5 +127,6 @@ export default function App() {
         </Routes>
       </main>
     </div>
+    </AdminGate>
   );
 }

--- a/ui/src/api/auth.ts
+++ b/ui/src/api/auth.ts
@@ -1,0 +1,8 @@
+// Admin token for the management API (#20). Stored in localStorage and sent as
+// `Authorization: Bearer <token>` on every /api request (see http.ts). The
+// AdminGate prompts for it; a 401 clears it and re-prompts.
+const KEY = "thumper.adminToken";
+
+export const getAdminToken = (): string => localStorage.getItem(KEY) ?? "";
+export const setAdminToken = (t: string): void => localStorage.setItem(KEY, t.trim());
+export const clearAdminToken = (): void => localStorage.removeItem(KEY);

--- a/ui/src/api/http.ts
+++ b/ui/src/api/http.ts
@@ -18,6 +18,8 @@ import type {
   TripwireDetail,
 } from "./types";
 
+import { clearAdminToken, getAdminToken } from "./auth";
+
 const BASE = "/api";
 
 // Carries the HTTP status so callers can distinguish a 404 (show a not-found
@@ -33,10 +35,21 @@ export class ApiError extends Error {
 }
 
 async function req<T>(path: string, init?: RequestInit): Promise<T> {
+  const { headers: initHeaders, ...rest } = init ?? {};
+  const token = getAdminToken();
   const res = await fetch(`${BASE}${path}`, {
-    headers: { "content-type": "application/json" },
-    ...init,
+    headers: {
+      "content-type": "application/json",
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+      ...initHeaders,
+    },
+    ...rest,
   });
+  // 401 = missing/expired admin token → drop it and re-prompt via AdminGate.
+  if (res.status === 401) {
+    clearAdminToken();
+    window.location.reload();
+  }
   if (!res.ok) {
     let detail = res.statusText;
     try {


### PR DESCRIPTION
Closes #20.

The management/UI API had no auth. Now:
- **`THUMPER_ADMIN_TOKEN`** gates every `/api` management route via a `require_admin` dependency on a secure-by-default router. Agent routes (`/enroll`, `/install.sh`, `/agent/*`, `/trigger`) moved to an unguarded `agent_router` and keep their own tokens.
- **Fail-closed:** token unset → `503` (never served open). Startup warning when unset.
- **UI:** sends `Authorization: Bearer <token>`; token-entry gate; a `401` clears it and re-prompts.

Tests: `test_admin_auth.py` (401/200/503/agent-open); full suite **255 passed**. UI builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)