### PR TITLE
docs: add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,91 @@
+name: Bug report
+description: Report something that isn't working as expected
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this. Please search [existing issues](https://github.com/jestasecurity/thumper/issues) first to avoid duplicates.
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of Thumper is affected?
+      options:
+        - Server (server/thumper/)
+        - Endpoint agent (agent/thumper_agent.sh)
+        - UI (ui/)
+        - Alert plugin
+        - Deploy plugin
+        - Docs
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Thumper version
+      description: The version you're running (see `pyproject.toml`, or the git commit/tag).
+      placeholder: "0.1.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Endpoint OS
+      description: Only relevant for agent bugs — the agent supports Linux and macOS.
+      options:
+        - N/A (server or UI issue)
+        - Linux
+        - macOS
+    validations:
+      required: false
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or output
+      description: Server logs, agent stdout, or browser console errors. This field is auto-formatted as a code block.
+      render: shell
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and this isn't a duplicate
+          required: true
+        - label: This is not a security vulnerability (see [SECURITY.md](https://github.com/jestasecurity/thumper/blob/main/SECURITY.md) for private reporting)
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/jestasecurity/thumper/security/policy
+    about: Do not open a public issue for security vulnerabilities — see SECURITY.md for private reporting instructions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,56 @@
+name: Feature request
+description: Suggest an enhancement or new capability
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion. Please search [existing issues](https://github.com/jestasecurity/thumper/issues) first — someone may have already asked.
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      options:
+        - Server
+        - Endpoint agent
+        - UI
+        - Alert plugin (new or existing)
+        - Deploy plugin (new or existing)
+        - Honeytoken type
+        - Docs
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: What's missing or painful today? Describe the problem, not the solution yet.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches, workarounds, or why an existing plugin/config option doesn't already cover this.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links, screenshots, or related issues.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!-- Tip: PR/commit titles in this repo tend to use a "type: description" style, e.g. "fix: ...", "docs: ...", "feat: ..." -->
+
+## Summary
+
+<!-- What does this PR do, and why? -->
+
+<!-- If this closes an issue, put the number below, e.g. "Closes #123" -->
+Closes #
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Docs
+- [ ] Refactor / internal (no user-facing change)
+- [ ] Other:
+
+## Checklist
+
+- [ ] `pytest -v` passes locally (`pip install -e ".[dev]"` first — see [CONTRIBUTING.md](https://github.com/jestasecurity/thumper/blob/main/CONTRIBUTING.md))
+- [ ] For UI changes: verified with `cd ui && npm install && npm run dev`
+- [ ] For a new/changed plugin: follows [docs/plugins.md](https://github.com/jestasecurity/thumper/blob/main/docs/plugins.md)
+- [ ] For a new honeytoken type: follows [docs/tokens.md](https://github.com/jestasecurity/thumper/blob/main/docs/tokens.md)
+- [ ] Added a one-line entry under `## [Unreleased]` in [CHANGELOG.md](https://github.com/jestasecurity/thumper/blob/main/CHANGELOG.md) (skip for internal-only changes)
+- [ ] PR is scoped to the linked issue — no unrelated changes
+
+## Testing notes
+
+<!-- How did you verify this? Manual steps, new/updated tests, edge cases considered. -->


### PR DESCRIPTION
Adds issue and PR templates for consistent formatting, per #4.

- `.github/ISSUE_TEMPLATE/bug_report.yml` — structured bug report form (component, version, endpoint OS, repro steps, logs).
- `.github/ISSUE_TEMPLATE/feature_request.yml` — problem/solution/alternatives form.
- `.github/ISSUE_TEMPLATE/config.yml` — routes security reports to SECURITY.md instead of a public issue.
- `.github/PULL_REQUEST_TEMPLATE.md` — checklist mirrored from CONTRIBUTING.md (tests, UI verification, plugin/token docs, changelog entry).

Closes #4