### PR TITLE
tests: cover token catalog, manifests, distribute route, endpoint detail, deployment content

### DIFF
--- a/tests/test_distribute_route.py
+++ b/tests/test_distribute_route.py
@@ -1,0 +1,50 @@
+"""Coverage for the POST /api/tripwires/{tid}/distribute HTTP route: the 404
+branch and delegation to the service. The service's own failure-isolation
+contract is already covered by test_deploy_isolation.py - this file only
+checks the route wrapper (#200)."""
+
+
+def test_distribute_unknown_tripwire_is_404(client_db):
+    tc, _ = client_db
+    resp = tc.post("/api/tripwires/does-not-exist/distribute")
+    assert resp.status_code == 404
+
+
+def test_distribute_with_no_deploy_integration_is_400(client_db):
+    tc, _ = client_db
+    tid = tc.post("/api/tripwires", json={
+        "name": "distribute-bait", "token_type": "aws",
+        "path": "~/.aws/credentials", "source": "template",
+    }).json()["id"]
+
+    resp = tc.post(f"/api/tripwires/{tid}/distribute")
+    assert resp.status_code == 400
+    assert "No deploy integration configured" in resp.json()["detail"]
+
+
+def test_distribute_isolates_a_failing_plugin(client_db, monkeypatch):
+    """Route-level check that a configured-but-failing deploy plugin still
+    returns 200 with a per-plugin 'failed' result."""
+    tc, db = client_db
+    from thumper import store
+    from thumper.services import deploy as deploy_svc
+
+    store.upsert_integration(db, plugin="ssh", kind="deploy", config={})
+
+    class Boom:
+        def deploy(self, install, targets):
+            raise RuntimeError("ssh unreachable")
+
+    monkeypatch.setattr(deploy_svc, "load_plugin", lambda name, config: Boom())
+
+    tid = tc.post("/api/tripwires", json={
+        "name": "distribute-bait-2", "token_type": "aws",
+        "path": "~/.aws/credentials", "source": "template",
+    }).json()["id"]
+
+    resp = tc.post(f"/api/tripwires/{tid}/distribute")
+    assert resp.status_code == 200
+    results = resp.json()["results"]
+    assert len(results) == 1
+    assert results[0]["plugin"] == "ssh"
+    assert results[0]["state"] == "failed"

--- a/tests/test_endpoint_assignment.py
+++ b/tests/test_endpoint_assignment.py
@@ -98,3 +98,24 @@ def test_reenroll_is_additive(client_db):
     _enroll(tc, "m1", a.id)
     db.expire_all()
     assert {d.tripwire_id for d in store.list_deployments_for_endpoint(db, eid)} == {a.id, b.id}
+
+
+# ── GET /api/endpoints/{eid} (#200) ──────────────────────────────────────────
+
+def test_get_endpoint_includes_deployments(client_db):
+    tc, db = client_db
+    a = _mk(db, "aws")
+    eid = _enroll(tc, "m1", a.id)
+
+    resp = tc.get(f"/api/endpoints/{eid}")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == eid
+    assert len(body["deployments"]) == 1
+    assert body["deployments"][0]["tripwire_id"] == a.id
+
+
+def test_get_endpoint_unknown_404(client_db):
+    tc, _ = client_db
+    assert tc.get("/api/endpoints/ep_nope").status_code == 404

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -165,3 +165,50 @@ def test_state_endpoint_rejects_bad_token(client_db):
                    headers={"Authorization": "Bearer wrong"}, data={"state": "planted"})
 
     assert resp.status_code == 401
+
+
+# ── GET /agent/deployments/{id}/content (#200) ───────────────────────────────
+
+def test_content_endpoint_returns_bait_body(client_db):
+    tc, db = client_db
+    _seed_endpoint(db)
+    _seed_deployment(db, "dp_1")
+
+    resp = tc.get("/api/agent/deployments/dp_1/content",
+                  headers={"Authorization": "Bearer tok_abc"})
+
+    assert resp.status_code == 200
+    assert resp.text == "bait-body"
+
+
+def test_content_endpoint_rejects_other_endpoints_deployment(client_db):
+    tc, db = client_db
+    _seed_endpoint(db, eid="ep_1", token="tok_abc")
+    _seed_endpoint(db, eid="ep_2", token="tok_def")
+    _seed_deployment(db, "dp_2", eid="ep_2")
+
+    resp = tc.get("/api/agent/deployments/dp_2/content",
+                  headers={"Authorization": "Bearer tok_abc"})
+
+    assert resp.status_code == 404
+
+
+def test_content_endpoint_unknown_deployment_404(client_db):
+    tc, db = client_db
+    _seed_endpoint(db)
+
+    resp = tc.get("/api/agent/deployments/dp_nope/content",
+                  headers={"Authorization": "Bearer tok_abc"})
+
+    assert resp.status_code == 404
+
+
+def test_content_endpoint_rejects_bad_token(client_db):
+    tc, db = client_db
+    _seed_endpoint(db)
+    _seed_deployment(db, "dp_1")
+
+    resp = tc.get("/api/agent/deployments/dp_1/content",
+                  headers={"Authorization": "Bearer wrong"})
+
+    assert resp.status_code == 401

