### PR TITLE
feat(ui): explain pending tripwire sync

### DIFF
--- a/ui/src/components/DeployBadge.test.tsx
+++ b/ui/src/components/DeployBadge.test.tsx
@@ -1,0 +1,17 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { DeployBadge } from "./ui.tsx";
+
+describe("<DeployBadge> component", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("explains that pending deployments wait for agent sync", () => {
+    render(<DeployBadge state="pending" />);
+
+    const badge = screen.getByTitle("waiting for agent sync");
+    expect(badge).toHaveTextContent("pending · waiting for sync");
+  });
+});

--- a/ui/src/components/ui.tsx
+++ b/ui/src/components/ui.tsx
@@ -67,6 +67,13 @@ export function DeployBadge({ state, triggered, endpointStatus }:
       </span>
     );
   }
+  if (state === "pending") {
+    return (
+      <span className="badge pending" title="waiting for agent sync">
+        <span className="dot" /> pending · waiting for sync
+      </span>
+    );
+  }
   const cls = state === "planted" ? "deployed" : state === "failed" ? "failed" : "pending";
   return (
     <span className={`badge ${cls}`}>

--- a/ui/src/pages/EndpointDetail.tsx
+++ b/ui/src/pages/EndpointDetail.tsx
@@ -141,6 +141,9 @@ export default function EndpointDetail() {
                   {available.length > 0 && (
                     <>
                       <div className="picker-heading">Existing tripwires</div>
+                      <div className="muted" style={{ padding: "0 12px 8px", fontSize: 12 }}>
+                        Takes effect on the agent's next sync.
+                      </div>
                       {available.map((t) => (
                         <button
                           key={t.id}


### PR DESCRIPTION
## Summary
- make pending deployment badges explain that they are waiting for agent sync
- add a small note to the endpoint tripwire picker before assigning new tripwires
- cover the pending badge copy with a UI component test

Closes #18.

## Verification
- cd ui && npm test
- cd ui && npm run build