### PR TITLE
Close modals with Escape and focus dialog controls

### DIFF
--- a/ui/src/components/Modal.test.tsx
+++ b/ui/src/components/Modal.test.tsx
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { Modal } from "./ui.tsx";
+import "@testing-library/jest-dom/vitest";
+
+describe("<Modal> component", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("focuses the first dialog control and restores previous focus on close", () => {
+    const opener = document.createElement("button");
+    opener.textContent = "Open";
+    document.body.appendChild(opener);
+    opener.focus();
+
+    const { getByRole, unmount } = render(
+      <Modal onClose={() => {}}>
+        <button>Confirm</button>
+      </Modal>,
+    );
+
+    expect(getByRole("button", { name: "Confirm" })).toHaveFocus();
+
+    unmount();
+
+    expect(opener).toHaveFocus();
+    opener.remove();
+  });
+
+  it("keeps focus stable across onClose prop changes and uses the latest Escape handler", () => {
+    const firstClose = vi.fn();
+    const latestClose = vi.fn();
+
+    const { getByRole, rerender } = render(
+      <Modal onClose={firstClose}>
+        <button>First</button>
+        <button>Second</button>
+      </Modal>,
+    );
+
+    const first = getByRole("button", { name: "First" });
+    const second = getByRole("button", { name: "Second" });
+    expect(first).toHaveFocus();
+
+    second.focus();
+    rerender(
+      <Modal onClose={latestClose}>
+        <button>First</button>
+        <button>Second</button>
+      </Modal>,
+    );
+
+    expect(second).toHaveFocus();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(firstClose).not.toHaveBeenCalled();
+    expect(latestClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/components/ui.tsx
+++ b/ui/src/components/ui.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import type { ReactNode } from "react";
+import { useEffect, useRef, useState } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import type { AlertStatus, DeploymentState, EndpointStatus } from "../api";
 
 export function Topbar({ title, action }: { title: string; action?: ReactNode }) {
@@ -133,10 +133,49 @@ export function CopyField({ value }: { value: string }) {
   );
 }
 
-export function Modal({ children, onClose }: { children: ReactNode; onClose: () => void }) {
+const FOCUSABLE_SELECTOR = [
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "a[href]",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
+export function Modal({
+  children,
+  onClose,
+  style,
+}: {
+  children: ReactNode;
+  onClose: () => void;
+  style?: CSSProperties;
+}) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+
+    document.addEventListener("keydown", onKeyDown);
+    const target = dialogRef.current?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR) ?? dialogRef.current;
+    target?.focus();
+
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
   return (
     <div className="modal-backdrop" onClick={onClose}>
-      <div className="card modal-card" onClick={(e) => e.stopPropagation()}>
+      <div
+        ref={dialogRef}
+        className="card modal-card"
+        role="dialog"
+        aria-modal="true"
+        tabIndex={-1}
+        style={style}
+        onClick={(e) => e.stopPropagation()}
+      >
         {children}
       </div>
     </div>

--- a/ui/src/components/ui.tsx
+++ b/ui/src/components/ui.tsx
@@ -152,18 +152,28 @@ export function Modal({
   style?: CSSProperties;
 }) {
   const dialogRef = useRef<HTMLDivElement>(null);
+  const onCloseRef = useRef(onClose);
 
   useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  useEffect(() => {
+    const previouslyFocused = document.activeElement;
+
     function onKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") onCloseRef.current();
     }
 
     document.addEventListener("keydown", onKeyDown);
     const target = dialogRef.current?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR) ?? dialogRef.current;
     target?.focus();
 
-    return () => document.removeEventListener("keydown", onKeyDown);
-  }, [onClose]);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      if (previouslyFocused instanceof HTMLElement) previouslyFocused.focus();
+    };
+  }, []);
 
   return (
     <div className="modal-backdrop" onClick={onClose}>

--- a/ui/src/pages/EndpointDetail.tsx
+++ b/ui/src/pages/EndpointDetail.tsx
@@ -3,18 +3,8 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 import { Trash2 } from "lucide-react";
 import type { EndpointDetail as ED, Tripwire } from "../api";
 import { api, ApiError } from "../api";
-import { DeployBadge, EndpointBadge, TimeAgo, Topbar } from "../components/ui.tsx";
+import { DeployBadge, EndpointBadge, Modal, TimeAgo, Topbar } from "../components/ui.tsx";
 import PageTitle from "../components/PageTitle.tsx";
-
-function Modal({ children, onClose }: { children: React.ReactNode; onClose: () => void }) {
-  return (
-    <div className="modal-backdrop" onClick={onClose}>
-      <div className="card modal-card" onClick={(e) => e.stopPropagation()}>
-        {children}
-      </div>
-    </div>
-  );
-}
 
 export default function EndpointDetail() {
   const { id = "" } = useParams();

--- a/ui/src/pages/Integrations.tsx
+++ b/ui/src/pages/Integrations.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import type { Integration, IntegrationTestResult, PluginManifest } from "../api";
 import { api } from "../api";
-import { TimeAgo, Topbar } from "../components/ui.tsx";
+import { Modal, TimeAgo, Topbar } from "../components/ui.tsx";
 import PageTitle from "../components/PageTitle.tsx";
 
 export default function Integrations() {
@@ -256,12 +256,7 @@ function ConfigModal({
   }
 
   return (
-    <div className="modal-backdrop" onClick={onClose}>
-      <div
-        className="card modal-card"
-        style={{ width: 480 }}
-        onClick={(e) => e.stopPropagation()}
-      >
+    <Modal onClose={onClose} style={{ width: 480 }}>
         <div className="card-head">
           <h2>Configure {manifest.display_name}</h2>
           <span className="type-tag">{manifest.kind}</span>
@@ -333,7 +328,6 @@ function ConfigModal({
             Cancel
           </button>
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 }

--- a/ui/src/pages/Integrations.tsx
+++ b/ui/src/pages/Integrations.tsx
@@ -257,77 +257,77 @@ function ConfigModal({
 
   return (
     <Modal onClose={onClose} style={{ width: 480 }}>
-        <div className="card-head">
-          <h2>Configure {manifest.display_name}</h2>
-          <span className="type-tag">{manifest.kind}</span>
-        </div>
-        <p className="modal-intro">{manifest.description}</p>
-        {manifest.config_schema.map((f) => {
-          const secretKept = f.type === "secret" && Boolean(current?.config?.[f.key]);
-          return (
-            <div className="field" key={f.key}>
-              <label>
-                <span>{f.label}</span>
-                <span className={`field-tag ${f.required ? "required" : "optional"}`}>
-                  {f.required ? "Required" : "Optional"}
-                </span>
-              </label>
-              <input
-                type={f.type === "secret" && !revealed[f.key] ? "password" : "text"}
-                placeholder={secretKept ? "•••••• - leave blank to keep current" : f.placeholder}
-                value={values[f.key] ?? ""}
-                onChange={(e) => setValues({ ...values, [f.key]: e.target.value })}
-              />
-              {f.generate && (
-                <div className="row field-actions">
-                  <button type="button" className="btn small" onClick={() => generateSecret(f.key)}>
-                    Generate
-                  </button>
+      <div className="card-head">
+        <h2>Configure {manifest.display_name}</h2>
+        <span className="type-tag">{manifest.kind}</span>
+      </div>
+      <p className="modal-intro">{manifest.description}</p>
+      {manifest.config_schema.map((f) => {
+        const secretKept = f.type === "secret" && Boolean(current?.config?.[f.key]);
+        return (
+          <div className="field" key={f.key}>
+            <label>
+              <span>{f.label}</span>
+              <span className={`field-tag ${f.required ? "required" : "optional"}`}>
+                {f.required ? "Required" : "Optional"}
+              </span>
+            </label>
+            <input
+              type={f.type === "secret" && !revealed[f.key] ? "password" : "text"}
+              placeholder={secretKept ? "•••••• - leave blank to keep current" : f.placeholder}
+              value={values[f.key] ?? ""}
+              onChange={(e) => setValues({ ...values, [f.key]: e.target.value })}
+            />
+            {f.generate && (
+              <div className="row field-actions">
+                <button type="button" className="btn small" onClick={() => generateSecret(f.key)}>
+                  Generate
+                </button>
+                <button
+                  type="button"
+                  className="btn small"
+                  disabled={!values[f.key]}
+                  onClick={() => copyKey(f.key)}
+                >
+                  {copied === f.key ? "Copied ✓" : "Copy"}
+                </button>
+                {f.type === "secret" && values[f.key] && (
                   <button
                     type="button"
                     className="btn small"
-                    disabled={!values[f.key]}
-                    onClick={() => copyKey(f.key)}
+                    onClick={() => setRevealed((r) => ({ ...r, [f.key]: !r[f.key] }))}
                   >
-                    {copied === f.key ? "Copied ✓" : "Copy"}
+                    {revealed[f.key] ? "Hide" : "Show"}
                   </button>
-                  {f.type === "secret" && values[f.key] && (
-                    <button
-                      type="button"
-                      className="btn small"
-                      onClick={() => setRevealed((r) => ({ ...r, [f.key]: !r[f.key] }))}
-                    >
-                      {revealed[f.key] ? "Hide" : "Show"}
-                    </button>
-                  )}
-                </div>
-              )}
-              {f.help && <div className="help">{f.help}</div>}
-            </div>
-          );
-        })}
-        {manifest.kind === "alert" && (
-          <div className="field">
-            <label>
-              <span>Example alert</span>
-              <span className="field-tag optional">JSON</span>
-            </label>
-            <pre className="code-block">{JSON.stringify(SAMPLE_ALERT, null, 2)}</pre>
-            <div className="help">
-              The event every alert integration receives when a tripwire fires - the
-              webhook delivers exactly this as the POST body (HMAC-signed when a
-              signing secret is set).
-            </div>
+                )}
+              </div>
+            )}
+            {f.help && <div className="help">{f.help}</div>}
           </div>
-        )}
-        <div className="row" style={{ marginTop: 6 }}>
-          <button className="btn primary" disabled={saving || missingRequired} onClick={save}>
-            {saving ? "Saving…" : "Save"}
-          </button>
-          <button className="btn" onClick={onClose}>
-            Cancel
-          </button>
+        );
+      })}
+      {manifest.kind === "alert" && (
+        <div className="field">
+          <label>
+            <span>Example alert</span>
+            <span className="field-tag optional">JSON</span>
+          </label>
+          <pre className="code-block">{JSON.stringify(SAMPLE_ALERT, null, 2)}</pre>
+          <div className="help">
+            The event every alert integration receives when a tripwire fires - the
+            webhook delivers exactly this as the POST body (HMAC-signed when a
+            signing secret is set).
+          </div>
         </div>
+      )}
+      <div className="row" style={{ marginTop: 6 }}>
+        <button className="btn primary" disabled={saving || missingRequired} onClick={save}>
+          {saving ? "Saving…" : "Save"}
+        </button>
+        <button className="btn" onClick={onClose}>
+          Cancel
+        </button>
+      </div>
     </Modal>
   );
 }


### PR DESCRIPTION
## Summary
- add Escape key handling to the shared Modal component
- focus the first available dialog control, or the dialog itself as a fallback
- reuse the shared Modal for endpoint and integration dialogs

Closes #168

## Tests
- npm test
- npm run build