--- a/tests/test_manifests_api.py
+++ b/tests/test_manifests_api.py
@@ -1,0 +1,21 @@
+"""Coverage for GET /api/manifests: public plugin manifests (#200)."""
+
+
+def test_manifests_lists_known_plugins(client_db):
+    tc, _ = client_db
+    resp = tc.get("/api/manifests")
+    assert resp.status_code == 200
+    body = resp.json()
+    names = {m["name"] for m in body}
+    assert "webhook" in names
+    assert "ssh" in names
+    assert any(m["kind"] == "deploy" for m in body)
+    assert any(m["kind"] == "alert" for m in body)
+
+
+def test_manifests_strips_internal_fields(client_db):
+    tc, _ = client_db
+    resp = tc.get("/api/manifests")
+    for manifest in resp.json():
+        assert not any(k.startswith("_") for k in manifest), \
+            f"internal field leaked in manifest: {manifest}"

--- a/tests/test_token_catalog_api.py
+++ b/tests/test_token_catalog_api.py
@@ -1,0 +1,40 @@
+"""Coverage for the token catalog API: GET /api/token-types and
+POST /api/tokens/preview (#200)."""
+from thumper.tokens.catalog import TOKEN_TYPES, TOKEN_TYPE_NAMES
+
+
+def test_token_types_returns_full_catalog(client_db):
+    tc, _ = client_db
+    resp = tc.get("/api/token-types")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert {t["type"] for t in body} == TOKEN_TYPE_NAMES
+    assert body == TOKEN_TYPES
+
+
+def test_preview_template_source_generates_content(client_db):
+    tc, _ = client_db
+    resp = tc.post("/api/tokens/preview", json={"token_type": "npm", "source": "template"})
+    assert resp.status_code == 200
+    assert resp.json()["content"].startswith("//registry.npmjs.org/:_authToken=npm_")
+
+
+def test_preview_custom_source_returns_custom_content(client_db):
+    tc, _ = client_db
+    resp = tc.post("/api/tokens/preview", json={
+        "token_type": "aws", "source": "custom", "custom_content": "hello-bait",
+    })
+    assert resp.status_code == 200
+    assert resp.json()["content"] == "hello-bait"
+
+
+def test_preview_custom_source_without_content_is_400(client_db):
+    tc, _ = client_db
+    resp = tc.post("/api/tokens/preview", json={"token_type": "aws", "source": "custom"})
+    assert resp.status_code == 400
+
+
+def test_preview_unknown_token_type_is_400(client_db):
+    tc, _ = client_db
+    resp = tc.post("/api/tokens/preview", json={"token_type": "not-a-real-type"})
+    assert resp.status_code == 400


### PR DESCRIPTION
Adds the missing test coverage from the audit in #200. All additions, no existing test logic touched.

- `tests/test_token_catalog_api.py` (new) — `GET /api/token-types`, `POST /api/tokens/preview` (template/custom/missing-content/unknown-type paths).
- `tests/test_manifests_api.py` (new) — `GET /api/manifests`, including that internal `_`-prefixed fields never leak.
- `tests/test_distribute_route.py` (new) — HTTP-level coverage for `POST /tripwires/{tid}/distribute`: 404, no-integration-400, and result serialization on a failing plugin. Complements `test_deploy_isolation.py`, which already covers the service logic directly. This only covers the route wrapper.
- `tests/test_endpoint_assignment.py` (+2 tests) — `GET /api/endpoints/{eid}`, reusing the file's existing `_mk`/`_enroll` helpers.
- `tests/test_heartbeat.py` (+4 tests) — `GET /agent/deployments/{id}/content`, reusing the file's existing `_seed_endpoint`/`_seed_deployment` helpers.

Full suite: 337 passed, 13 skipped (pre-existing), 0 failed.

Closes #200