### PR TITLE
ci: add ruff linting to CI and fix existing violations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,21 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install
+        run: pip install -e ".[dev]"
+
+      - name: Lint
+        run: ruff check .
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 # only curl + openssl - it has no Python dependencies of its own.
 postgres = ["psycopg[binary]>=3.3.4"]
 mysql = ["pymysql>=1.1"]
-dev = ["pytest>=9.1.1"]
+dev = ["pytest>=9.1.1", "ruff>=0.4.0"]
 
 [tool.pytest.ini_options]
 # Tests import `thumper`, which lives under server/. Put it on the path here so
@@ -41,3 +41,6 @@ where = ["server"]
 [tool.setuptools.package-data]
 "thumper.migrations" = ["*.py", "*.mako", "*.ini"]
 "thumper.migrations.versions" = ["*.py"]
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]

--- a/server/thumper/api/routes.py
+++ b/server/thumper/api/routes.py
@@ -8,7 +8,6 @@ Two distinct contracts live here:
     no JSON parser). See docs/architecture.md.
 """
 import hmac
-import json
 import logging
 from datetime import datetime, timedelta, timezone
 from urllib.parse import parse_qs, urlparse

--- a/server/thumper/services/integrations.py
+++ b/server/thumper/services/integrations.py
@@ -2,7 +2,6 @@
 from sqlalchemy.orm import Session
 
 from .. import store
-from ..plugins.registry import get_manifest
 from .secrets_crypto import unpack_config
 
 

--- a/server/thumper/store.py
+++ b/server/thumper/store.py
@@ -1,7 +1,6 @@
 """Repository layer over SQLAlchemy ORM. All queries live here so the rest of
 the app deals in ORM model instances (attribute access: row.id, row.name, …).
 """
-import json
 import secrets
 from typing import Optional
 
@@ -13,7 +12,7 @@ from .db import (
     Alert, Deployment, DeliveryAttempt, Endpoint, Integration, Tripwire,
 )
 from .models import iso_now
-from .services.secrets_crypto import pack_config, unpack_config
+from .services.secrets_crypto import pack_config
 
 
 def _id(prefix: str) -> str:

--- a/tests/test_agent_linux_inotify.py
+++ b/tests/test_agent_linux_inotify.py
@@ -46,7 +46,8 @@ class _Stub(http.server.BaseHTTPRequestHandler):
         elif self.path.startswith("/content/"):
             self._text(BAIT_BODY)
         else:
-            self.send_response(404); self.end_headers()
+            self.send_response(404)
+            self.end_headers()
 
 
 def _write(path, body):

--- a/tests/test_agent_live_sync.py
+++ b/tests/test_agent_live_sync.py
@@ -43,7 +43,9 @@ class _StubHandler(http.server.BaseHTTPRequestHandler):
             self._text(f"agent_token={_StubHandler.valid_token}\nendpoint_id=ep_1\n")
         elif self.path == "/api/agent/heartbeat":
             if self.headers.get("Authorization") != f"Bearer {_StubHandler.valid_token}":
-                self.send_response(401); self.end_headers(); return
+                self.send_response(401)
+                self.end_headers()
+                return
             _StubHandler.heartbeats_ok += 1
             self._text("ok")
         else:
@@ -66,7 +68,9 @@ class _StubHandler(http.server.BaseHTTPRequestHandler):
         elif self.path.startswith("/content/"):
             did = self.path.split("/")[-1]
             if did in _StubHandler.fail_content:
-                self.send_response(500); self.end_headers(); return
+                self.send_response(500)
+                self.end_headers()
+                return
             self._text(BAIT_BODY)
         else:
             self.send_response(404)

--- a/tests/test_agent_singleton.py
+++ b/tests/test_agent_singleton.py
@@ -6,7 +6,6 @@ a second start while one is alive exits 0 without enrolling; a stale/foreign loc
 is reclaimed.
 """
 import http.server
-import os
 import signal
 import subprocess
 import threading

