### PR TITLE
Add absolute timestamp tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added absolute local-time tooltips to relative timestamps in the dashboard UI.
+
 ### Changed
 
 ### Fixed

--- a/ui/src/components/ui.tsx
+++ b/ui/src/components/ui.tsx
@@ -128,3 +128,7 @@ export function timeAgo(iso: string): string {
   if (h < 24) return `${h}h ago`;
   return `${Math.floor(h / 24)}d ago`;
 }
+
+export function TimeAgo({ iso }: { iso: string }) {
+  return <span title={new Date(iso).toLocaleString()}>{timeAgo(iso)}</span>;
+}

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate } from "react-router-dom";
 import { RefreshCw } from "lucide-react";
 import type { Alert, DashboardStats, Tripwire } from "../api";
 import { api } from "../api";
-import { AlertBadge, timeAgo, Topbar, TripwireBadge, TypeTag } from "../components/ui.tsx";
+import { AlertBadge, TimeAgo, Topbar, TripwireBadge, TypeTag } from "../components/ui.tsx";
 import PageTitle from "../components/PageTitle.tsx";
 
 type AlertFilter = "open" | "all" | "resolved";
@@ -170,7 +170,7 @@ export default function Dashboard() {
               <tbody>
                 {shownAlerts.slice(0, 8).map((a) => (
                   <tr key={a.id}>
-                    <td className="muted">{timeAgo(a.timestamp)}</td>
+                    <td className="muted"><TimeAgo iso={a.timestamp} /></td>
                     <td><AlertBadge status={a.status} /></td>
                     <td>
                       <Link to={`/endpoints/${a.endpoint_id}`}>{a.endpoint_hostname}</Link>

--- a/ui/src/pages/EndpointDetail.tsx
+++ b/ui/src/pages/EndpointDetail.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 import { Trash2 } from "lucide-react";
 import type { EndpointDetail as ED, Tripwire } from "../api";
 import { api, ApiError } from "../api";
-import { DeployBadge, EndpointBadge, timeAgo, Topbar } from "../components/ui.tsx";
+import { DeployBadge, EndpointBadge, TimeAgo, Topbar } from "../components/ui.tsx";
 import PageTitle from "../components/PageTitle.tsx";
 
 function Modal({ children, onClose }: { children: React.ReactNode; onClose: () => void }) {
@@ -120,8 +120,8 @@ export default function EndpointDetail() {
           <div className="row" style={{ gap: 10 }}>
             <EndpointBadge status={ep.status} />
             <span className="muted">{ep.platform ?? "unknown platform"}</span>
-            <span className="muted">enrolled {timeAgo(ep.enrolled_at)}</span>
-            <span className="muted">last seen {ep.last_seen ? timeAgo(ep.last_seen) : "-"}</span>
+            <span className="muted">enrolled <TimeAgo iso={ep.enrolled_at} /></span>
+            <span className="muted">last seen {ep.last_seen ? <TimeAgo iso={ep.last_seen} /> : "-"}</span>
           </div>
         </div>
 
@@ -187,8 +187,8 @@ export default function EndpointDetail() {
                       <Link to={`/tripwires/${d.tripwire_id}`}>{nameOf(d.tripwire_id)}</Link>
                     </td>
                     <td className="path">{d.id}</td>
-                    <td className="muted">{timeAgo(d.created_at)}</td>
-                    <td className="muted">{d.last_triggered ? timeAgo(d.last_triggered) : "-"}</td>
+                    <td className="muted"><TimeAgo iso={d.created_at} /></td>
+                    <td className="muted">{d.last_triggered ? <TimeAgo iso={d.last_triggered} /> : "-"}</td>
                     <td><DeployBadge state={d.state} triggered={d.triggered_count} endpointStatus={d.endpoint_status} /></td>
                     <td>
                       <button

--- a/ui/src/pages/Endpoints.tsx
+++ b/ui/src/pages/Endpoints.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import type { Endpoint } from "../api";
 import { api } from "../api";
-import { EndpointBadge, timeAgo, Topbar } from "../components/ui.tsx";
+import { EndpointBadge, TimeAgo, Topbar } from "../components/ui.tsx";
 import PageTitle from "../components/PageTitle.tsx";
 
 export default function Endpoints() {
@@ -46,8 +46,8 @@ export default function Endpoints() {
                   <tr key={e.id} className="clickable-row" onClick={() => nav(`/endpoints/${e.id}`)}>
                     <td>{e.hostname}</td>
                     <td className="muted">{e.platform ?? "-"}</td>
-                    <td className="muted">{timeAgo(e.enrolled_at)}</td>
-                    <td className="muted">{e.last_seen ? timeAgo(e.last_seen) : "-"}</td>
+                    <td className="muted"><TimeAgo iso={e.enrolled_at} /></td>
+                    <td className="muted">{e.last_seen ? <TimeAgo iso={e.last_seen} /> : "-"}</td>
                     <td>{e.deployment_count}</td>
                     <td className={e.triggered_count > 0 ? "danger-text" : ""}>
                       {e.triggered_count}

--- a/ui/src/pages/Integrations.tsx
+++ b/ui/src/pages/Integrations.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import type { Integration, IntegrationTestResult, PluginManifest } from "../api";
 import { api } from "../api";
-import { timeAgo, Topbar } from "../components/ui.tsx";
+import { TimeAgo, Topbar } from "../components/ui.tsx";
 import PageTitle from "../components/PageTitle.tsx";
 
 export default function Integrations() {
@@ -58,7 +58,7 @@ export default function Integrations() {
         </span>
       );
     }
-    const when = st.last_test_at ? ` · ${timeAgo(st.last_test_at)}` : "";
+    const when = st.last_test_at ? <> · <TimeAgo iso={st.last_test_at} /></> : null;
     if (st.last_test_status === "ok") {
       return (
         <span className="badge deployed">

--- a/ui/src/pages/TripwireDetail.tsx
+++ b/ui/src/pages/TripwireDetail.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import type { TripwireDetail as TD } from "../api";
 import { api, ApiError } from "../api";
-import { CopyField, DeployBadge, Modal, timeAgo, Topbar, TypeTag } from "../components/ui.tsx";
+import { CopyField, DeployBadge, Modal, TimeAgo, Topbar, TypeTag } from "../components/ui.tsx";
 import { Pencil, Trash2 } from "lucide-react";
 import PageTitle from "../components/PageTitle.tsx";
 
@@ -118,7 +118,7 @@ export default function TripwireDetail() {
             <TypeTag type={tw.token_type} />
             <span className="path">{tw.path}</span>
             <span className="muted">source: {tw.source}</span>
-            <span className="muted">created {timeAgo(tw.created_at)}</span>
+            <span className="muted">created <TimeAgo iso={tw.created_at} /></span>
           </div>
 
           {tw.token && (
@@ -174,9 +174,9 @@ export default function TripwireDetail() {
                       <Link to={`/endpoints/${d.endpoint_id}`}>{d.endpoint_hostname}</Link>
                     </td>
                     <td className="path">{d.id}</td>
-                    <td className="muted">{timeAgo(d.created_at)}</td>
+                    <td className="muted"><TimeAgo iso={d.created_at} /></td>
                     <td className="muted">
-                      {d.last_triggered ? timeAgo(d.last_triggered) : "-"}
+                      {d.last_triggered ? <TimeAgo iso={d.last_triggered} /> : "-"}
                     </td>
                     <td><DeployBadge state={d.state} triggered={d.triggered_count} endpointStatus={d.endpoint_status} /></td>
                   </tr>

--- a/ui/src/pages/Tripwires.tsx
+++ b/ui/src/pages/Tripwires.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate } from "react-router-dom";
 import { Pencil, Trash2 } from "lucide-react";
 import type { InstallCommand, Tripwire } from "../api";
 import { api } from "../api";
-import { CopyField, Modal, timeAgo, Topbar, TripwireBadge, TypeTag } from "../components/ui.tsx";
+import { CopyField, Modal, TimeAgo, Topbar, TripwireBadge, TypeTag } from "../components/ui.tsx";
 import PageTitle from "../components/PageTitle.tsx";
 
 export default function Tripwires() {
@@ -156,7 +156,7 @@ export default function Tripwires() {
                     <td><TypeTag type={t.token_type} /></td>
                     <td className="path">{t.path}</td>
                     <td className="muted">{t.source}</td>
-                    <td className="muted">{timeAgo(t.created_at)}</td>
+                    <td className="muted"><TimeAgo iso={t.created_at} /></td>
                     <td>{t.deployed_count}</td>
                     <td><TripwireBadge deployed={t.deployed_count} triggered={t.triggered_count} /></td>
                     <td className="row-actions" onClick={(e) => e.stopPropagation()}>


### PR DESCRIPTION
## Summary\n- add a shared TimeAgo component that keeps relative timestamp text and exposes the absolute local timestamp via title\n- replace relative timestamp call sites across dashboard, endpoints, tripwires, and integrations\n- add an Unreleased changelog entry\n\n## Tests\n- cd ui && npm run build\n- cd ui && npm test\n\nCloses #153