### PR TITLE
Strips whitespace from name on tripwire creation and associated tests

### DIFF
--- a/server/thumper/api/routes.py
+++ b/server/thumper/api/routes.py
@@ -206,14 +206,17 @@ def list_tripwires(db: Session = Depends(get_db)):
 @router.post("/tripwires", response_model=TripwireOut)
 def create_tripwire(body: CreateTripwireIn, db: Session = Depends(get_db)):
     path = _validate_bait_path(body.path)
+    name = body.name.strip()
     if body.source == "custom" and not body.custom_content:
         raise HTTPException(400, "custom source requires custom_content")
+    if not name:
+        raise HTTPException(400, "name is required")
     token = body.token or render_content(
         token_type=body.token_type, source=body.source,
         custom_content=body.custom_content,
     )
     tripwire = store.create_tripwire(
-        db, name=body.name, token_type=body.token_type, path=path,
+        db, name=name, token_type=body.token_type, path=path,
         source=body.source, custom_content=body.custom_content, token=token,
     )
     return _tripwire_out(db, tripwire)

--- a/tests/test_tripwire_crud.py
+++ b/tests/test_tripwire_crud.py
@@ -20,6 +20,35 @@ def _enroll(tc, machine_id, tripwire_ids):
     assert r.status_code == 200
 
 
+def test_create_tripwire_strips_name(client_db):
+    tc, db = client_db
+
+    resp = tc.post("/api/tripwires", json={
+        "name": "  foo  ",
+        "token_type": "aws",
+        "path": "~/.aws/credentials",
+        "source": "template",
+    })
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["name"] == "foo"
+    assert store.get_tripwire(db, body["id"]).name == "foo"
+
+
+def test_create_empty_name_is_400(client_db):
+    tc, db = client_db
+
+    resp = tc.post("/api/tripwires", json={
+            "name": "   ",
+            "token_type": "aws",
+            "path": "~/.aws/credentials", 
+            "source": "template",
+    })
+
+    assert resp.status_code == 400
+
+
 def test_rename_tripwire(client_db):
     tc, db = client_db
     a = _mk(db, "old-name")


### PR DESCRIPTION
Closes #116
- One-line fix: `.strip()` on create, matching rename behavior
- Created 2 tests: `test_create_tripwire_strips_name` and `test_create_empty_name_is_400` inside `tests/test_tripwire_crud.py`