### PR TITLE
Flag the dev admin token as insecure at startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,9 @@ THUMPER_ENROLL_TOKEN=dev-enroll-token
 THUMPER_INSTALL_TOKEN=dev-install-token
 
 # Admin token - REQUIRED. Gates the whole management/UI API. Unset = the
-# management API is disabled (503, fail-closed). Generate a strong random value.
+# management API is disabled (503, fail-closed). This obvious dev value is
+# publicly known and flagged loudly at startup - generate a strong random value
+# for anything other than local development.
 THUMPER_ADMIN_TOKEN=dev-admin-token
 
 # Path to the built UI (ui/dist). Used in Docker / monolith mode.

--- a/server/thumper/config.py
+++ b/server/thumper/config.py
@@ -93,24 +93,34 @@ ENROLL_TOKEN = os.environ.get("THUMPER_ENROLL_TOKEN", _DEFAULT_ENROLL_TOKEN)
 _DEFAULT_INSTALL_TOKEN = "dev-install-token"
 INSTALL_TOKEN = os.environ.get("THUMPER_INSTALL_TOKEN", _DEFAULT_INSTALL_TOKEN)
 
-# Admin token gating the whole management/UI API (#20). NO default on purpose:
-# fail closed. When unset, the management API is disabled (503) rather than
-# served open - a dev default would just recreate the no-auth hole. Set
-# THUMPER_ADMIN_TOKEN to a random secret to enable the dashboard/API.
+# Admin token gating the whole management/UI API (#20). NO code default on
+# purpose: fail closed. When unset, the management API is disabled (503) rather
+# than served open. .env.example ships this obvious dev value for local use;
+# it's publicly known, so a prod deploy that copies it is flagged at startup
+# (below) exactly like the enroll/install defaults - but it is never a code
+# default, so an unset token still fails closed.
+_DEFAULT_ADMIN_TOKEN = "dev-admin-token"
 ADMIN_TOKEN = os.environ.get("THUMPER_ADMIN_TOKEN", "")
 
 
-def insecure_default_tokens(enroll: str | None = None, install: str | None = None) -> list[str]:
+def insecure_default_tokens(
+    enroll: str | None = None,
+    install: str | None = None,
+    admin: str | None = None,
+) -> list[str]:
     """Names of the shared tokens still set to their built-in dev defaults.
     Used to warn loudly at startup so a production deploy doesn't silently run
     with publicly-known credentials."""
     enroll = ENROLL_TOKEN if enroll is None else enroll
     install = INSTALL_TOKEN if install is None else install
+    admin = ADMIN_TOKEN if admin is None else admin
     flagged = []
     if enroll == _DEFAULT_ENROLL_TOKEN:
         flagged.append("THUMPER_ENROLL_TOKEN")
     if install == _DEFAULT_INSTALL_TOKEN:
         flagged.append("THUMPER_INSTALL_TOKEN")
+    if admin == _DEFAULT_ADMIN_TOKEN:
+        flagged.append("THUMPER_ADMIN_TOKEN")
     return flagged
 
 # Secret used to encrypt integration config (plugin credentials) at rest (#24).

--- a/tests/test_default_token_warning.py
+++ b/tests/test_default_token_warning.py
@@ -16,3 +16,22 @@ def test_no_defaults_when_overridden():
 def test_only_install_default():
     assert insecure_default_tokens("s3cr3t-enroll", "dev-install-token") == [
         "THUMPER_INSTALL_TOKEN"]
+
+
+def test_admin_dev_default_flagged():
+    # The value .env.example ships is publicly known; a prod deploy that copies
+    # it must be warned even though ADMIN_TOKEN has no code default (fail-closed).
+    assert insecure_default_tokens(
+        "s3cr3t-enroll", "s3cr3t-install", "dev-admin-token") == [
+        "THUMPER_ADMIN_TOKEN"]
+
+
+def test_admin_secret_not_flagged():
+    assert insecure_default_tokens(
+        "s3cr3t-enroll", "s3cr3t-install", "s3cr3t-admin") == []
+
+
+def test_all_three_defaults_flagged():
+    assert insecure_default_tokens(
+        "dev-enroll-token", "dev-install-token", "dev-admin-token") == [
+        "THUMPER_ENROLL_TOKEN", "THUMPER_INSTALL_TOKEN", "THUMPER_ADMIN_TOKEN"]


### PR DESCRIPTION
Closes #197.

`THUMPER_ADMIN_TOKEN` is fail-closed (no code default — unset disables the management API with a 503). But `.env.example` ships an obvious `dev-admin-token`, and `insecure_default_tokens()` only checked the enroll/install defaults, so a deploy copying the example ran with a publicly-known admin token and **no** startup warning.

- `config.py`: recognize `dev-admin-token` (the `.env.example` value) as a known-insecure default and flag it, exactly like enroll/install. An **unset** token still fails closed — this adds no code default.
- `.env.example`: note the value is publicly known and flagged at startup.
- Tests: admin flagged when set to the dev value, not when overridden, and all-three case.

336 passed locally (TDD: red → green).