### PR TITLE
[codex] Add npm registry honeytoken type

### DIFF
--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -1,6 +1,6 @@
 # Adding a honeytoken type
 
-Thumper ships with five built-in token types (`aws`, `github`, `gcp`, `azure`, `ssh`). Adding a new one touches exactly two files and one test, and both files must stay in sync or the API will accept the type name but fail to generate content.
+Thumper ships with six built-in token types (`aws`, `github`, `npm`, `gcp`, `azure`, `ssh`). Adding a new one touches exactly two files and one test, and both files must stay in sync or the API will accept the type name but fail to generate content.
 
 ## The two touch points
 

--- a/server/thumper/tokens/catalog.py
+++ b/server/thumper/tokens/catalog.py
@@ -37,6 +37,19 @@ TOKEN_TYPES = [
                        "exfiltrates these to self-replicate via the API.",
     },
     {
+        "type": "npm",
+        "display_name": "npm token",
+        "default_path": "~/.npmrc",
+        "suggested_paths": [
+            "~/.npmrc",
+            "~/project/.npmrc",
+            "~/.env",
+        ],
+        "description": "Fake npm registry auth token (~/.npmrc). The credential "
+                       "the Shai-Hulud worm scans for first to self-publish "
+                       "malicious packages.",
+    },
+    {
         "type": "gcp",
         "display_name": "GCP service account",
         "default_path": "~/.config/gcloud/application_default_credentials.json",

--- a/server/thumper/tokens/generator.py
+++ b/server/thumper/tokens/generator.py
@@ -16,6 +16,7 @@ import secrets
 
 _HEX = "0123456789abcdef"
 _B64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+_ALNUM = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
 
 
 def _rand(alphabet: str, n: int) -> str:
@@ -28,6 +29,10 @@ def rand_hex(n: int) -> str:
 
 def rand_b64(n: int) -> str:
     return _rand(_B64, n)
+
+
+def rand_alnum(n: int) -> str:
+    return _rand(_ALNUM, n)
 
 
 def generate_token(token_type: str) -> str:
@@ -45,6 +50,9 @@ def generate_token(token_type: str) -> str:
             f"  oauth_token: github_pat_{rand_b64(22)}_{rand_b64(59)}\n"
             "  user: ci-deploy-bot\n"
         )
+
+    if token_type == "npm":
+        return f"//registry.npmjs.org/:_authToken=npm_{rand_alnum(36)}\n"
 
     if token_type == "gcp":
         return json.dumps(

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -2,11 +2,12 @@ import json
 
 import pytest
 
-from thumper.tokens.generator import generate_token, rand_b64, rand_hex
+from thumper.tokens.generator import generate_token, rand_alnum, rand_b64, rand_hex
 
 
 HEX_ALPHABET = set("0123456789abcdef")
 B64_ALPHABET = set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/")
+ALNUM_ALPHABET = set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
 
 
 @pytest.mark.parametrize("length", [0, 1, 32])
@@ -25,6 +26,14 @@ def test_rand_b64_returns_requested_length_and_base64_alphabet(length):
     assert set(value) <= B64_ALPHABET
 
 
+@pytest.mark.parametrize("length", [0, 1, 32])
+def test_rand_alnum_returns_requested_length_and_alnum_alphabet(length):
+    value = rand_alnum(length)
+
+    assert len(value) == length
+    assert set(value) <= ALNUM_ALPHABET
+
+
 def test_generate_aws_token_has_credentials_file_shape():
     token = generate_token("aws")
 
@@ -39,6 +48,16 @@ def test_generate_github_token_has_oauth_file_shape():
     assert "github.com:" in token
     assert "oauth_token: github_pat_" in token
     assert "user: ci-deploy-bot" in token
+
+
+def test_generate_npm_token_has_npmrc_shape():
+    token = generate_token("npm")
+
+    prefix = "//registry.npmjs.org/:_authToken=npm_"
+    assert token.startswith(prefix)
+    token_value = token.removeprefix(prefix).strip()
+    assert len(token_value) == 36
+    assert set(token_value) <= ALNUM_ALPHABET
 
 
 def test_generate_gcp_token_has_service_account_json_shape():

--- a/tests/test_tripwire_content.py
+++ b/tests/test_tripwire_content.py
@@ -44,6 +44,21 @@ def test_post_tripwire_generates_and_stores_token(client_db):
     assert "AKIA" in row.token
 
 
+def test_post_tripwire_generates_npmrc_token(client_db):
+    tc, db = client_db
+    resp = tc.post("/api/tripwires", json={
+        "name": "npm-bait", "token_type": "npm",
+        "path": "~/.npmrc", "source": "template",
+    })
+    assert resp.status_code == 200
+    tid = resp.json()["id"]
+
+    db.expire_all()
+    row = store.get_tripwire(db, tid)
+    assert row.token is not None
+    assert row.token.startswith("//registry.npmjs.org/:_authToken=npm_")
+
+
 def test_enroll_uses_stored_tripwire_token(client_db):
     tc, db = client_db
 


### PR DESCRIPTION
## What this PR does

Fixes #109.

Adds an npm registry auth-token honeytoken type for `.npmrc` files:

- adds `npm` to the token catalog with `~/.npmrc` as the default path
- generates realistic npmjs registry auth-token content with an `npm_` token prefix and random alphanumeric garbage material
- covers the generator shape and tripwire creation/storage path in tests
- updates the honeytoken type docs to list npm as a built-in type

## Why

Thumper already calls out `.npmrc` as a Shai-Hulud target, but did not have a dedicated npmjs.org registry token type. This keeps the existing GitHub Packages `.npmrc` path intact while adding a separate npm registry bait.

## Validation

- `/opt/homebrew/bin/python3.11 -m pip install -e ".[dev]"`
- `/opt/homebrew/bin/python3.11 -m ruff check docs/tokens.md server/thumper/tokens/catalog.py server/thumper/tokens/generator.py tests/test_generator.py tests/test_tripwire_content.py`
- `/opt/homebrew/bin/python3.11 -m pytest tests/test_generator.py tests/test_tripwire_content.py -v` — 20 passed
- `/opt/homebrew/bin/python3.11 -m pytest -v` — 275 passed, 1 skipped

AI assistance disclosure: I used Codex to prepare this patch and validation summary; I reviewed the diff and ran the checks above locally.
