### PR TITLE
Add GitLab PAT honeytoken type

### DIFF
--- a/server/thumper/tokens/catalog.py
+++ b/server/thumper/tokens/catalog.py
@@ -37,6 +37,19 @@ TOKEN_TYPES = [
                        "exfiltrates these to self-replicate via the API.",
     },
     {
+        "type": "gitlab",
+        "display_name": "GitLab PAT",
+        "default_path": "~/.config/glab-cli/config.yml",
+        "suggested_paths": [
+            "~/.config/glab-cli/config.yml",
+            "~/.python-gitlab.cfg",
+            "~/.git-credentials",
+            "~/.env",
+        ],
+        "description": "Fake GitLab personal access token. CI/dev workstations often "
+                       "store these for repository and pipeline automation.",
+    },
+    {
         "type": "npm",
         "display_name": "npm token",
         "default_path": "~/.npmrc",

--- a/server/thumper/tokens/generator.py
+++ b/server/thumper/tokens/generator.py
@@ -52,6 +52,13 @@ def generate_token(token_type: str) -> str:
             "  user: ci-deploy-bot\n"
         )
 
+    if token_type == "gitlab":
+        return (
+            "gitlab.com:\n"
+            f"  token: glpat-{rand_alnum(20)}\n"
+            "  user: ci-deploy-bot\n"
+        )
+
     if token_type == "npm":
         return f"//registry.npmjs.org/:_authToken=npm_{rand_alnum(36)}\n"
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -51,6 +51,14 @@ def test_generate_github_token_has_oauth_file_shape():
     assert "user: ci-deploy-bot" in token
 
 
+def test_generate_gitlab_token_has_pat_file_shape():
+    token = generate_token("gitlab")
+
+    assert "gitlab.com:" in token
+    assert "token: glpat-" in token
+    assert "user: ci-deploy-bot" in token
+
+
 def test_generate_npm_token_has_npmrc_shape():
     token = generate_token("npm")
 

--- a/tests/test_tripwire_content.py
+++ b/tests/test_tripwire_content.py
@@ -60,6 +60,21 @@ def test_post_tripwire_generates_npmrc_token(client_db):
     assert row.token.startswith("//registry.npmjs.org/:_authToken=npm_")
 
 
+def test_post_tripwire_generates_gitlab_pat(client_db):
+    tc, db = client_db
+    resp = tc.post("/api/tripwires", json={
+        "name": "gitlab-bait", "token_type": "gitlab",
+        "path": "~/.config/glab-cli/config.yml", "source": "template",
+    })
+    assert resp.status_code == 200
+    tid = resp.json()["id"]
+
+    db.expire_all()
+    row = store.get_tripwire(db, tid)
+    assert row.token is not None
+    assert "glpat-" in row.token
+
+
 def test_post_tripwire_generates_docker_config_token(client_db):
     tc, db = client_db
     resp = tc.post("/api/tripwires", json={


### PR DESCRIPTION
## Summary
- add GitLab PAT to the token catalog
- generate glpat-style honeytokens in a glab-compatible config shape
- cover generator and tripwire creation paths

Closes #117

## Tests
- uv run --extra dev pytest tests/test_generator.py tests/test_tripwire_content.py
- uv run --extra dev pytest