### PR TITLE
Restrict CORS to an allow-list (#23)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,6 @@ THUMPER_DASHBOARD_REFRESH=60
 # Generate a strong random value for production.
 # THUMPER_SECRET_KEY=
 
+
+# CORS allow-list (comma-separated browser origins). Default: the Vite dev origin.
+# THUMPER_ALLOWED_ORIGINS=https://thumper.example.com

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -93,6 +93,7 @@ All options overridable via environment:
 | `THUMPER_DASHBOARD_REFRESH` | `60` | Auto-refresh interval (seconds, 0 = off) |
 | `THUMPER_ALLOWED_HOOK_CIDRS` | _(unset)_ | Comma-separated CIDRs/IPs exempted from the SSRF guard for outbound integration targets |
 | `THUMPER_SECRET_KEY` | _(unset)_ | Encrypts integration credentials at rest (Fernet); unset stores them in plaintext |
+| `THUMPER_ALLOWED_ORIGINS` | `http://localhost:5173` | Comma-separated browser origins allowed by CORS (instead of wildcard) |
 
 ## Security & trust model
 

--- a/server/thumper/config.py
+++ b/server/thumper/config.py
@@ -41,6 +41,12 @@ def _parse_cidrs(raw: str):
 # SSRF guard (#74) doesn't block a legitimately-internal Splunk/Loki/webhook.
 ALLOWED_HOOK_CIDRS = _parse_cidrs(os.environ.get("THUMPER_ALLOWED_HOOK_CIDRS", ""))
 
+# Browser origins allowed to call the API (CORS, #23). Default = the Vite dev
+# origin; in monolith mode the UI is same-origin so CORS isn't needed. Set a
+# comma-separated THUMPER_ALLOWED_ORIGINS in production instead of wildcard.
+ALLOWED_ORIGINS = [o.strip() for o in os.environ.get(
+    "THUMPER_ALLOWED_ORIGINS", "http://localhost:5173").split(",") if o.strip()]
+
 # Directory holding the installable plugins (each: plugin.py + manifest.yaml).
 # This is the repo-root `plugins/` tree, NOT server/thumper/plugins/ (which is
 # the plugin *framework* - base classes + loader).

--- a/server/thumper/main.py
+++ b/server/thumper/main.py
@@ -14,7 +14,8 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from .api import router
 from .config import (
-    UI_DIST, base_url_fail_closed, insecure_base_url, insecure_default_tokens)
+    ALLOWED_ORIGINS, UI_DIST, base_url_fail_closed, insecure_base_url,
+    insecure_default_tokens)
 from .db import init_db
 from .services.secrets_crypto import encryption_enabled
 
@@ -58,13 +59,13 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Thumper", version="0.1.0", lifespan=lifespan)
 
-# In dev the UI runs on :5173 and proxies /api → :8000, so it's same-origin to
-# the browser; CORS is permissive here to keep direct API calls / tools simple.
+# CORS restricted to an allow-list (#23) - the Vite dev origin by default,
+# THUMPER_ALLOWED_ORIGINS in production. In monolith mode the UI is same-origin.
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_origins=ALLOWED_ORIGINS,
+    allow_methods=["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
+    allow_headers=["authorization", "content-type"],
 )
 
 app.include_router(router)

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,0 +1,19 @@
+"""CORS is restricted to an allow-list, not wide open (#23). Default allows the
+Vite dev origin; operators override via THUMPER_ALLOWED_ORIGINS."""
+from fastapi.testclient import TestClient
+
+from thumper.main import app
+
+client = TestClient(app)
+
+
+def test_disallowed_origin_is_not_allowed():
+    r = client.get("/healthz", headers={"Origin": "http://evil.example"})
+    acao = r.headers.get("access-control-allow-origin")
+    assert acao != "*"                     # not wide open
+    assert acao != "http://evil.example"   # arbitrary origin not echoed
+
+
+def test_allowed_origin_is_echoed():
+    r = client.get("/healthz", headers={"Origin": "http://localhost:5173"})
+    assert r.headers.get("access-control-allow-origin") == "http://localhost:5173"


### PR DESCRIPTION
Closes #23.

`allow_origins=["*"]` → `THUMPER_ALLOWED_ORIGINS` (default `http://localhost:5173`); methods/headers scoped to what the API uses. Monolith mode is same-origin so unaffected.

Test: `test_cors.py` (wildcard/arbitrary origin rejected, allowed origin echoed). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)