### PR TITLE
Add CopyField clipboard fallback for HTTP

### DIFF
--- a/ui/src/components/ui.tsx
+++ b/ui/src/components/ui.tsx
@@ -86,6 +86,34 @@ export function EndpointBadge({ status }: { status: EndpointStatus }) {
 }
 
 /** Monospace block with a copy button - used for the install command. */
+async function copyText(value: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(value);
+      return true;
+    }
+  } catch {
+    // Fall back below; clipboard.writeText can reject outside secure contexts.
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = value;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.top = "-9999px";
+  textarea.style.left = "-9999px";
+  document.body.appendChild(textarea);
+  textarea.select();
+  textarea.setSelectionRange(0, textarea.value.length);
+  try {
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
 export function CopyField({ value }: { value: string }) {
   const [label, setLabel] = useState("Copy");
   return (
@@ -93,13 +121,9 @@ export function CopyField({ value }: { value: string }) {
       <code>{value}</code>
       <button
         className="btn"
-        onClick={() => {
-          if (navigator.clipboard) {
-            navigator.clipboard.writeText(value);
-            setLabel("✓ Copied");
-          } else {
-            setLabel("Copy failed, try manually");
-          }
+        onClick={async () => {
+          const copied = await copyText(value);
+          setLabel(copied ? "✓ Copied" : "Copy failed, try manually");
           setTimeout(() => setLabel("Copy"), 1200);
         }}
       >


### PR DESCRIPTION
## Summary
- use `navigator.clipboard.writeText` when available
- fall back to a temporary textarea + `document.execCommand("copy")` for non-secure HTTP contexts
- keep the existing copied/failure feedback behavior

Closes #195

## Tests
- npm run build
- npm test