### PR TITLE
feat(plugins): add the vault plugin kind (VaultPlugin base + loader)

### DIFF
--- a/server/thumper/plugins/base.py
+++ b/server/thumper/plugins/base.py
@@ -1,17 +1,19 @@
 """The plugin contract. Community plugins import from here.
 
-A plugin is a DIRECTORY under plugins/{deploy,alert}/<name>/ containing:
+A plugin is a DIRECTORY under plugins/{deploy,alert,vault}/<name>/ containing:
   - manifest.yaml : name, kind, display_name, version, author, description,
                     and config_schema (fields: string | secret | boolean) that
                     the UI renders into a config form automatically.
-  - plugin.py     : defines a class named `Plugin` subclassing DeployPlugin or
-                    AlertPlugin. It is constructed with the saved config dict.
+  - plugin.py     : defines a class named `Plugin` subclassing DeployPlugin,
+                    AlertPlugin, or VaultPlugin. It is constructed with the saved
+                    config dict.
 
 The contract is intentionally minimal so it can grow without breaking plugins:
 the `path` and HMAC `callback_url`/`hmac_secret` travel INSIDE the Token object,
 not as separate arguments.
 """
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 
 from pydantic import BaseModel
 
@@ -74,3 +76,46 @@ class AlertPlugin(ABC):
             "endpoint_hostname": "thumper-server",
             "message": "Thumper test event - your integration is wired up correctly.",
         })
+
+
+@dataclass
+class AccessEvent:
+    """A detected read of a canary secret in a secrets manager."""
+    path: str
+    timestamp: str
+    accessor: str | None = None
+    source_ip: str | None = None
+    policy: str | None = None
+    extra: dict = field(default_factory=dict)
+
+
+class VaultPlugin(ABC):
+    """Connect to a secrets manager, plant/delete canary secrets, poll for reads.
+
+    A `vault` plugin plants realistic-but-fake secrets in a real secrets manager
+    (HashiCorp Vault, AWS Secrets Manager, ...) and polls that manager's audit log
+    to detect reads - a read of a canary is the signal, delivered through the same
+    alert pipeline as file-based tripwires."""
+
+    def __init__(self, config: dict):
+        self.config = config or {}
+
+    @abstractmethod
+    def connect(self) -> None:
+        """Authenticate and verify connectivity. Raise PluginError on failure."""
+
+    @abstractmethod
+    def plant(self, path: str, value: str, metadata: dict) -> None:
+        """Write a canary secret at the given path. Raise PluginError on failure."""
+
+    @abstractmethod
+    def delete(self, path: str) -> None:
+        """Remove a canary secret. Raise PluginError on failure."""
+
+    @abstractmethod
+    def poll(self, paths: list[str], since: str | None = None) -> list[AccessEvent]:
+        """Check audit logs for reads on the given paths since `since`."""
+
+    def test(self) -> None:
+        """Verify connectivity (default: calls connect)."""
+        self.connect()

--- a/server/thumper/plugins/loader.py
+++ b/server/thumper/plugins/loader.py
@@ -1,6 +1,6 @@
 """Discover and instantiate plugins from the filesystem.
 
-Drop a directory with a manifest.yaml + plugin.py into plugins/{deploy,alert}/
+Drop a directory with a manifest.yaml + plugin.py into plugins/{deploy,alert,vault}/
 and it shows up - no registration code, no imports to edit.
 
 Discovery and module loading are cached: the plugin set is fixed at process
@@ -14,7 +14,7 @@ import yaml
 
 from ..config import PLUGINS_DIR
 
-_KINDS = ("deploy", "alert")
+_KINDS = ("deploy", "alert", "vault")
 
 _manifest_cache: list[dict] | None = None
 _module_cache: dict[str, object] = {}

--- a/tests/test_vault_plugin_loader.py
+++ b/tests/test_vault_plugin_loader.py
@@ -1,0 +1,62 @@
+import pytest
+import yaml
+
+from thumper.plugins import loader
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    loader.reset_cache()
+    yield
+    loader.reset_cache()
+
+
+@pytest.fixture
+def vault_plugin_dir(tmp_path, monkeypatch):
+    """Create a minimal vault plugin under a temp PLUGINS_DIR."""
+    monkeypatch.setattr(loader, "PLUGINS_DIR", tmp_path)
+    vault_dir = tmp_path / "vault" / "fakevault"
+    vault_dir.mkdir(parents=True)
+    (vault_dir / "manifest.yaml").write_text(yaml.dump({
+        "name": "fakevault",
+        "kind": "vault",
+        "display_name": "Fake Vault",
+        "version": "0.1.0",
+        "author": "test",
+        "description": "A test vault plugin",
+        "config_schema": [
+            {"key": "url", "label": "Vault URL", "type": "string", "required": True},
+        ],
+    }))
+    (vault_dir / "plugin.py").write_text(
+        "from thumper.plugins.base import VaultPlugin\n"
+        "class Plugin(VaultPlugin):\n"
+        "    def connect(self): pass\n"
+        "    def plant(self, path, value, metadata): pass\n"
+        "    def delete(self, path): pass\n"
+        "    def poll(self, paths, since=None): return []\n"
+    )
+    return vault_dir
+
+
+def test_discover_finds_vault_plugin(vault_plugin_dir):
+    manifests = loader.discover_manifests()
+    names = [m["name"] for m in manifests]
+    assert "fakevault" in names
+
+
+def test_discovered_vault_manifest_has_kind(vault_plugin_dir):
+    manifests = loader.discover_manifests()
+    fake = next(m for m in manifests if m["name"] == "fakevault")
+    assert fake["kind"] == "vault"
+
+
+def test_load_vault_plugin(vault_plugin_dir):
+    plugin = loader.load_plugin("fakevault", {"url": "http://localhost:8200"})
+    for method in ("connect", "plant", "delete", "poll"):
+        assert hasattr(plugin, method)
+
+
+def test_vault_plugin_poll_returns_list(vault_plugin_dir):
+    plugin = loader.load_plugin("fakevault", {"url": "http://localhost:8200"})
+    assert plugin.poll(["/secret/test"]) == []


### PR DESCRIPTION
**Task 1 of #255** (secret-manager honeytokens).

Introduces the `vault` plugin kind — the foundation for planting canary secrets in a real secrets manager (HashiCorp Vault, AWS Secrets Manager) and detecting reads via audit-log polling.

### Changes
- **`VaultPlugin` ABC** (`plugins/base.py`) — `connect` / `plant` / `delete` / `poll(paths, since) → list[AccessEvent]`, plus a default `test()`.
- **`AccessEvent` dataclass** — a detected canary read (`path`, `timestamp`, `accessor`, `source_ip`, `policy`, `extra`).
- **`"vault"` added to the loader `_KINDS`** — manifests under `plugins/vault/*/` are now discovered and `load_plugin` instantiates them. The discovery/instantiation machinery is kind-agnostic, so no other loader change is needed.

### Scope
Foundation only — no vault plugins, DB models, routes, poller, or UI yet (those are the remaining tasks tracked in #255). The `_KINDS` change is a no-op until a `plugins/vault/` directory exists, so existing plugins are unaffected.

### Tests
`tests/test_vault_plugin_loader.py` (4 tests: discovery, kind, load, poll-returns-list) — all pass. Existing plugin/manifest tests (manifests API, deploy isolation, webhook, mdm) still green. ruff clean.

Part of #255.