### PR TITLE
docs: sync token type list across CHANGELOG, checklist, and UI union

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Initial release: control-plane server, endpoint agent, dashboard UI, and the plu
 - **Server**: FastAPI control plane with SQLite/Postgres/MySQL support via SQLAlchemy + Alembic, and signed tripwire-trigger callbacks with replay protection.
 - **Agent**: standalone Bash endpoint agent (`agent/thumper_agent.sh`, curl + openssl only, no Python dependency) that plants honeytoken files and reports reads back to the server.
 - **UI**: React/Vite dashboard for creating tripwires, managing the enrolled endpoint fleet, and viewing the live alert feed.
-- **Honeytoken types**: six built-in types — `aws`, `github`, `npm`, `gcp`, `azure`, `ssh`. Each generated with a realistic-but-non-functional credential shape.
+- **Honeytoken types**: seven built-in types — `aws`, `github`, `npm`, `docker`, `gcp`, `azure`, `ssh`. Each generated with a realistic-but-non-functional credential shape.
 - **Alert plugins**: generic webhook, Splunk (HEC), Loki.
 - **Deploy plugins**: SSH (direct) and MDM (Jamf Pro).
 - **Deployment**: single Docker image (`docker compose up --build`) and a Helm chart for Kubernetes (`deploy/helm/thumper`).

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -107,3 +107,4 @@ pytest -v
 - [ ] `generator.py` — matching `if token_type == "..."` branch added
 - [ ] `tests/test_tripwire_content.py` — new test added
 - [ ] `pytest -v` passes
+- [ ] `CHANGELOG.md` — bump the "N built-in types" count and add the new type to the list

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -1,7 +1,7 @@
 // These types mirror the FastAPI backend's response models. Keep them in sync
 // with server/thumper/models.py - this is the contract between UI and server.
 
-export type TokenType = "aws" | "github" | "gcp" | "azure" | "ssh";
+export type TokenType = "aws" | "github" | "npm" | "docker" | "gcp" | "azure" | "ssh";
 
 /** Where the bait content comes from. Only "template" is active in v1; the
  *  others are wired in the UI as coming-soon. */


### PR DESCRIPTION
<!-- Tip: PR/commit titles in this repo tend to use a "type: description" style, e.g. "fix: ...", "docs: ...", "feat: ..." -->

## Summary

Fixes a token-type-list sync gap flagged during #206's review: #207 added `docker` (catalog.py/generator.py now ship seven types), but three places that mirror that list didn't catch up: `CHANGELOG.md`, `docs/tokens.md`'s checklist, and the UI's `TokenType` union.

Closes # (no filed issue, self-identified follow-up from LiorFink00's review comment on #206)

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Docs
- [ ] Refactor / internal (no user-facing change)
- [ ] Other:

## Checklist

- [x] `pytest -v` passes locally (`pip install -e ".[dev]"` first — see [CONTRIBUTING.md](https://github.com/jestasecurity/thumper/blob/main/CONTRIBUTING.md))
- [x] For UI changes: verified with `cd ui && npm install && npm run dev`
- [ ] For a new/changed plugin: follows [docs/plugins.md](https://github.com/jestasecurity/thumper/blob/main/docs/plugins.md)
- [ ] For a new honeytoken type: follows [docs/tokens.md](https://github.com/jestasecurity/thumper/blob/main/docs/tokens.md)
- [ ] Added a one-line entry under `## [Unreleased]` in [CHANGELOG.md](https://github.com/jestasecurity/thumper/blob/main/CHANGELOG.md) (skip for internal-only changes)
- [x] PR is scoped to the linked issue — no unrelated changes

## Testing notes
Applied all three changes to a fresh clone of `main` and verified:
- `pytest -v` → 340 passed, 13 skipped (pre-existing), 0 failed.
- `cd ui && npx tsc --noEmit` → 0 errors, confirming the widened `TokenType` union doesn't break any exhaustive match elsewhere in the codebase (there is none, checked via grep before this PR, confirmed via the compiler now).
<!-- How did you verify this? Manual steps, new/updated tests, edge cases considered. -->
