### PR TITLE
fix: restore require_admin override in test_admin_auth's client fixture

### DIFF
--- a/tests/test_admin_auth.py
+++ b/tests/test_admin_auth.py
@@ -31,6 +31,7 @@ def client(monkeypatch):
     app.dependency_overrides[get_db] = lambda: db
     yield TestClient(app)
     del app.dependency_overrides[get_db]
+    app.dependency_overrides[require_admin] = lambda: None  # restore conftest's bypass
     db.close()
 
 


### PR DESCRIPTION
## Summary

`test_admin_auth.py`'s `client` fixture pops the conftest `require_admin` bypass to test the real auth gate, but never restores it, only `get_db` gets cleaned up in teardown. It was relying on conftest's autouse `_bypass_admin_auth` to re-add the override before the next test runs, instead of restoring what it removed itself.

Found while investigating an intermittent failure in `test_endpoint_ephemeral.py::test_get_endpoints_does_not_list_stale_ephemeral` under `pytest-randomly`. I couldn't fully pin down that this exact interaction is the cause, didn't want to claim more certainty than I have, but the asymmetry is a real bug regardless: a fixture should restore what it changes rather than depend on another fixture to clean up after it, and both center on the same shared `app.dependency_overrides[require_admin]` state.

Closes # (no filed issue - found during flake investigation, going straight to a fix per request)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Refactor / internal (no user-facing change)
- [ ] Other:

## Checklist

- [x] `pytest -v` passes locally (`pip install -e ".[dev]"` first — see [CONTRIBUTING.md](https://github.com/jestasecurity/thumper/blob/main/CONTRIBUTING.md))
- [ ] For UI changes: verified with `cd ui && npm install && npm run dev`
- [ ] For a new/changed plugin: follows [docs/plugins.md](https://github.com/jestasecurity/thumper/blob/main/docs/plugins.md)
- [ ] For a new honeytoken type: follows [docs/tokens.md](https://github.com/jestasecurity/thumper/blob/main/docs/tokens.md)
- [ ] Added a one-line entry under `## [Unreleased]` in [CHANGELOG.md](https://github.com/jestasecurity/thumper/blob/main/CHANGELOG.md) (skip for internal-only changes)
- [x] PR is scoped to the linked issue — no unrelated changes

## Testing notes

Full suite run 3 times with different orderings after the fix: `-p no:randomly` (sequential), `--randomly-seed=1`, and one unpinned random seed. All three: 346 passed, 15 skipped, 0 failed. Note: the original flake was already low-frequency (roughly 1 failure in 3-4 full runs before this fix), so 3 clean runs is encouraging but not proof the exact mechanism is eliminated.
