### PR TITLE
Run UI tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,10 @@ jobs:
         run: npm run build
         working-directory: ui
 
+      - name: Run UI tests
+        run: npm run test
+        working-directory: ui
+
   docker-build:
     # Build the monolith image so base-image bumps and Dockerfile breakage are
     # caught in CI rather than at deploy time (#148).


### PR DESCRIPTION
## Summary
- run the existing Vitest suite in the UI CI job after the production build
- keeps the check close to `npm ci`/`npm run build` so UI test regressions fail pull requests

Closes #158.

## Tests
- `npm run test`
- `npm run build`