### PR TITLE
fix(agent): log shutdown lifecycle

### DIFF
--- a/agent/thumper_agent.sh
+++ b/agent/thumper_agent.sh
@@ -979,8 +979,10 @@ run() {
     # release the singleton lock. Combined into one trap (replacing the release-
     # only trap set after acquire_singleton) so none clobbers the others.
     cleanup_heartbeat() { [ -n "$HEARTBEAT_PID" ] && kill "$HEARTBEAT_PID" 2>/dev/null; }
-    trap 'stop_watcher; remove_fifos; cleanup_heartbeat; release_singleton; exit 0' INT TERM
-    trap 'stop_watcher; remove_fifos; cleanup_heartbeat; release_singleton' EXIT
+    # Disable the EXIT trap on a handled signal so cleanup and the shutdown log
+    # run exactly once. Natural exits retain their original status.
+    trap 'trap - EXIT; log "agent shutting down (signal)"; stop_watcher; remove_fifos; cleanup_heartbeat; release_singleton; exit 0' INT TERM
+    trap 'log "agent shutting down (exit)"; stop_watcher; remove_fifos; cleanup_heartbeat; release_singleton' EXIT
     # Remote kill: the heartbeat loop raises USR1 when the server flags us.
     trap 'self_destruct' USR1
 

--- a/tests/test_agent_atime.py
+++ b/tests/test_agent_atime.py
@@ -139,6 +139,20 @@ def test_atime_sensor_plants_a_regular_file_and_arms_it(server, tmp_path):
         p.wait(timeout=5)
 
 
+def test_agent_logs_clean_shutdown(server, tmp_path):
+    bait = tmp_path / "credentials"
+    Stub.bait_path = str(bait)
+    p = _spawn(server, tmp_path)
+    assert _wait(lambda: bait.exists() and _atime(bait) < ARMED_MAX), (
+        "agent did not reach its watching state"
+    )
+
+    p.terminate()
+    stdout, _ = p.communicate(timeout=5)
+
+    assert stdout.count("agent shutting down (signal)") == 1
+
+
 def test_atime_sensor_is_rearmable(server, tmp_path):
     bait = tmp_path / "credentials"
     Stub.bait_path = str(bait)


### PR DESCRIPTION
Closes #97.

## What changed
- emit an explicit shutdown log for signal-driven and natural agent exits
- suppress the natural-exit trap after a handled signal so cleanup and logging happen once
- add a cross-platform atime-agent regression test for the signal shutdown message

## Verification
- `uv run pytest -q tests/test_agent_atime.py` — 5 passed
- `uv run ruff check .` — passed
- `uv run pytest -q` — 361 passed, 1 skipped