### PR TITLE
ci: cancel duplicate PR workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add a CI concurrency group keyed by PR number when available
- cancel older in-progress CI runs for the same PR/ref so push + pull_request does not keep duplicate jobs alive

Fixes #236.

## Testing
- Verified the concurrency stanza is present in .github/workflows/ci.yml
- git diff --check