### PR TITLE
Add modal keyboard focus handling

### DIFF
--- a/ui/src/components/Modal.test.tsx
+++ b/ui/src/components/Modal.test.tsx
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { Modal } from "./ui.tsx";
+
+describe("<Modal> component", () => {
+  afterEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+  });
+
+  it("focuses the dialog and closes on Escape", () => {
+    const onClose = vi.fn();
+
+    render(
+      <Modal onClose={onClose}>
+        <h2>Confirm action</h2>
+      </Modal>
+    );
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveFocus();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("restores focus when unmounted", () => {
+    const priorButton = document.createElement("button");
+    document.body.appendChild(priorButton);
+    priorButton.focus();
+
+    const { unmount } = render(
+      <Modal onClose={() => {}}>
+        <h2>Confirm action</h2>
+      </Modal>
+    );
+
+    expect(screen.getByRole("dialog")).toHaveFocus();
+
+    unmount();
+
+    expect(priorButton).toHaveFocus();
+  });
+});

--- a/ui/src/components/ui.tsx
+++ b/ui/src/components/ui.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import type { AlertStatus, DeploymentState, EndpointStatus } from "../api";
 
@@ -134,9 +134,42 @@ export function CopyField({ value }: { value: string }) {
 }
 
 export function Modal({ children, onClose }: { children: ReactNode; onClose: () => void }) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const onCloseRef = useRef(onClose);
+
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  useEffect(() => {
+    const previousFocus = document.activeElement;
+    cardRef.current?.focus({ preventScroll: true });
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        onCloseRef.current();
+      }
+    }
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      if (previousFocus instanceof HTMLElement) {
+        previousFocus.focus({ preventScroll: true });
+      }
+    };
+  }, []);
+
   return (
     <div className="modal-backdrop" onClick={onClose}>
-      <div className="card modal-card" onClick={(e) => e.stopPropagation()}>
+      <div
+        ref={cardRef}
+        className="card modal-card"
+        role="dialog"
+        aria-modal="true"
+        tabIndex={-1}
+        onClick={(e) => e.stopPropagation()}
+      >
         {children}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- focus the modal dialog when it opens
- close modals on Escape and restore the previously focused element on unmount
- add modal behavior coverage with React Testing Library

Closes #168

## Tests
- npm test -- src/components/Modal.test.tsx src/components/PageTitle.test.tsx
- npm run build