### PR TITLE
test(agent): de-flake the atime tests (read-before-baseline race)

### DIFF
--- a/tests/test_agent_atime.py
+++ b/tests/test_agent_atime.py
@@ -147,6 +147,12 @@ def test_atime_sensor_is_rearmable(server, tmp_path):
         assert _wait(lambda: bait.exists() and _atime(bait) < ARMED_MAX), (
             "bait not planted+armed"
         )
+        # Let the INITIAL arm+baseline settle before read #1 - same two-step race as
+        # the re-arm settle below. atime_poll arms then reads the baseline, and the
+        # "armed" gate above trips on the arm; a read landing before the baseline read
+        # is captured AS the baseline and missed. A real reader hits a steady-state
+        # agent, not this startup window (closed a ~8% macOS flake).
+        time.sleep(2)
         # simulate read #1: bump atime forward (what a real read does under relatime)
         os.utime(bait, (time.time(), os.stat(bait).st_mtime))
         assert _wait(lambda: _atime_hits() >= 1), "read #1 was not detected"

--- a/tests/test_agent_mixed.py
+++ b/tests/test_agent_mixed.py
@@ -144,6 +144,11 @@ def test_mixed_sensors_plant_and_fire_together(server, tmp_path):
         ), "atime-sensor bait was not planted as an armed regular file"
         # read the FIFO bait (blocks until the agent serves it) -> fires with pid
         threading.Thread(target=lambda: open(fifo).read(), daemon=True).start()
+        # Let the atime baseline settle before bumping it: watch_mixed's atime_poll
+        # arms then reads the baseline, and the armed gate above trips on the arm, so
+        # a read landing in that window is captured as the baseline and missed. A real
+        # reader hits a steady-state agent, not this startup window (macOS flake).
+        time.sleep(2)
         # 'read' the atime bait -> fires (detection)
         os.utime(atin, (time.time(), os.stat(atin).st_mtime))
         assert _wait(lambda: _fired("/cb/dep_fifo")), "FIFO bait did not fire"


### PR DESCRIPTION
## Problem
Now that the atime sensor (#160) is on `main`, its two macOS tests flake intermittently (~8% locally, likely higher on CI):
- `test_agent_atime.py::test_atime_sensor_is_rearmable`
- `test_agent_mixed.py::test_mixed_sensors_plant_and_fire_together`

## Root cause
`atime_poll` **arms** the bait (atime → year-2000) and then **reads the baseline** in two steps, with a `stat` subprocess between. The tests' "bait is armed" gate (`st_atime < ARMED_MAX`) trips on the *arm*, and the tests then immediately simulate read #1 (`os.utime` bump). If that bump lands before the baseline read, it's captured **as** the baseline and never fires → read #1 is missed.

The re-arm before read #2 already had a `time.sleep(2)` settle for exactly this reason; read #1 (and the mixed test's atime bump) just never got the symmetric one.

## Fix
Add the matching settle before read #1 / the mixed atime bump. **Test-only** — a real reader hits a steady-state agent, never this sub-second startup window, so there's no product change.

## Verification
`test_atime_sensor_is_rearmable`: **0/20** under local stress (was ~1-2/12). Same fix applied to the mixed test's identical race.

This removes the last known flake source on `main` (the heartbeat flake was fixed in #213).

---
Relates to #235 (the arm→baseline race this de-flakes on the test side) and #237 (the startup-timing flake class).