### PR TITLE
fix: warn on default admin token

### DIFF
--- a/server/thumper/config.py
+++ b/server/thumper/config.py
@@ -98,19 +98,27 @@ INSTALL_TOKEN = os.environ.get("THUMPER_INSTALL_TOKEN", _DEFAULT_INSTALL_TOKEN)
 # served open - a dev default would just recreate the no-auth hole. Set
 # THUMPER_ADMIN_TOKEN to a random secret to enable the dashboard/API.
 ADMIN_TOKEN = os.environ.get("THUMPER_ADMIN_TOKEN", "")
+_DEFAULT_ADMIN_TOKEN = "dev-admin-token"
 
 
-def insecure_default_tokens(enroll: str | None = None, install: str | None = None) -> list[str]:
+def insecure_default_tokens(
+    enroll: str | None = None,
+    install: str | None = None,
+    admin: str | None = None,
+) -> list[str]:
     """Names of the shared tokens still set to their built-in dev defaults.
     Used to warn loudly at startup so a production deploy doesn't silently run
     with publicly-known credentials."""
     enroll = ENROLL_TOKEN if enroll is None else enroll
     install = INSTALL_TOKEN if install is None else install
+    admin = ADMIN_TOKEN if admin is None else admin
     flagged = []
     if enroll == _DEFAULT_ENROLL_TOKEN:
         flagged.append("THUMPER_ENROLL_TOKEN")
     if install == _DEFAULT_INSTALL_TOKEN:
         flagged.append("THUMPER_INSTALL_TOKEN")
+    if admin == _DEFAULT_ADMIN_TOKEN:
+        flagged.append("THUMPER_ADMIN_TOKEN")
     return flagged
 
 # Secret used to encrypt integration config (plugin credentials) at rest (#24).

--- a/tests/test_default_token_warning.py
+++ b/tests/test_default_token_warning.py
@@ -5,14 +5,20 @@ from thumper.config import insecure_default_tokens
 
 
 def test_both_defaults_flagged():
-    assert insecure_default_tokens("dev-enroll-token", "dev-install-token") == [
+    assert insecure_default_tokens("dev-enroll-token", "dev-install-token", "") == [
         "THUMPER_ENROLL_TOKEN", "THUMPER_INSTALL_TOKEN"]
 
 
 def test_no_defaults_when_overridden():
-    assert insecure_default_tokens("s3cr3t-enroll", "s3cr3t-install") == []
+    assert insecure_default_tokens("s3cr3t-enroll", "s3cr3t-install", "s3cr3t-admin") == []
 
 
 def test_only_install_default():
-    assert insecure_default_tokens("s3cr3t-enroll", "dev-install-token") == [
+    assert insecure_default_tokens("s3cr3t-enroll", "dev-install-token", "s3cr3t-admin") == [
         "THUMPER_INSTALL_TOKEN"]
+
+
+def test_admin_default_flagged_but_unset_admin_is_not():
+    assert insecure_default_tokens("s3cr3t-enroll", "s3cr3t-install", "dev-admin-token") == [
+        "THUMPER_ADMIN_TOKEN"]
+    assert insecure_default_tokens("s3cr3t-enroll", "s3cr3t-install", "") == []


### PR DESCRIPTION
## Summary
- flag `THUMPER_ADMIN_TOKEN=dev-admin-token` as an insecure default at startup
- keep unset admin token behavior fail-closed and unflagged by `insecure_default_tokens()`
- extend the default-token regression tests for the admin token case

Closes #197.

## Verification
- uv run --extra dev pytest tests/test_default_token_warning.py tests/test_admin_auth.py
- uv run --extra dev ruff check server/thumper/config.py tests/test_default_token_warning.py
- uv run --extra dev pytest