### PR TITLE
[codex] Add Docker honeytoken type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Docker registry credentials honeytoken type for `~/.docker/config.json`.
+
 ### Changed
 
 ### Fixed

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -1,6 +1,6 @@
 # Adding a honeytoken type
 
-Thumper ships with six built-in token types (`aws`, `github`, `npm`, `gcp`, `azure`, `ssh`). Adding a new one touches exactly two files and one test, and both files must stay in sync or the API will accept the type name but fail to generate content.
+Thumper ships with seven built-in token types (`aws`, `github`, `npm`, `docker`, `gcp`, `azure`, `ssh`). Adding a new one touches exactly two files and one test, and both files must stay in sync or the API will accept the type name but fail to generate content.
 
 ## The two touch points
 

--- a/server/thumper/tokens/catalog.py
+++ b/server/thumper/tokens/catalog.py
@@ -50,6 +50,18 @@ TOKEN_TYPES = [
                        "malicious packages.",
     },
     {
+        "type": "docker",
+        "display_name": "Docker registry auth",
+        "default_path": "~/.docker/config.json",
+        "suggested_paths": [
+            "~/.docker/config.json",
+            "~/.dockercfg",
+            "~/project/.docker/config.json",
+        ],
+        "description": "Fake Docker registry auth config. Supply-chain attackers "
+                       "scan this file for registry credentials they can exfiltrate.",
+    },
+    {
         "type": "gcp",
         "display_name": "GCP service account",
         "default_path": "~/.config/gcloud/application_default_credentials.json",

--- a/server/thumper/tokens/generator.py
+++ b/server/thumper/tokens/generator.py
@@ -11,6 +11,7 @@ generation lives on the SERVER (not the browser) because creating a tripwire
 also mints a per-token HMAC secret and callback binding - security-relevant work
 the client must not do.
 """
+import base64
 import json
 import secrets
 
@@ -53,6 +54,20 @@ def generate_token(token_type: str) -> str:
 
     if token_type == "npm":
         return f"//registry.npmjs.org/:_authToken=npm_{rand_alnum(36)}\n"
+
+    if token_type == "docker":
+        password = f"dckr_pat_{rand_alnum(44)}"
+        auth = base64.b64encode(f"ci-deploy-bot:{password}".encode()).decode()
+        return json.dumps(
+            {
+                "auths": {
+                    "https://index.docker.io/v1/": {
+                        "auth": auth,
+                    },
+                },
+            },
+            indent=2,
+        )
 
     if token_type == "gcp":
         return json.dumps(

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,3 +1,4 @@
+import base64
 import json
 
 import pytest
@@ -58,6 +59,19 @@ def test_generate_npm_token_has_npmrc_shape():
     token_value = token.removeprefix(prefix).strip()
     assert len(token_value) == 36
     assert set(token_value) <= ALNUM_ALPHABET
+
+
+def test_generate_docker_token_has_config_json_shape():
+    token = generate_token("docker")
+    data = json.loads(token)
+
+    registry = data["auths"]["https://index.docker.io/v1/"]
+    decoded_auth = base64.b64decode(registry["auth"]).decode()
+    username, password = decoded_auth.split(":", 1)
+    assert username == "ci-deploy-bot"
+    assert password.startswith("dckr_pat_")
+    assert len(password.removeprefix("dckr_pat_")) == 44
+    assert set(password.removeprefix("dckr_pat_")) <= ALNUM_ALPHABET
 
 
 def test_generate_gcp_token_has_service_account_json_shape():

--- a/tests/test_tripwire_content.py
+++ b/tests/test_tripwire_content.py
@@ -1,4 +1,5 @@
 """Tripwire token is generated at creation time and stored in the tripwires table."""
+import json
 from unittest.mock import patch
 
 import pytest
@@ -57,6 +58,23 @@ def test_post_tripwire_generates_npmrc_token(client_db):
     row = store.get_tripwire(db, tid)
     assert row.token is not None
     assert row.token.startswith("//registry.npmjs.org/:_authToken=npm_")
+
+
+def test_post_tripwire_generates_docker_config_token(client_db):
+    tc, db = client_db
+    resp = tc.post("/api/tripwires", json={
+        "name": "docker-bait", "token_type": "docker",
+        "path": "~/.docker/config.json", "source": "template",
+    })
+    assert resp.status_code == 200
+    tid = resp.json()["id"]
+
+    db.expire_all()
+    row = store.get_tripwire(db, tid)
+    assert row.token is not None
+    data = json.loads(row.token)
+    assert "https://index.docker.io/v1/" in data["auths"]
+    assert isinstance(data["auths"]["https://index.docker.io/v1/"]["auth"], str)
 
 
 def test_enroll_uses_stored_tripwire_token(client_db):

--- a/tests/test_tripwire_crud.py
+++ b/tests/test_tripwire_crud.py
@@ -20,6 +20,17 @@ def _enroll(tc, machine_id, tripwire_ids):
     assert r.status_code == 200
 
 
+def test_token_types_includes_docker_config(client_db):
+    tc, _ = client_db
+
+    resp = tc.get("/api/token-types")
+
+    assert resp.status_code == 200
+    docker = next(item for item in resp.json() if item["type"] == "docker")
+    assert docker["default_path"] == "~/.docker/config.json"
+    assert "~/.docker/config.json" in docker["suggested_paths"]
+
+
 def test_create_tripwire_strips_name(client_db):
     tc, db = client_db
 


### PR DESCRIPTION
Closes #166.

## Summary
- Add a `docker` honeytoken catalog entry for `~/.docker/config.json`.
- Generate valid Docker config JSON with base64-encoded fake registry auth material.
- Cover the generator, tripwire storage path, and `GET /api/token-types` acceptance behavior.
- Update token docs and the Unreleased changelog entry for the new built-in type.

## Validation
- `/opt/homebrew/bin/python3.11 -m pip install -e ".[dev]"`
- `/opt/homebrew/bin/python3.11 -m ruff check .`
- `/opt/homebrew/bin/python3.11 -m pytest tests/test_generator.py tests/test_tripwire_content.py tests/test_tripwire_crud.py -v` (31 passed)
- `/opt/homebrew/bin/python3.11 -m pytest -v` (336 passed, 1 skipped)

## AI assistance disclosure
Implemented with AI assistance from OpenAI Codex and reviewed before submission.
