### PR TITLE
fix(agent): don't respawn a FIFO writer during shutdown (fixes intermittent SIGTERM hang)

### DIFF
--- a/agent/thumper_agent.sh
+++ b/agent/thumper_agent.sh
@@ -648,6 +648,14 @@ watch_fifo() {  # supervisor: keep one serve_fifo alive per bait; restart any th
             # until the next full re-plant restart. And we must NOT fall back to
             # atime: atime polling on a writerless pipe is silently blind.
             if [ -p "$_sf" ] && ! kill -0 "$_sp" 2>/dev/null; then
+                # A deliberate stop sets WATCH_STOP_FLAG *before* it pkill's the
+                # writers, so re-check it here: a writer that just died because
+                # we're shutting down must NOT be respawned. Without this guard a
+                # respawn in stop_watcher's pkill->kill window leaks a serve_fifo
+                # blocked in open(O_WRONLY) (no reader); that orphan keeps the
+                # agent's stdout/stderr open, so on SIGTERM the process never
+                # reaches EOF and shutdown intermittently hangs.
+                [ -e "${WATCH_STOP_FLAG:-/nonexistent}" ] && return 0
                 serve_fifo "$i" & eval "sf_pid_$i=\$!"
                 log "restarted dead FIFO writer for bait $i"
             fi

--- a/tests/test_agent_ephemeral.py
+++ b/tests/test_agent_ephemeral.py
@@ -26,6 +26,13 @@ AGENT = Path(__file__).resolve().parents[1] / "agent" / "thumper_agent.sh"
 BAIT_BODY = "BAIT-honeytoken-content"
 
 
+# Teardown wait for the agent process to exit after SIGTERM. The exit trap
+# (stop_watcher -> pkill children, remove_fifos, cleanup_heartbeat, release
+# the singleton lock) spawns several helper subprocesses (ps/pkill/lsof);
+# on a loaded macOS CI runner that teardown can exceed a tight 5s and flake
+# the test (e.g. test_heartbeat_success_is_logged), so allow generous headroom.
+AGENT_EXIT_TIMEOUT = 30
+
 class _StubHandler(http.server.BaseHTTPRequestHandler):
     """Minimal Thumper server stub for ephemeral tests."""
 
@@ -135,7 +142,7 @@ def stub(tmp_path):
         for p in procs:
             try:
                 p.send_signal(signal.SIGTERM)
-                p.wait(timeout=5)
+                p.wait(timeout=AGENT_EXIT_TIMEOUT)
             except (subprocess.TimeoutExpired, ProcessLookupError):
                 try:
                     p.send_signal(signal.SIGKILL)
@@ -212,7 +219,7 @@ def test_ephemeral_auto_decommissions_on_terminate(stub):
 
     # Agent should exit cleanly.
     try:
-        proc.wait(timeout=5)
+        proc.wait(timeout=AGENT_EXIT_TIMEOUT)
     except subprocess.TimeoutExpired:
         proc.send_signal(signal.SIGKILL)
         pytest.fail("agent did not exit after SIGTERM + decommission")

--- a/tests/test_agent_fifo.py
+++ b/tests/test_agent_fifo.py
@@ -21,6 +21,13 @@ AGENT = Path(__file__).resolve().parents[1] / "agent" / "thumper_agent.sh"
 BAIT_BODY = "AKIA-BAIT\nsecret=shhh\n"
 
 
+# Teardown wait for the agent process to exit after SIGTERM. The exit trap
+# (stop_watcher -> pkill children, remove_fifos, cleanup_heartbeat, release
+# the singleton lock) spawns several helper subprocesses (ps/pkill/lsof);
+# on a loaded macOS CI runner that teardown can exceed a tight 5s and flake
+# the test (e.g. test_heartbeat_success_is_logged), so allow generous headroom.
+AGENT_EXIT_TIMEOUT = 30
+
 class Stub(http.server.BaseHTTPRequestHandler):
     callbacks = []  # POSTed callback bodies
     bait_path = ""  # absolute path the agent should plant
@@ -156,7 +163,7 @@ def test_callback_includes_reader_pid_and_user(server, tmp_path):
         )
     finally:
         p.terminate()
-        p.wait(timeout=5)
+        p.wait(timeout=AGENT_EXIT_TIMEOUT)
 
 
 def test_reading_the_fifo_fires_a_callback(server, tmp_path):
@@ -196,7 +203,7 @@ def test_reading_the_fifo_fires_a_callback(server, tmp_path):
         )
     finally:
         p.terminate()
