### PR TITLE
test: pair manifest name to kind explicitly

### DIFF
--- a/tests/test_manifests_api.py
+++ b/tests/test_manifests_api.py
@@ -5,12 +5,9 @@ def test_manifests_lists_known_plugins(client_db):
     tc, _ = client_db
     resp = tc.get("/api/manifests")
     assert resp.status_code == 200
-    body = resp.json()
-    names = {m["name"] for m in body}
-    assert "webhook" in names
-    assert "ssh" in names
-    assert any(m["kind"] == "deploy" for m in body)
-    assert any(m["kind"] == "alert" for m in body)
+    by_name = {m["name"]: m for m in resp.json()}
+    assert by_name["webhook"]["kind"] == "alert"
+    assert by_name["ssh"]["kind"] == "deploy"
 
 
 def test_manifests_strips_internal_fields(client_db):


### PR DESCRIPTION
## Summary

Tightens `test_manifests_lists_known_plugins` to pair each plugin name to its expected `kind` directly, instead of checking existence and kind separately. Non-blocking follow-up LiorFink00 flagged when approving #212.

Closes # (no filed issue, optional tightening from #212's review)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs
- [x] Refactor / internal (no user-facing change)
- [ ] Other:

## Checklist

- [x] `pytest -v` passes locally (`pip install -e ".[dev]"` first — see [CONTRIBUTING.md](https://github.com/jestasecurity/thumper/blob/main/CONTRIBUTING.md))
- [ ] For UI changes: verified with `cd ui && npm install && npm run dev`
- [ ] For a new/changed plugin: follows [docs/plugins.md](https://github.com/jestasecurity/thumper/blob/main/docs/plugins.md)
- [ ] For a new honeytoken type: follows [docs/tokens.md](https://github.com/jestasecurity/thumper/blob/main/docs/tokens.md)
- [ ] Added a one-line entry under `## [Unreleased]` in [CHANGELOG.md](https://github.com/jestasecurity/thumper/blob/main/CHANGELOG.md) (skip for internal-only changes)
- [x] PR is scoped to the linked issue — no unrelated changes

## Testing notes

`pytest -v` on a fresh clone: 340 passed, 13 skipped (pre-existing), 0 failed.

Note unrelated to this PR: a stray `pytest-randomly` plugin in my local env randomized test order and surfaced a pre-existing order-dependent flake in `test_endpoint_ephemeral.py::test_get_endpoints_does_not_list_stale_ephemeral` (passes in isolation, passes with default ordering). Not touched here since it's outside this PR's scope, flagging in case it's worth its own issue.
