### PR TITLE
fix(agent): close atime arm baseline race

### DIFF
--- a/agent/thumper_agent.sh
+++ b/agent/thumper_agent.sh
@@ -585,6 +585,11 @@ watch_inotify() {
 # so it's the primary layer that covers the FIFO sensor's blind spots
 # (statSync-guarded / mmap / scan-only readers). See #28, #100.
 ATIME_ARM_STAMP=200001010000   # `touch -t` stamp: 2000-01-01 00:00 - atime far in the past
+# A deliberately conservative upper bound for the armed timestamp.  Using the
+# known bound as the baseline closes the arm -> stat race: a read in that gap is
+# no longer captured as the baseline and swallowed.  2000-01-01 is below 1e9 in
+# every supported timezone; a real read on a contemporary host is above it.
+ATIME_ARM_BASELINE=1000000000
 arm_atime() {  # arm_atime <path>: set atime to the past so the next read bumps it (relatime/APFS)
     # -c: never CREATE the file. Arming a missing bait would otherwise leave an
     # empty file behind, making verify_planted think a failed-plant dep is planted
@@ -608,7 +613,7 @@ atime_poll() {
     for i in $1; do
         eval "p=\$dep_path_$i"
         arm_atime "$p"                                  # arm so relatime bumps atime on a read
-        eval "atime_$i=\$(read_atime \"\$p\")"
+        eval "atime_$i=$ATIME_ARM_BASELINE"
     done
     while true; do
         sleep "$POLL"
@@ -619,7 +624,7 @@ atime_poll() {
             if [ "$cur" != "0" ] && [ "$cur" -gt "$prev" ] 2>/dev/null; then
                 fire "$i" "atime-change" "" "" "" "$p"
                 arm_atime "$p"                          # RE-ARM so the NEXT read is detectable too
-                eval "atime_$i=\$(read_atime \"\$p\")"
+                eval "atime_$i=$ATIME_ARM_BASELINE"
             fi
         done
     done

--- a/tests/test_agent_fifo.py
+++ b/tests/test_agent_fifo.py
@@ -481,3 +481,13 @@ def test_atime_stat_order_prefers_portable_access_time():
             f'stat -f %a {badvar} 2>/dev/null || stat -c %X' not in src
         ), "source must not contain the wrong stat order (stat -f %a before stat -c %X)"
     assert "watch_fs_usage" not in src, "fs_usage sensor must be removed"
+
+
+def test_atime_arm_uses_known_baseline_instead_of_racy_stat():
+    # #235: a read between arm_atime and read_atime used to become the baseline,
+    # swallowing that first access.  Both initial arm and re-arm must assign the
+    # known sentinel bound directly rather than sampling the filesystem again.
+    src = AGENT.read_text()
+    assert "ATIME_ARM_BASELINE=1000000000" in src
+    assert src.count('eval "atime_$i=$ATIME_ARM_BASELINE"') == 2
+    assert r'eval "atime_$i=\$(read_atime' not in src


### PR DESCRIPTION
Closes #235.

## What changed
- use the known armed-atime upper bound as the initial and re-arm baseline
- avoid reading the baseline back in a separate `stat` subprocess
- add a regression test that prevents the racy baseline sampling from returning

A read that lands immediately after `touch -a` now compares above the sentinel bound on the first poll instead of being captured as the baseline.

## Verification
- `uv run pytest -q tests/test_agent_fifo.py` — 13 passed
- `uv run ruff check .` — passed
- `uv run pytest -q` — 361 passed, 1 skipped