### PR TITLE
feat: print install startup log preview

### DIFF
--- a/server/thumper/api/routes.py
+++ b/server/thumper/api/routes.py
@@ -608,8 +608,16 @@ nohup sh "$DIR/thumper_agent.sh" run \\
 sleep 1
 if kill -0 $! 2>/dev/null; then
   echo "thumper: agent installed in $DIR and watching (logs: $DIR/agent.log)"
+  if [ -s "$DIR/agent.log" ]; then
+    echo "thumper: first startup log lines:"
+    sed -n '1,20p' "$DIR/agent.log"
+  fi
 else
   echo "thumper: agent exited immediately; check $DIR/agent.log" >&2
+  if [ -s "$DIR/agent.log" ]; then
+    echo "thumper: first startup log lines:" >&2
+    sed -n '1,20p' "$DIR/agent.log" >&2
+  fi
   exit 1
 fi
 """

--- a/tests/test_install_command.py
+++ b/tests/test_install_command.py
@@ -88,3 +88,15 @@ def test_install_script_autoinstalls_inotify_tools(client_db):
     assert 'uname -s' in s          # gated to Linux
     for pm in ("apt-get", "dnf", "yum", "zypper", "apk", "pacman"):
         assert pm in s, f"missing package manager {pm}"
+
+
+def test_install_script_prints_startup_log_preview(client_db):
+    """After starting the agent, the installer should show a short log preview
+    so command-line installs have immediate success/failure context (#13)."""
+    tc, _ = client_db
+    resp = tc.get("/api/install.sh", params={"token": "dev-install-token", "tripwire": "tw_x"})
+    assert resp.status_code == 200
+    s = resp.text
+    assert "thumper: first startup log lines:" in s
+    assert "sed -n '1,20p' \"$DIR/agent.log\"" in s
+    assert s.count("sed -n '1,20p' \"$DIR/agent.log\"") == 2


### PR DESCRIPTION
## Summary
- print the first 20 startup log lines after the install script confirms the agent is still running
- print the same short preview to stderr when the agent exits immediately
- cover the generated installer script with a regression test

Closes #13.

## Verification
- uv run --extra dev pytest tests/test_install_command.py
- uv run --extra dev ruff check server/thumper/api/routes.py tests/test_install_command.py
- uv run --extra dev pytest