### PR TITLE
fix: allowlist integration config keys against the plugin manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Removed stale dashboard copy that described the old macOS `fs_usage`/sudo-based tripwire sensor.
+- Rejected unknown or oversized config keys when saving an integration, instead of persisting them unvalidated.
 
 ## [0.1.0] - unreleased
 

--- a/server/thumper/api/routes.py
+++ b/server/thumper/api/routes.py
@@ -46,7 +46,8 @@ from ..plugins.registry import get_manifest, load_plugin, public_manifests
 from ..services.alerting import deliver_alert
 from ..services.content import render_content
 from ..services.deploy import build_install, build_install_command, distribute
-from ..services.integrations import mask_config, merge_config, redact_secrets, saved_config
+from ..services.integrations import (ConfigValidationError, mask_config, merge_config,
+                                     redact_secrets, saved_config, validate_config)
 from ..services.secrets_crypto import ConfigDecryptError, unpack_config
 from ..services.signing import verify
 from ..services.ssrf import SsrfError, assert_config_urls_allowed
@@ -481,6 +482,10 @@ def save_integration(plugin: str, config: dict, db: Session = Depends(get_db)):
     manifest = get_manifest(plugin)
     if manifest is None:
         raise HTTPException(404, "unknown plugin")
+    try:
+        validate_config(manifest, config)
+    except ConfigValidationError as exc:
+        raise HTTPException(400, str(exc))
     merged = merge_config(saved_config(db, plugin), config)
     try:
         assert_config_urls_allowed(plugin, merged)  # SSRF guard (#74)

--- a/server/thumper/services/integrations.py
+++ b/server/thumper/services/integrations.py
@@ -5,6 +5,31 @@ from .. import store
 from .secrets_crypto import unpack_config
 
 
+MAX_CONFIG_VALUE_LENGTH = 4096
+
+
+class ConfigValidationError(Exception):
+    """Raised when incoming integration config fails schema validation."""
+
+
+def validate_config(manifest: dict, incoming: dict) -> None:
+    """Reject config keys the plugin's manifest doesn't declare, and cap value
+    length. save_integration previously merged any caller-supplied dict with no
+    allowlist. This mirrors mask_config's config_schema iteration to build the
+    allowlist instead of an echo-list."""
+    allowed = {field["key"] for field in manifest.get("config_schema", [])}
+    unknown = set(incoming) - allowed
+    if unknown:
+        raise ConfigValidationError(
+            f"unknown config key(s) for {manifest['name']!r}: {', '.join(sorted(unknown))}"
+        )
+    for key, value in incoming.items():
+        if isinstance(value, str) and len(value) > MAX_CONFIG_VALUE_LENGTH:
+            raise ConfigValidationError(
+                f"{key!r} exceeds max length of {MAX_CONFIG_VALUE_LENGTH} characters"
+            )
+
+
 def mask_config(manifest: dict, config: dict) -> dict:
     """Echo non-secret config back for display; replace secrets with bullets."""
     masked: dict = {}

--- a/tests/test_save_integration_validation.py
+++ b/tests/test_save_integration_validation.py
@@ -1,0 +1,61 @@
+from thumper import store
+
+
+def test_save_integration_rejects_unknown_key(client_db):
+    tc, db = client_db
+    resp = tc.post("/api/integrations/webhook", json={
+        "url": "http://127.0.0.1/x", "admin": True,
+    })
+    assert resp.status_code == 400
+    assert "admin" in resp.json()["detail"]
+    db.expire_all()
+    assert store.get_integration(db, "webhook") is None
+
+
+def test_save_integration_accepts_only_schema_keys(client_db):
+    tc, db = client_db
+    resp = tc.post("/api/integrations/webhook", json={
+        "url": "http://127.0.0.1/x", "signing_secret": "s3cr3t",
+    })
+    assert resp.status_code == 200
+    db.expire_all()
+    row = store.get_integration(db, "webhook")
+    assert row is not None
+
+
+def test_save_integration_rejects_oversized_value(client_db):
+    tc, db = client_db
+    resp = tc.post("/api/integrations/webhook", json={
+        "url": "http://127.0.0.1/x" + "a" * 5000,
+    })
+    assert resp.status_code == 400
+    assert "exceeds max length" in resp.json()["detail"]
+    db.expire_all()
+    assert store.get_integration(db, "webhook") is None
+
+
+def test_save_integration_unknown_key_does_not_leak_into_existing_config(client_db):
+    """A rejected request must not partially merge - the existing saved config
+    (e.g. a previously-set secret) must be untouched."""
+    tc, db = client_db
+    tc.post("/api/integrations/webhook", json={
+        "url": "http://127.0.0.1/x", "signing_secret": "original-secret",
+    })
+
+    resp = tc.post("/api/integrations/webhook", json={
+        "url": "http://127.0.0.1/y", "extra_field": "smuggled",
+    })
+
+    assert resp.status_code == 400
+    db.expire_all()
+    row = store.get_integration(db, "webhook")
+    from thumper.services.secrets_crypto import unpack_config
+    saved = unpack_config(row.config_json)
+    assert saved["url"] == "http://127.0.0.1/x"
+    assert "extra_field" not in saved
+
+
+def test_save_integration_unknown_plugin_still_404s_before_validation(client_db):
+    tc, _ = client_db
+    resp = tc.post("/api/integrations/nope", json={"anything": "x"})
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary

`save_integration` merged any caller-supplied dict with no validation against the plugin's declared `config_schema` - #105. Adds `validate_config()` in `services/integrations.py`, mirroring the existing `mask_config()` iteration pattern one function above it: rejects unknown keys, caps value length at 4096 chars. Called before `merge_config` so a rejected request never partially merges.

Note: #20/#172 already gate the whole `/api` router behind `require_admin`, so this closes a defense-in-depth gap rather than an open unauthenticated door. The original issue's "combined with unauthenticated API" framing predates that fix.

Closes #105

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Refactor / internal (no user-facing change)
- [ ] Other:

## Checklist

- [x] `pytest -v` passes locally (`pip install -e ".[dev]"` first — see [CONTRIBUTING.md](https://github.com/jestasecurity/thumper/blob/main/CONTRIBUTING.md))
- [ ] For UI changes: verified with `cd ui && npm install && npm run dev`
- [ ] For a new/changed plugin: follows [docs/plugins.md](https://github.com/jestasecurity/thumper/blob/main/docs/plugins.md)
- [ ] For a new honeytoken type: follows [docs/tokens.md](https://github.com/jestasecurity/thumper/blob/main/docs/tokens.md)
- [x] Added a one-line entry under `## [Unreleased]` in [CHANGELOG.md](https://github.com/jestasecurity/thumper/blob/main/CHANGELOG.md) (skip for internal-only changes)
- [x] PR is scoped to the linked issue — no unrelated changes

## Testing notes

`pytest -v`: 351 passed, 15 skipped (pre-existing), 0 failed. `ruff check` clean on all three touched files. New file `tests/test_save_integration_validation.py` covers: unknown key rejected + nothing persisted, schema-only keys accepted, oversized value rejected, a rejected request doesn't partially clobber existing saved config, and unknown-plugin 404 still fires before validation runs.
