### PR TITLE
Validate numeric agent interval arguments

### DIFF
--- a/agent/thumper_agent.sh
+++ b/agent/thumper_agent.sh
@@ -56,6 +56,12 @@ TAB=$(printf '\t')
 
 log() { printf '[thumper %s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*"; }
 err() { printf '[thumper %s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >&2; }
+is_uint() {
+    case "$1" in
+        ''|*[!0-9]*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
 
 # ── state (key=value lines, NOT json) ────────────────────────────────────────
 state_get() {  # state_get <file> <key>
@@ -819,9 +825,9 @@ while [ $# -gt 0 ]; do
         --enroll-token) ENROLL_TOKEN=$2; shift 2 ;;
         --tripwire)     TRIPWIRES="${TRIPWIRES:+$TRIPWIRES,}$2"; shift 2 ;;
         --state-file)   STATE_FILE=$2; shift 2 ;;
-        --poll)         POLL=$2; shift 2 ;;
-        --heartbeat)    HEARTBEAT=$2; shift 2 ;;
-        --sync-interval) SYNC_INTERVAL=$2; shift 2 ;;
+        --poll)         is_uint "${2:-}" || { err "--poll must be a non-negative integer"; exit 2; }; POLL=$2; shift 2 ;;
+        --heartbeat)    is_uint "${2:-}" || { err "--heartbeat must be a non-negative integer"; exit 2; }; HEARTBEAT=$2; shift 2 ;;
+        --sync-interval) is_uint "${2:-}" || { err "--sync-interval must be a non-negative integer"; exit 2; }; SYNC_INTERVAL=$2; shift 2 ;;
         --once)         ONCE=1; shift ;;
         --simulate)     SIMULATE=1; shift ;;
         --force)        FORCE=1; shift ;;

--- a/tests/test_agent_singleton.py
+++ b/tests/test_agent_singleton.py
@@ -161,3 +161,19 @@ def test_lock_released_on_clean_exit(agent):
     assert result.returncode == 0
     assert "/api/enroll" in _StubHandler.seen
     assert not agent["lock_dir"].exists()
+
+
+@pytest.mark.parametrize("flag", ["--poll", "--heartbeat", "--sync-interval"])
+def test_numeric_interval_args_reject_non_numbers(agent, flag):
+    result = agent["run"](flag, "abc")
+
+    assert result.returncode == 2
+    assert f"{flag} must be a non-negative integer" in result.stderr
+    assert "/api/enroll" not in _StubHandler.seen
+
+
+def test_zero_disables_optional_agent_intervals(agent):
+    result = agent["run"]("--heartbeat", "0", "--sync-interval", "0")
+
+    assert result.returncode == 0
+    assert "/api/enroll" in _StubHandler.seen


### PR DESCRIPTION
Fixes #165.

## Summary
- add a POSIX numeric validator for agent interval flags
- reject non-numeric --poll, --heartbeat, and --sync-interval values before enrollment
- keep 0 accepted for optional intervals that callers may disable

## Tests
- uv run --extra dev pytest tests/test_agent_singleton.py