### PR TITLE
Relax heartbeat log shutdown wait

### DIFF
--- a/tests/test_agent_live_sync.py
+++ b/tests/test_agent_live_sync.py
@@ -245,7 +245,7 @@ def test_heartbeat_success_is_logged(agent):
     assert _wait_until(lambda: _StubHandler.heartbeats_ok > before), "no heartbeat sent"
 
     proc.send_signal(signal.SIGTERM)
-    stdout, stderr = proc.communicate(timeout=5)
+    stdout, stderr = proc.communicate(timeout=15)
     assert "heartbeat succeeded" in stdout + stderr
 
 


### PR DESCRIPTION
## Summary
- give the heartbeat logging live-sync test a longer shutdown window after SIGTERM
- avoids failing the macOS matrix when the agent exits slightly slower under CI load

This came up as a macOS-only timeout in an otherwise unrelated UI-test PR.

## Tests
- `.venv/bin/pytest -q tests/test_agent_live_sync.py::test_heartbeat_success_is_logged`
- `.venv/bin/ruff check tests/test_agent_live_sync.py`