### PR TITLE
docs: fix honeytoken count in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,18 +18,13 @@ Initial release: control-plane server, endpoint agent, dashboard UI, and the plu
 
 ### Added
 
-- **Server**: FastAPI control plane with SQLite/Postgres/MySQL support via SQLAlchemy + Alembic,
-  and signed tripwire-trigger callbacks with replay protection.
-- **Agent**: standalone Bash endpoint agent (`agent/thumper_agent.sh`, curl + openssl only, no
-  Python dependency) that plants honeytoken files and reports reads back to the server.
-- **UI**: React/Vite dashboard for creating tripwires, managing the enrolled endpoint fleet, and
-  viewing the live alert feed.
-- **Honeytoken types**: five built-in types — `aws`, `github`, `gcp`, `azure`, `ssh`. Each
-  generated with a realistic-but-non-functional credential shape.
+- **Server**: FastAPI control plane with SQLite/Postgres/MySQL support via SQLAlchemy + Alembic, and signed tripwire-trigger callbacks with replay protection.
+- **Agent**: standalone Bash endpoint agent (`agent/thumper_agent.sh`, curl + openssl only, no Python dependency) that plants honeytoken files and reports reads back to the server.
+- **UI**: React/Vite dashboard for creating tripwires, managing the enrolled endpoint fleet, and viewing the live alert feed.
+- **Honeytoken types**: six built-in types — `aws`, `github`, `npm`, `gcp`, `azure`, `ssh`. Each generated with a realistic-but-non-functional credential shape.
 - **Alert plugins**: generic webhook, Splunk (HEC), Loki.
 - **Deploy plugins**: SSH (direct) and MDM (Jamf Pro).
-- **Deployment**: single Docker image (`docker compose up --build`) and a Helm chart for
-  Kubernetes (`deploy/helm/thumper`).
+- **Deployment**: single Docker image (`docker compose up --build`) and a Helm chart for Kubernetes (`deploy/helm/thumper`).
 
 [Unreleased]: https://github.com/jestasecurity/thumper/compare/v0.0.0...HEAD
 [0.1.0]: https://github.com/jestasecurity/thumper/releases/tag/v0.1.0


### PR DESCRIPTION
Small follow-up to #170.

- Fixes the `0.1.0` honeytoken count from five to six and adds the missing `npm` type.
- Verified against `server/thumper/tokens/catalog.py` and `generator.py` on `main` — both list six types (`aws`, `github`, `npm`, `gcp`, `azure`, `ssh`).
- No other changes — link definitions, the `- unreleased` marker, and everything else from #170 are untouched.