### PR TITLE
Fix stale tripwire sensor UI copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Removed stale dashboard copy that described the old macOS `fs_usage`/sudo-based tripwire sensor.
+
 ## [0.1.0] - unreleased
 
 Initial release: control-plane server, endpoint agent, dashboard UI, and the plugin system.

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -87,7 +87,7 @@ export interface EndpointDetail extends Endpoint {
   deployments: Deployment[];
 }
 
-/** A fired tripwire - enriched by the endpoint monitor (fs_usage). */
+/** A fired tripwire - enriched by the endpoint monitor. */
 export interface Alert {
   id: string;
   deployment_id: string;

--- a/ui/src/pages/TripwireDetail.tsx
+++ b/ui/src/pages/TripwireDetail.tsx
@@ -133,9 +133,9 @@ export default function TripwireDetail() {
             Run the command below on the machines you choose - paste it on a box, or push it
             via your MDM / SSH / Ansible. It's self-bootstrapping: it downloads the agent,
             self-enrolls, and starts watching. Each machine gets its <strong>own unique</strong>{" "}
-            honeytoken instance + secret. <code>sudo</code> is required so the monitor can see
-            file reads (macOS <code>fs_usage</code>). Your MDM decides which devices are in
-            scope - Thumper doesn't manage groups.
+            honeytoken instance + secret. The agent watches reads with an unprivileged
+            FIFO/inotify sensor and an atime-poll fallback. Your MDM decides which devices are
+            in scope - Thumper doesn't manage groups.
           </p>
           <CopyField value={tw.install.command} />
           <div className="row" style={{ marginTop: 12 }}>

--- a/ui/src/pages/Tripwires.tsx
+++ b/ui/src/pages/Tripwires.tsx
@@ -117,8 +117,8 @@ export default function Tripwires() {
               </div>
               <p className="muted" style={{ marginTop: 0 }}>
                 Run it on the machines you choose - paste it on a box, or push it via your MDM /
-                SSH. One agent self-enrolls and plants + watches all selected tripwires.{" "}
-                <code>sudo</code> is required (macOS <code>fs_usage</code>).
+                SSH. One agent self-enrolls and plants + watches all selected tripwires with an
+                unprivileged FIFO/inotify watcher and an atime-poll fallback.
               </p>
               <CopyField value={install.command} />
             </div>


### PR DESCRIPTION
## Summary\n- replace stale sudo/fs_usage tripwire sensor copy with the current unprivileged FIFO/inotify watcher wording\n- remove the stale fs_usage API type comment\n- add an Unreleased changelog entry\n\n## Tests\n- cd ui && npm run build\n- cd ui && npm test\n- rg -n "fs_usage|sudo.*required|required.*sudo" ui/src\n\nCloses #194