### PR TITLE
Show endpoint platform badges

### DIFF
--- a/ui/src/components/ui.tsx
+++ b/ui/src/components/ui.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import type { ReactNode } from "react";
+import { Monitor } from "lucide-react";
 import type { AlertStatus, DeploymentState, EndpointStatus } from "../api";
 
 export function Topbar({ title, action }: { title: string; action?: ReactNode }) {
@@ -81,6 +82,24 @@ export function EndpointBadge({ status }: { status: EndpointStatus }) {
   return (
     <span className={`badge ${cls}`}>
       <span className="dot" /> {status}
+    </span>
+  );
+}
+
+function platformLabel(platform: string | null): string {
+  if (!platform) return "unknown";
+  const normalized = platform.toLowerCase();
+  if (normalized === "darwin") return "macOS";
+  if (normalized === "win32" || normalized === "windows") return "Windows";
+  if (normalized === "linux") return "Linux";
+  return platform;
+}
+
+export function PlatformBadge({ platform }: { platform: string | null }) {
+  return (
+    <span className="platform-badge" title={platform ?? "unknown platform"}>
+      <Monitor size={13} aria-hidden="true" />
+      {platformLabel(platform)}
     </span>
   );
 }

--- a/ui/src/pages/EndpointDetail.tsx
+++ b/ui/src/pages/EndpointDetail.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 import { Trash2 } from "lucide-react";
 import type { EndpointDetail as ED, Tripwire } from "../api";
 import { api, ApiError } from "../api";
-import { DeployBadge, EndpointBadge, TimeAgo, Topbar } from "../components/ui.tsx";
+import { DeployBadge, EndpointBadge, PlatformBadge, TimeAgo, Topbar } from "../components/ui.tsx";
 import PageTitle from "../components/PageTitle.tsx";
 
 function Modal({ children, onClose }: { children: React.ReactNode; onClose: () => void }) {
@@ -119,7 +119,7 @@ export default function EndpointDetail() {
         <div className="card">
           <div className="row" style={{ gap: 10 }}>
             <EndpointBadge status={ep.status} />
-            <span className="muted">{ep.platform ?? "unknown platform"}</span>
+            <PlatformBadge platform={ep.platform} />
             <span className="muted">enrolled <TimeAgo iso={ep.enrolled_at} /></span>
             <span className="muted">last seen {ep.last_seen ? <TimeAgo iso={ep.last_seen} /> : "-"}</span>
           </div>

--- a/ui/src/pages/Endpoints.tsx
+++ b/ui/src/pages/Endpoints.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import type { Endpoint } from "../api";
 import { api } from "../api";
-import { EndpointBadge, TimeAgo, Topbar } from "../components/ui.tsx";
+import { EndpointBadge, PlatformBadge, TimeAgo, Topbar } from "../components/ui.tsx";
 import PageTitle from "../components/PageTitle.tsx";
 
 export default function Endpoints() {
@@ -45,7 +45,7 @@ export default function Endpoints() {
                 {endpoints.map((e) => (
                   <tr key={e.id} className="clickable-row" onClick={() => nav(`/endpoints/${e.id}`)}>
                     <td>{e.hostname}</td>
-                    <td className="muted">{e.platform ?? "-"}</td>
+                    <td><PlatformBadge platform={e.platform} /></td>
                     <td className="muted"><TimeAgo iso={e.enrolled_at} /></td>
                     <td className="muted">{e.last_seen ? <TimeAgo iso={e.last_seen} /> : "-"}</td>
                     <td>{e.deployment_count}</td>

--- a/ui/src/styles/app.css
+++ b/ui/src/styles/app.css
@@ -203,6 +203,13 @@ tr.clickable:hover td { background: var(--bg-elev2); cursor: pointer; }
 .badge.failed, .badge.unknown,
 .badge.triggered { background: rgba(255, 93, 93, 0.12); color: var(--danger); border-color: rgba(255, 93, 93, 0.28); }
 .badge.resolved { background: rgba(139, 148, 168, 0.10); color: var(--text-dim); border-color: var(--border); }
+.platform-badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  height: 24px; padding: 0 8px; border-radius: 999px;
+  border: 1px solid var(--border); color: var(--text-dim);
+  background: var(--bg-elev); font-size: 12px; font-weight: 600;
+}
+.platform-badge svg { color: var(--text-faint); }
 
 /* segmented filter (alert status: open / all / resolved) */
 .seg { display: inline-flex; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }


### PR DESCRIPTION
## Summary
- add a reusable PlatformBadge for endpoint platform values
- show normalized platform labels with an icon in the Endpoints table
- reuse the badge on the endpoint detail summary

Closes #167

## Tests
- npm test
- npm run build