--- a/tests/test_agent_symlink_plant.py
+++ b/tests/test_agent_symlink_plant.py
@@ -43,7 +43,8 @@ class _Stub(http.server.BaseHTTPRequestHandler):
         elif self.path.startswith("/content/"):
             self._text(BAIT_BODY)
         else:
-            self.send_response(404); self.end_headers()
+            self.send_response(404)
+            self.end_headers()
 
 
 @pytest.fixture

--- a/tests/test_alert_management.py
+++ b/tests/test_alert_management.py
@@ -62,7 +62,9 @@ def test_list_alerts_invalid_status_raises(client_db):
 
 def test_resolve_all_alerts_store(client_db):
     _, db = client_db
-    _mk(db, did="dp_1"); _mk(db, did="dp_2"); _mk(db, did="dp_3")
+    _mk(db, did="dp_1")
+    _mk(db, did="dp_2")
+    _mk(db, did="dp_3")
     assert store.resolve_all_alerts(db) == 3
     assert store.resolve_all_alerts(db) == 0  # nothing left open
     assert store.list_alerts(db, status="open") == []
@@ -70,7 +72,8 @@ def test_resolve_all_alerts_store(client_db):
 
 def test_resolve_all_endpoint(client_db):
     tc, db = client_db
-    _mk(db, did="dp_1"); _mk(db, did="dp_2")
+    _mk(db, did="dp_1")
+    _mk(db, did="dp_2")
     resp = tc.post("/api/alerts/resolve-all")
     assert resp.status_code == 200
     assert resp.json() == {"resolved": 2}
@@ -79,7 +82,9 @@ def test_resolve_all_endpoint(client_db):
 
 def test_bulk_resolve_for_deployment(client_db):
     _, db = client_db
-    _mk(db, did="dp_1"); _mk(db, did="dp_1"); _mk(db, did="dp_2")
+    _mk(db, did="dp_1")
+    _mk(db, did="dp_1")
+    _mk(db, did="dp_2")
     assert store.resolve_deployment_alerts(db, "dp_1") == 2
     # a second call resolves nothing new
     assert store.resolve_deployment_alerts(db, "dp_1") == 0
@@ -88,7 +93,8 @@ def test_bulk_resolve_for_deployment(client_db):
 
 def test_active_triggers_counts_open_deployments_only(client_db):
     _, db = client_db
-    _mk(db, did="dp_1"); _mk(db, did="dp_2")
+    _mk(db, did="dp_1")
+    _mk(db, did="dp_2")
     assert store.count_distinct_alert_deployments(db) == 2
     store.resolve_deployment_alerts(db, "dp_1")
     assert store.count_distinct_alert_deployments(db) == 1
@@ -96,7 +102,8 @@ def test_active_triggers_counts_open_deployments_only(client_db):
 
 def test_list_alerts_status_filter(client_db):
     _, db = client_db
-    a = _mk(db, did="dp_1"); _mk(db, did="dp_2")
+    a = _mk(db, did="dp_1")
+    _mk(db, did="dp_2")
     store.resolve_alert(db, a.id)
     assert len(store.list_alerts(db)) == 2
     assert len(store.list_alerts(db, status="open")) == 1
@@ -129,7 +136,8 @@ def test_resolve_unknown_alert_endpoint_404(client_db):
 
 def test_bulk_resolve_endpoint(client_db):
     tc, db = client_db
-    _mk(db, did="dp_1"); _mk(db, did="dp_1")
+    _mk(db, did="dp_1")
+    _mk(db, did="dp_1")
     resp = tc.post("/api/alerts/resolve", json={"deployment_id": "dp_1"})
     assert resp.status_code == 200
     assert resp.json() == {"resolved": 2}
@@ -138,7 +146,8 @@ def test_bulk_resolve_endpoint(client_db):
 
 def test_stats_active_triggers_reflects_open(client_db):
     tc, db = client_db
