### PR TITLE
docs: fix the signed-callback link cut by its label in architecture.svg

### DIFF
--- a/assets/architecture.svg
+++ b/assets/architecture.svg
@@ -44,7 +44,7 @@
   <g><rect class="lbl-bg" x="300" y="200" width="54" height="17"/><text class="llabel" x="307" y="213">HTTPS</text></g>
   <g><rect class="lbl-bg" x="744" y="176" width="150" height="17"/><text class="llabel" x="751" y="189">enroll · deploy spec</text></g>
   <g><rect class="lbl-bg" x="610" y="342" width="92" height="17"/><text class="llabel" x="617" y="355">alert fan-out</text></g>
-  <g><rect class="lbl-bg" x="735" y="296" width="104" height="17"/><text class="llabel" x="742" y="309" fill="#ff8a8a">signed callback</text></g>
+  <g><rect class="lbl-bg" x="735" y="286" width="104" height="17"/><text class="llabel" x="742" y="299" fill="#ff8a8a">signed callback</text></g>
 
   <!-- UI node -->
   <rect class="node" x="72" y="170" width="186" height="150" rx="11"/>


### PR DESCRIPTION
The red **signed callback** connector in `assets/architecture.svg` renders with a gap in the middle: its horizontal segment runs at `y=312`, but the label's opaque background box (`.lbl-bg`, `fill:#07090e`) was positioned at `y=296–313` — right on top of that segment — so it painted over the line.

Every other connector label (HTTPS, enroll · deploy spec, alert fan-out) sits ~11px *above* its line. This lifts the `signed callback` label to match (`y=296 → 286`), so the red link is continuous.

One-line change; before/after rendered and verified.

---
Closes #278.