-        p.wait(timeout=5)
+        p.wait(timeout=AGENT_EXIT_TIMEOUT)
 
 
 def test_clean_exit_removes_fifos(server, tmp_path):
@@ -226,7 +233,7 @@ def test_clean_exit_removes_fifos(server, tmp_path):
     )
     assert _wait(lambda: bait.exists())
     p.terminate()
-    p.wait(timeout=5)
+    p.wait(timeout=AGENT_EXIT_TIMEOUT)
     assert not bait.exists(), "FIFO left behind after clean exit"
 
 
@@ -292,7 +299,7 @@ def test_two_agents_one_host_both_detect(server, tmp_path):
         for p in procs:
             p.terminate()
         for p in procs:
-            p.wait(timeout=5)
+            p.wait(timeout=AGENT_EXIT_TIMEOUT)
 
 
 def test_duplicate_install_does_not_sweep_live_agents_fifo(server, tmp_path):
@@ -373,7 +380,7 @@ def test_duplicate_install_does_not_sweep_live_agents_fifo(server, tmp_path):
         )
     finally:
         p_a.terminate()
-        p_a.wait(timeout=5)
+        p_a.wait(timeout=AGENT_EXIT_TIMEOUT)
         import subprocess as _sp
 
         _sp.run(
@@ -421,7 +428,7 @@ def test_tampered_fifo_is_recovered(server, tmp_path):
         ), "tampered FIFO was not recovered - sensor left permanently blind"
     finally:
         p.terminate()
-        p.wait(timeout=5)
+        p.wait(timeout=AGENT_EXIT_TIMEOUT)
 
 
 def test_simulate_does_not_leave_a_no_reader_fifo(server, tmp_path):