-    _mk(db, did="dp_1"); _mk(db, did="dp_2")
+    _mk(db, did="dp_1")
+    _mk(db, did="dp_2")
     assert tc.get("/api/stats").json()["active_triggers"] == 2
     tc.post("/api/alerts/resolve", json={"deployment_id": "dp_1"})
     assert tc.get("/api/stats").json()["active_triggers"] == 1
@@ -148,7 +157,8 @@ def test_stats_active_triggers_reflects_open(client_db):
 
 def test_endpoint_trigger_count_is_open_only(client_db):
     _, db = client_db
-    a = _mk(db, did="dp_1", eid="ep_1"); _mk(db, did="dp_2", eid="ep_1")
+    a = _mk(db, did="dp_1", eid="ep_1")
+    _mk(db, did="dp_2", eid="ep_1")
     assert store.count_alerts_for_endpoint(db, "ep_1") == 2
     store.resolve_alert(db, a.id)
     assert store.count_alerts_for_endpoint(db, "ep_1") == 1
@@ -156,7 +166,8 @@ def test_endpoint_trigger_count_is_open_only(client_db):
 
 def test_tripwire_trigger_count_is_open_only(client_db):
     _, db = client_db
-    a = _mk(db, did="dp_1", tid="tw_1"); _mk(db, did="dp_2", tid="tw_1")
+    a = _mk(db, did="dp_1", tid="tw_1")
+    _mk(db, did="dp_2", tid="tw_1")
     assert store.count_alerts_for_tripwire(db, "tw_1") == 2
     store.resolve_alert(db, a.id)
     assert store.count_alerts_for_tripwire(db, "tw_1") == 1
@@ -164,7 +175,8 @@ def test_tripwire_trigger_count_is_open_only(client_db):
 
 def test_deployment_trigger_count_is_open_only(client_db):
     _, db = client_db
-    a = _mk(db, did="dp_1"); _mk(db, did="dp_1")
+    a = _mk(db, did="dp_1")
+    _mk(db, did="dp_1")
     assert store.count_alerts_for_deployment(db, "dp_1") == 2
     store.resolve_alert(db, a.id)
     assert store.count_alerts_for_deployment(db, "dp_1") == 1

--- a/tests/test_alerting.py
+++ b/tests/test_alerting.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from thumper import store
-from thumper.db import Base, DeliveryAttempt, Integration, get_db
+from thumper.db import Base, DeliveryAttempt, Integration
 from thumper.services import alerting
 
 

--- a/tests/test_endpoint_decommission.py
+++ b/tests/test_endpoint_decommission.py
@@ -27,7 +27,8 @@ def _raw_endpoint(db, eid, token):
     ep = Endpoint(id=eid, hostname="host-1", platform="linux", machine_id=f"m-{eid}",
                   agent_token=token, enrolled_at="2026-01-01T00:00:00Z",
                   last_seen="2026-06-17T12:00:00Z")
-    db.add(ep); db.commit()
+    db.add(ep)
+    db.commit()
     return ep
 
 

--- a/tests/test_install_command.py
+++ b/tests/test_install_command.py
@@ -2,8 +2,6 @@
 of tripwires (SP1 of #34). The single-tripwire path (build_install, used by
 TripwireDetail + the deploy plugins) must stay byte-for-byte unchanged.
 """
-import pytest
-
 from thumper import store
 
 

--- a/tests/test_webhook_test_server.py
+++ b/tests/test_webhook_test_server.py
@@ -3,8 +3,6 @@ import hashlib
 import hmac
 from pathlib import Path
 
-import pytest
-
 TOOL_FILE = Path(__file__).resolve().parents[1] / "tools" / "webhook_test_server.py"
 
 


### PR DESCRIPTION
Closes #112

Adds a `lint` job to CI that runs `ruff check .` on every push and PR. Also adds `ruff` to `[dev]` dependencies so contributors can run it locally.

Fixed all 27 existing violations to keep CI green from day one:
- 8× F401 unused imports (`json`, `os`, `pytest`, `get_manifest`, `get_db`, `unpack_config`)
- 19× E702 multiple statements on one line (semicolons in test stubs)