### PR TITLE
docs: sync the gitlab token type across CHANGELOG, docs, and the TS union

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - Docker registry credentials honeytoken type for `~/.docker/config.json`.
+- GitLab personal access token honeytoken type for `~/.config/glab-cli/config.yml`.
 - Added absolute local-time tooltips to relative timestamps in the dashboard UI.
 
 ### Changed
@@ -26,7 +27,7 @@ Initial release: control-plane server, endpoint agent, dashboard UI, and the plu
 - **Server**: FastAPI control plane with SQLite/Postgres/MySQL support via SQLAlchemy + Alembic, and signed tripwire-trigger callbacks with replay protection.
 - **Agent**: standalone Bash endpoint agent (`agent/thumper_agent.sh`, curl + openssl only, no Python dependency) that plants honeytoken files and reports reads back to the server.
 - **UI**: React/Vite dashboard for creating tripwires, managing the enrolled endpoint fleet, and viewing the live alert feed.
-- **Honeytoken types**: seven built-in types — `aws`, `github`, `npm`, `docker`, `gcp`, `azure`, `ssh`. Each generated with a realistic-but-non-functional credential shape.
+- **Honeytoken types**: eight built-in types — `aws`, `github`, `gitlab`, `npm`, `docker`, `gcp`, `azure`, `ssh`. Each generated with a realistic-but-non-functional credential shape.
 - **Alert plugins**: generic webhook, Splunk (HEC), Loki.
 - **Deploy plugins**: SSH (direct) and MDM (Jamf Pro).
 - **Deployment**: single Docker image (`docker compose up --build`) and a Helm chart for Kubernetes (`deploy/helm/thumper`).

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -1,6 +1,6 @@
 # Adding a honeytoken type
 
-Thumper ships with seven built-in token types (`aws`, `github`, `npm`, `docker`, `gcp`, `azure`, `ssh`). Adding a new one touches exactly two files and one test, and both files must stay in sync or the API will accept the type name but fail to generate content.
+Thumper ships with eight built-in token types (`aws`, `github`, `gitlab`, `npm`, `docker`, `gcp`, `azure`, `ssh`). Adding a new one touches exactly two files and one test, and both files must stay in sync or the API will accept the type name but fail to generate content.
 
 ## The two touch points
 

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -1,7 +1,7 @@
 // These types mirror the FastAPI backend's response models. Keep them in sync
 // with server/thumper/models.py - this is the contract between UI and server.
 
-export type TokenType = "aws" | "github" | "npm" | "docker" | "gcp" | "azure" | "ssh";
+export type TokenType = "aws" | "github" | "gitlab" | "npm" | "docker" | "gcp" | "azure" | "ssh";
 
 /** Where the bait content comes from. Only "template" is active in v1; the
  *  others are wired in the UI as coming-soon. */


### PR DESCRIPTION
Follow-up to #219 (merged), which added the GitLab PAT honeytoken to `catalog.py`/`generator.py` (8th type, inserted after `github`) but not to the three mirror files — so they drifted:

- `docs/tokens.md` and `CHANGELOG.md` still said **seven** built-in types
- the `TokenType` union in `ui/src/api/types.ts` omitted `gitlab` (the API accepted `"gitlab"` at runtime, but the TS type didn't)

This adds `gitlab` in catalog order to the union, bumps both counts to **eight**, and adds an `[Unreleased]` changelog entry. The union now matches `TOKEN_TYPES` exactly: `aws, github, gitlab, npm, docker, gcp, azure, ssh`.

Docs/types only — no code change. This is the same drift #217 fixed for `npm`/`docker`; closing it out for `gitlab`.

---
Relates to #117 (the GitLab PAT honeytoken type whose mirror files this syncs).