--- a/tests/test_agent_live_sync.py
+++ b/tests/test_agent_live_sync.py
@@ -7,6 +7,7 @@ runs independently of the watcher, so the test is deterministic regardless of
 whether fs_usage is usable in CI.
 """
 import http.server
+import os
 import signal
 import subprocess
 import threading
@@ -20,12 +21,28 @@ BAIT_BODY = "BAIT-honeytoken-content"
 REAL_SECRET = "REAL-SECRET-DO-NOT-DELETE"
 
 
-# Teardown wait for the agent process to exit after SIGTERM. The exit trap
-# (stop_watcher -> pkill children, remove_fifos, cleanup_heartbeat, release
-# the singleton lock) spawns several helper subprocesses (ps/pkill/lsof);
-# on a loaded macOS CI runner that teardown can exceed a tight 5s and flake
-# the test (e.g. test_heartbeat_success_is_logged), so allow generous headroom.
+# Belt-and-suspenders teardown wait. The real shutdown fix is agent-side (the
+# FIFO supervisor no longer respawns a writer once a stop is signalled) plus
+# signalling the whole process group below; this generous timeout only guards
+# against unrelated slow-runner jitter so a legitimate exit is never cut short.
 AGENT_EXIT_TIMEOUT = 30
+
+
+def _term_group(p):
+    """SIGTERM the agent's whole process group, so no orphaned watcher/writer
+    child can survive to hold the stdout/stderr pipe open (which would hang a
+    communicate()). Safe because start() spawns each agent in its own session."""
+    try:
+        os.killpg(os.getpgid(p.pid), signal.SIGTERM)
+    except (ProcessLookupError, PermissionError):
+        p.send_signal(signal.SIGTERM)
+
+
+def _kill_group(p):
+    try:
+        os.killpg(os.getpgid(p.pid), signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        p.send_signal(signal.SIGKILL)
 
 class _StubHandler(http.server.BaseHTTPRequestHandler):
     deployments = []         # current set: [{"id","path"}]
@@ -108,7 +125,8 @@ def agent(tmp_path):
             ["sh", str(AGENT), "run", "--server", base,
              "--enroll-token", "dev-enroll-token", "--tripwire", "tw_test",
              "--state-file", str(state), *flags],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            start_new_session=True)  # own process group -> teardown can kill the whole tree
         procs.append(p)
         return p
 
@@ -121,11 +139,11 @@ def agent(tmp_path):
                "keep": keep, "drop": drop, "add": add}
     finally:
         for p in procs:
-            p.send_signal(signal.SIGTERM)
+            _term_group(p)
             try:
                 p.wait(timeout=AGENT_EXIT_TIMEOUT)
             except subprocess.TimeoutExpired:
-                p.send_signal(signal.SIGKILL)
+                _kill_group(p)
         httpd.shutdown()
 
 
@@ -251,7 +269,11 @@ def test_heartbeat_success_is_logged(agent):
     before = _StubHandler.heartbeats_ok
     assert _wait_until(lambda: _StubHandler.heartbeats_ok > before), "no heartbeat sent"
 
-    proc.send_signal(signal.SIGTERM)
+    # SIGTERM the whole group (not just the main pid): communicate() blocks
+    # until stdout/stderr reach EOF, so any watcher/writer child still holding
+    # the pipe would hang it. The agent-side fix stops the leak at the source;
+    # this makes the assertion robust even if a child lingers.
+    _term_group(proc)
     stdout, stderr = proc.communicate(timeout=AGENT_EXIT_TIMEOUT)
     assert "heartbeat succeeded" in stdout + stderr
 

--- a/tests/test_agent_live_sync.py
+++ b/tests/test_agent_live_sync.py
@@ -20,6 +20,13 @@ BAIT_BODY = "BAIT-honeytoken-content"
 REAL_SECRET = "REAL-SECRET-DO-NOT-DELETE"
 
 
+# Teardown wait for the agent process to exit after SIGTERM. The exit trap
+# (stop_watcher -> pkill children, remove_fifos, cleanup_heartbeat, release
+# the singleton lock) spawns several helper subprocesses (ps/pkill/lsof);
+# on a loaded macOS CI runner that teardown can exceed a tight 5s and flake
+# the test (e.g. test_heartbeat_success_is_logged), so allow generous headroom.
+AGENT_EXIT_TIMEOUT = 30
+
 class _StubHandler(http.server.BaseHTTPRequestHandler):
     deployments = []         # current set: [{"id","path"}]
     seen = []
@@ -116,7 +123,7 @@ def agent(tmp_path):
         for p in procs:
             p.send_signal(signal.SIGTERM)
             try:
-                p.wait(timeout=5)
+                p.wait(timeout=AGENT_EXIT_TIMEOUT)
             except subprocess.TimeoutExpired:
                 p.send_signal(signal.SIGKILL)
         httpd.shutdown()
@@ -245,7 +252,7 @@ def test_heartbeat_success_is_logged(agent):
     assert _wait_until(lambda: _StubHandler.heartbeats_ok > before), "no heartbeat sent"
 
     proc.send_signal(signal.SIGTERM)
-    stdout, stderr = proc.communicate(timeout=5)
+    stdout, stderr = proc.communicate(timeout=AGENT_EXIT_TIMEOUT)
     assert "heartbeat succeeded" in stdout + stderr
 
 


### PR DESCRIPTION
## Root cause (not a flake — a real shutdown bug)
The recurring macOS failure of `test_heartbeat_success_is_logged` looked like a slow-teardown flake, but the recovered CI log showed it **still hung at 30s** — so bumping the timeout was the wrong fix. The real cause is an agent shutdown race:

`stop_watcher` sets `WATCH_STOP_FLAG`, then `pkill`s the `serve_fifo` writers, then kills the supervisor. But the `watch_fifo` supervisor only checks the flag **once per second** at the top of its loop. If `pkill` lands mid-iteration, the supervisor sees the just-killed writer as "died" and **respawns `serve_fifo &`** *after* the stop was signalled. It's then killed, orphaning that fresh writer, which blocks forever in `open(O_WRONLY)` (no reader) and keeps the agent's `stdout`/`stderr` open. `communicate()` never reaches EOF → shutdown intermittently hangs.

**This also leaks a writer process + a held FIFO past a `SIGTERM`** — relevant to the ephemeral CI action's clean teardown, not just tests.

## Fix
1. **Agent** — re-check `WATCH_STOP_FLAG` immediately before respawning a writer, so a deliberate stop can never trigger a respawn. Legitimate mid-run crash recovery is unaffected (the flag only exists during a stop).
2. **Test (defence-in-depth)** — spawn each agent in its own session (`start_new_session=True`) and `SIGTERM` the whole **process group** on teardown, so no lingering child can hang a `communicate()` again. The `AGENT_EXIT_TIMEOUT = 30` constant stays only as jitter headroom, no longer load-bearing.

## Verification
- Previously-flaky `test_heartbeat_success_is_logged`: **10/10** under local stress (was intermittent).
- Full `test_agent_live_sync.py` + `test_agent_fifo.py` suites green (incl. FIFO writer-recovery — the guard doesn't break legitimate respawns).
- `sh -n` + ruff clean.