### PR TITLE
feat: expose server version

### DIFF
--- a/server/thumper/api/routes.py
+++ b/server/thumper/api/routes.py
@@ -17,7 +17,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException, 
 from fastapi.responses import PlainTextResponse
 from sqlalchemy.orm import Session
 
-from .. import store
+from .. import __version__, store
 from ..config import AGENT_PATH, BASE_URL, DASHBOARD_REFRESH, DB_URL, ENROLL_TOKEN, INSTALL_TOKEN
 from ..db import get_db, get_engine
 from ..models import (
@@ -486,6 +486,12 @@ def delete_integration(plugin: str, db: Session = Depends(get_db)):
         raise HTTPException(404, "unknown plugin")
     store.delete_integration(db, plugin)
     return {"status": "ok"}
+
+
+# ── version ─────────────────────────────────────────────────────────────────
+@router.get("/version")
+def get_version():
+    return {"version": __version__}
 
 
 # ── settings (read-only) ────────────────────────────────────────────────────

--- a/server/thumper/main.py
+++ b/server/thumper/main.py
@@ -12,6 +12,7 @@ from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
+from . import __version__
 from .api import router
 from .config import (
     UI_DIST, base_url_fail_closed, insecure_base_url, insecure_default_tokens)
@@ -56,7 +57,7 @@ async def lifespan(app: FastAPI):
     yield
 
 
-app = FastAPI(title="Thumper", version="0.1.0", lifespan=lifespan)
+app = FastAPI(title="Thumper", version=__version__, lifespan=lifespan)
 
 # In dev the UI runs on :5173 and proxies /api → :8000, so it's same-origin to
 # the browser; CORS is permissive here to keep direct API calls / tools simple.
@@ -72,7 +73,7 @@ app.include_router(router)
 
 @app.get("/healthz")
 def healthz():
-    return {"status": "ok"}
+    return {"status": "ok", "version": __version__}
 
 
 @app.exception_handler(StarletteHTTPException)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,16 @@
+"""GET /healthz and GET /api/version expose the package version."""
+from thumper import __version__
+
+
+def test_healthz_includes_version(client_db):
+    tc, _ = client_db
+    resp = tc.get("/healthz")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok", "version": __version__}
+
+
+def test_api_version_matches_healthz(client_db):
+    tc, _ = client_db
+    health = tc.get("/healthz").json()["version"]
+    api = tc.get("/api/version").json()["version"]
+    assert health == api == __version__

--- a/ui/src/api/http.ts
+++ b/ui/src/api/http.ts
@@ -16,6 +16,7 @@ import type {
   TokenTypeInfo,
   Tripwire,
   TripwireDetail,
+  VersionInfo,
 } from "./types";
 
 const BASE = "/api";
@@ -53,6 +54,7 @@ async function req<T>(path: string, init?: RequestInit): Promise<T> {
 export const httpApi = {
   getStats: () => req<DashboardStats>("/stats"),
   getSettings: () => req<AppSettings>("/settings"),
+  getVersion: () => req<VersionInfo>("/version"),
 
   // Tripwire definitions
   listTripwires: () => req<Tripwire[]>("/tripwires"),

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -147,6 +147,10 @@ export interface IntegrationTestResult {
   tested_at: string;
 }
 
+export interface VersionInfo {
+  version: string;
+}
+
 export interface AppSettings {
   database: { backend: string; location: string };
   thresholds: { stale_minutes: number; inactive_hours: number };

--- a/ui/src/pages/Settings.tsx
+++ b/ui/src/pages/Settings.tsx
@@ -6,10 +6,14 @@ import PageTitle from "../components/PageTitle.tsx";
 
 export default function Settings() {
   const [settings, setSettings] = useState<AppSettings | null>(null);
+  const [version, setVersion] = useState<string | null>(null);
   const PAGE_TITLE = "Settings";
 
   useEffect(() => {
-    api.getSettings().then(setSettings);
+    Promise.all([api.getSettings(), api.getVersion()]).then(([s, v]) => {
+      setSettings(s);
+      setVersion(v.version);
+    });
   }, []);
 
   if (!settings) return <div className="content">Loading...</div>;
@@ -67,6 +71,12 @@ export default function Settings() {
             </div>
           </div>
         </div>
+
+        {version && (
+          <p className="muted" style={{ marginTop: "1.5rem", marginBottom: 0 }}>
+            Server version {version}
+          </p>
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
Closes #151

## Summary

* include the server version in `/healthz`
* add a small `/api/version` endpoint for the UI
* fetch and display the running server version on the Settings page
* add backend tests to verify both version responses use the canonical `__version__`

## Details

The server version is now read from `thumper.__version__` instead of duplicating the version string.

`GET /healthz` now returns:

```json
{"status": "ok", "version": "0.1.0"}
```

The UI uses `/api/version` instead of `/healthz` so it works cleanly through the existing Vite `/api` proxy during local development.

## Testing

* `pytest tests/test_version.py -v` — passed
* `cd ui && npm run build` — passed
* `cd ui && npm test` — passed

I also ran the full backend suite with `pytest -v` on Windows. The new version tests passed, but some existing agent/symlink/signal tests failed due Windows-specific behavior, including missing `signal.SIGKILL` and symlink privilege errors. I did not modify the agent code in this PR.
