### PR TITLE
fix(agent): recover dead sensor watchers 🩷

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Restarted dead endpoint sensor processes instead of leaving live-sync agents silently blind.
 - Removed stale dashboard copy that described the old macOS `fs_usage`/sudo-based tripwire sensor.
 - Rejected unknown or oversized config keys when saving an integration, instead of persisting them unvalidated.
 - Required a matching agent_token to re-enroll an existing machine_id, instead of upserting on the client-supplied value alone.

--- a/agent/thumper_agent.sh
+++ b/agent/thumper_agent.sh
@@ -643,6 +643,12 @@ WATCH_STARTED=""
 process_start_fingerprint() {  # stable for one PID lifetime; empty if gone
     # BSD `lstart` is second-resolution, so include the full command as an
     # additional identity dimension while keeping this agent shell-only.
+    # NOTE: our workers are backgrounded shell FUNCTIONS (serve_fifo/atime_poll),
+    # so `command=` is the agent's own argv for every one of them - it hardens the
+    # fingerprint against a foreign process that reused the PID, but does NOT tell
+    # two same-second siblings of THIS agent apart. The `_ww_owner = MAIN_PID`
+    # gate in cleanup_watcher_workers is what bounds a kill to this agent's own
+    # workers; the fingerprint only guards against acting on a reused PID.
     ps -o lstart=,command= -p "$1" 2>/dev/null |
         sed 's/^[[:space:]]*//; s/[[:space:]]*$//'
 }

--- a/agent/thumper_agent.sh
+++ b/agent/thumper_agent.sh
@@ -635,6 +635,56 @@ watch_atime() { atime_poll "$(all_indices)"; }   # poll every bait (homogeneous 
 # restarted ONLY when the set actually changed - never periodically - so we never
 # blind ourselves between cycles.
 WATCH_PID=""
+WATCH_STARTED=""
+
+# Record sensor workers owned by the current supervisor. If that supervisor is
+# killed abruptly, its children are reparented and `pkill -P` can no longer find
+# them; this registry lets the sync loop remove those orphans before restart.
+process_start_fingerprint() {  # stable for one PID lifetime; empty if gone
+    # BSD `lstart` is second-resolution, so include the full command as an
+    # additional identity dimension while keeping this agent shell-only.
+    ps -o lstart=,command= -p "$1" 2>/dev/null |
+        sed 's/^[[:space:]]*//; s/[[:space:]]*$//'
+}
+
+process_identity_matches() {  # process_identity_matches <pid> <fingerprint>
+    [ -n "${1:-}" ] && [ -n "${2:-}" ] || return 1
+    _identity_current=$(process_start_fingerprint "$1")
+    [ -n "$_identity_current" ] && [ "$_identity_current" = "$2" ]
+}
+
+watcher_identity_matches() {
+    [ -n "${WATCH_PID:-}" ] && [ -n "${WATCH_STARTED:-}" ] || return 1
+    process_identity_matches "$WATCH_PID" "$WATCH_STARTED"
+}
+
+write_watcher_workers() {  # write_watcher_workers <pid ...>
+    [ -n "${WATCH_WORKERS_FILE:-}" ] || return 0
+    _ww_tmp="$WATCH_WORKERS_FILE.tmp.$$"
+    : > "$_ww_tmp"
+    for _ww_pid in "$@"; do
+        [ -n "$_ww_pid" ] || continue
+        _ww_started=$(process_start_fingerprint "$_ww_pid")
+        [ -n "$_ww_started" ] && printf '%s\t%s\t%s\n' \
+            "$MAIN_PID" "$_ww_pid" "$_ww_started" >> "$_ww_tmp"
+    done
+    mv "$_ww_tmp" "$WATCH_WORKERS_FILE"
+}
+
+cleanup_watcher_workers() {
+    [ -f "${WATCH_WORKERS_FILE:-}" ] || return 0
+    _ww_tab=$(printf '\t')
+    while IFS="$_ww_tab" read -r _ww_owner _ww_pid _ww_started; do
+        case "$_ww_owner:$_ww_pid" in *[!0-9:]*|:|*:) continue ;; esac
+        [ "$_ww_owner" = "$MAIN_PID" ] || continue
+        # A bare PID is unsafe: the worker may have exited and its PID may have
+        # been reused during the sync interval. Kill only the exact process
+        # lifetime recorded by this main agent instance.
+        process_identity_matches "$_ww_pid" "$_ww_started" &&
+            kill "$_ww_pid" 2>/dev/null || true
+    done < "$WATCH_WORKERS_FILE"
+    rm -f "$WATCH_WORKERS_FILE"
+}
 
 snapshot() {  # emit the current set as "id<TAB>path" lines
     i=1
@@ -689,13 +739,28 @@ serve_fifo() {  # serve_fifo <i> - serve one bait FIFO forever; a read = a hit
 
 watch_fifo() {  # supervisor: keep one serve_fifo alive per bait; restart any that dies
     log "watching $DEP_COUNT bait file(s) via FIFO"
+    update_fifo_worker_registry() {
+        _worker_pids=""; _wr_i=1
+        while [ "$_wr_i" -le "$DEP_COUNT" ]; do
+            eval "_wr_pid=\$sf_pid_$_wr_i"
+            _worker_pids="$_worker_pids $_wr_pid"
+            _wr_i=$((_wr_i + 1))
+        done
+        # shellcheck disable=SC2086
+        write_watcher_workers $_worker_pids
+    }
     i=1
-    while [ "$i" -le "$DEP_COUNT" ]; do serve_fifo "$i" & eval "sf_pid_$i=\$!"; i=$((i + 1)); done
+    while [ "$i" -le "$DEP_COUNT" ]; do
+        serve_fifo "$i" &
+        eval "sf_pid_$i=\$! sf_started_$i=\$(process_start_fingerprint \"\$!\")"
+        i=$((i + 1))
+    done
+    update_fifo_worker_registry
     while :; do
         [ -e "${WATCH_STOP_FLAG:-/nonexistent}" ] && return 0
         i=1
         while [ "$i" -le "$DEP_COUNT" ]; do
-            eval "_sp=\$sf_pid_$i _sf=\$dep_path_$i"
+            eval "_sp=\$sf_pid_$i _ss=\$sf_started_$i _sf=\$dep_path_$i"
             # Restart a writer that died while its FIFO still exists. Without this
             # that ONE bait has no writer, any reader's open() blocks forever, and
             # nothing fires - and verify_planted can't catch it because it only
@@ -704,7 +769,7 @@ watch_fifo() {  # supervisor: keep one serve_fifo alive per bait; restart any th
             # writers exit, so a single death among live siblings went unrecovered
             # until the next full re-plant restart. And we must NOT fall back to
             # atime: atime polling on a writerless pipe is silently blind.
-            if [ -p "$_sf" ] && ! kill -0 "$_sp" 2>/dev/null; then
+            if [ -p "$_sf" ] && ! process_identity_matches "$_sp" "$_ss"; then
                 # A deliberate stop sets WATCH_STOP_FLAG *before* it pkill's the
                 # writers, so re-check it here: a writer that just died because
                 # we're shutting down must NOT be respawned. Without this guard a
@@ -713,7 +778,9 @@ watch_fifo() {  # supervisor: keep one serve_fifo alive per bait; restart any th
                 # agent's stdout/stderr open, so on SIGTERM the process never
                 # reaches EOF and shutdown intermittently hangs.
                 [ -e "${WATCH_STOP_FLAG:-/nonexistent}" ] && return 0
-                serve_fifo "$i" & eval "sf_pid_$i=\$!"
+                serve_fifo "$i" &
+                eval "sf_pid_$i=\$! sf_started_$i=\$(process_start_fingerprint \"\$!\")"
+                update_fifo_worker_registry
                 log "restarted dead FIFO writer for bait $i"
             fi
             i=$((i + 1))
@@ -730,13 +797,33 @@ watch_mixed() {
     _atidx=""; i=1
     while [ "$i" -le "$DEP_COUNT" ]; do
         if [ "$(effective_sensor "$i")" = fifo ]; then
-            serve_fifo "$i" & eval "sf_pid_$i=\$!"
+            serve_fifo "$i" &
+            eval "sf_pid_$i=\$! sf_started_$i=\$(process_start_fingerprint \"\$!\")"
         else
             _atidx="$_atidx $i"                         # atime/inotify/unknown -> atime poll (detection)
         fi
         i=$((i + 1))
     done
-    [ -n "$_atidx" ] && atime_poll "$_atidx" &
+    _atime_pid=""
+    if [ -n "$_atidx" ]; then
+        atime_poll "$_atidx" &
+        _atime_pid=$!
+        _atime_started=$(process_start_fingerprint "$_atime_pid")
+    fi
+    update_mixed_worker_registry() {
+        _worker_pids=""; _wr_i=1
+        while [ "$_wr_i" -le "$DEP_COUNT" ]; do
+            if [ "$(effective_sensor "$_wr_i")" = fifo ]; then
+                eval "_wr_pid=\$sf_pid_$_wr_i"
+                _worker_pids="$_worker_pids $_wr_pid"
+            fi
+            _wr_i=$((_wr_i + 1))
+        done
+        [ -n "$_atidx" ] && _worker_pids="$_worker_pids $_atime_pid"
+        # shellcheck disable=SC2086
+        write_watcher_workers $_worker_pids
+    }
+    update_mixed_worker_registry
     # Supervise the FIFO writers, exactly like watch_fifo: a serve_fifo that dies
     # leaves its pipe on disk, so any reader's open() blocks forever and that bait
     # is silently blind until a full restart (Roee #160 N1). Re-check the stop flag
@@ -744,13 +831,26 @@ watch_mixed() {
     # would hold the agent's stdout/stderr open on shutdown.
     while :; do
         [ -e "${WATCH_STOP_FLAG:-/nonexistent}" ] && return 0
+        # The mixed supervisor itself can stay alive after its atime child dies.
+        # Track that child explicitly so top-level WATCH_PID liveness cannot hide
+        # a partially blind sensor set (#99, follow-up from #160).
+        if [ -n "$_atidx" ] && ! process_identity_matches "$_atime_pid" "$_atime_started"; then
+            [ -e "${WATCH_STOP_FLAG:-/nonexistent}" ] && return 0
+            atime_poll "$_atidx" &
+            _atime_pid=$!
+            _atime_started=$(process_start_fingerprint "$_atime_pid")
+            update_mixed_worker_registry
+            log "restarted dead atime watcher"
+        fi
         i=1
         while [ "$i" -le "$DEP_COUNT" ]; do
             if [ "$(effective_sensor "$i")" = fifo ]; then
-                eval "_sp=\$sf_pid_$i _sf=\$dep_path_$i"
-                if [ -p "$_sf" ] && ! kill -0 "$_sp" 2>/dev/null; then
+                eval "_sp=\$sf_pid_$i _ss=\$sf_started_$i _sf=\$dep_path_$i"
+                if [ -p "$_sf" ] && ! process_identity_matches "$_sp" "$_ss"; then
                     [ -e "${WATCH_STOP_FLAG:-/nonexistent}" ] && return 0
-                    serve_fifo "$i" & eval "sf_pid_$i=\$!"
+                    serve_fifo "$i" &
+                    eval "sf_pid_$i=\$! sf_started_$i=\$(process_start_fingerprint \"\$!\")"
+                    update_mixed_worker_registry
                     log "restarted dead FIFO writer for bait $i"
                 fi
             fi
@@ -781,6 +881,12 @@ start_watcher() {  # launch the right sensor in the background; set WATCH_PID
         watch_atime &
     fi
     WATCH_PID=$!
+    WATCH_STARTED=$(process_start_fingerprint "$WATCH_PID")
+    if [ -z "$WATCH_STARTED" ]; then
+        # The supervisor exited before its identity could be captured. Leave no
+        # unverified PID that a later stop/restart path might signal.
+        WATCH_PID=""
+    fi
 }
 
 stop_watcher() {  # kill the watcher AND its serve_fifo children
@@ -788,10 +894,23 @@ stop_watcher() {  # kill the watcher AND its serve_fifo children
     : > "${WATCH_STOP_FLAG:-/dev/null}" 2>/dev/null || true  # mark stop deliberate
     # Reap children FIRST. Killing the parent subshell first reparents the
     # serve_fifo / inotifywait children to PID 1, after which `pkill -P` matches
-    # nothing and leaks them on every reconcile.
-    pkill -P "$WATCH_PID" 2>/dev/null || true
-    kill "$WATCH_PID" 2>/dev/null || true
+    # nothing and leaks them on every reconcile. The registry is the fallback
+    # for workers already orphaned by an abrupt supervisor death.
+    _old_watcher=$WATCH_PID
+    _old_watcher_matches=0
+    watcher_identity_matches && _old_watcher_matches=1
+    if [ "$_old_watcher_matches" = 1 ]; then
+        pkill -P "$_old_watcher" 2>/dev/null || true
+        kill "$_old_watcher" 2>/dev/null || true
+    fi
+    # Do not let start_watcher remove the stop flag until the old supervisor can
+    # no longer respawn workers or overwrite the registry for the next generation.
+    # `wait` is safe even when identity no longer matches: it addresses only this
+    # shell's original child job, never the unrelated process that reused its PID.
+    wait "$_old_watcher" 2>/dev/null || true
+    cleanup_watcher_workers
     WATCH_PID=""
+    WATCH_STARTED=""
 }
 
 remove_fifos() {  # remove every manifest path that is a FIFO (clean exit / startup sweep)
@@ -916,6 +1035,7 @@ run() {
     MANIFEST_FILE="$(dirname "$STATE_FILE")/planted.list"
     BAITCACHE="$(dirname "$STATE_FILE")/bait"
     WATCH_STOP_FLAG="$(dirname "$STATE_FILE")/watcher.stopping"
+    WATCH_WORKERS_FILE="$(dirname "$STATE_FILE")/watcher.workers"
     mkdir -p "$(dirname "$STATE_FILE")"
     case "$SENSOR" in
         atime) FIFO_MODE=0; log "sensor: atime poll (regular-file bait, re-armable)" ;;
@@ -937,6 +1057,10 @@ run() {
     # CURRENT sensor: a prior FIFO run's leftover pipes must be cleared even when
     # this run is atime mode, else plant() would curl into a no-reader FIFO and
     # hang forever (only manifest paths that ARE FIFOs are removed, so it's safe).
+    # A worker registry is valid only for the main-process lifecycle that wrote
+    # it. Never act on stale PIDs from an earlier boot/run: they may have been
+    # reused by an unrelated process. Current-run supervisors recreate the file.
+    rm -f "$WATCH_WORKERS_FILE"
     remove_fifos
     resolve_target_user
 
@@ -1001,9 +1125,23 @@ run() {
         return 0
     fi
 
-    # Live sync: re-pull on an interval; restart the watcher only on a real change.
+    # Live sync: re-pull on an interval; restart the watcher on a real change or crash.
     while true; do
         sleep "$SYNC_INTERVAL"
+        # The watcher is a separate background process. A transient sensor crash
+        # must not leave the still-running sync loop permanently blind. This check
+        # runs at most once per sync interval, which is also a natural backoff
+        # when the underlying failure persists (#99).
+        if ! watcher_identity_matches; then
+            log "watcher exited unexpectedly - restarting"
+            # Reap the original child job before cleaning its orphan registry.
+            # If its PID was reused, wait still cannot target the unrelated process.
+            [ -n "${WATCH_PID:-}" ] && wait "$WATCH_PID" 2>/dev/null || true
+            WATCH_PID=""
+            WATCH_STARTED=""
+            cleanup_watcher_workers
+            start_watcher
+        fi
         _old=$(snapshot | sort)
         # A failed pull is often a dead token (DB reset / re-enroll needed), which
         # would otherwise retry forever - recover via resync (re-enroll, rate-

--- a/tests/test_agent_fifo.py
+++ b/tests/test_agent_fifo.py
@@ -389,6 +389,115 @@ def test_duplicate_install_does_not_sweep_live_agents_fifo(server, tmp_path):
         )
 
 
+def test_startup_does_not_kill_a_pid_from_a_stale_worker_registry(server, tmp_path):
+    """Registry PIDs from an earlier agent lifecycle may have been reused."""
+    bait = tmp_path / "bait_aws"
+    Stub.bait_path = str(bait)
+    unrelated = subprocess.Popen(["sleep", "30"])
+    try:
+        (tmp_path / "watcher.workers").write_text(f"stale\t{unrelated.pid}\tunknown\n")
+        result = _run(server, tmp_path, "--once")
+        assert result.returncode == 0
+        assert unrelated.poll() is None, "startup killed a process from stale registry data"
+        assert not (tmp_path / "watcher.workers").exists()
+    finally:
+        unrelated.terminate()
+        unrelated.wait(timeout=5)
+
+
+def test_live_cleanup_rejects_poisoned_worker_identity(server, tmp_path):
+    """A same-lifecycle registry row cannot kill a mismatched process lifetime."""
+    bait = tmp_path / "bait_aws"
+    Stub.bait_path = str(bait)
+    state = tmp_path / "agent.json"
+    workers = tmp_path / "watcher.workers"
+    proc = subprocess.Popen(
+        [
+            "sh", str(AGENT), "run", "--server",
+            f"http://127.0.0.1:{server.server_port}", "--enroll-token", "e",
+            "--tripwire", "tw_1", "--state-file", str(state),
+            "--heartbeat", "0", "--sync-interval", "1", "--sensor", "fifo",
+        ],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+    )
+    unrelated = subprocess.Popen(["sleep", "30"])
+    try:
+        assert _wait(lambda: bait.exists() and workers.exists()), "watcher not ready"
+        # Poison a current-lifecycle row with an unrelated PID and an impossible
+        # start fingerprint, then kill the supervisor to trigger registry cleanup.
+        workers.write_text(f"{proc.pid}\t{unrelated.pid}\tdefinitely-not-its-start\n")
+        assert _wait(lambda: len(_children(proc.pid)) == 1), "supervisor not found"
+        os.kill(_children(proc.pid)[0], 9)
+        assert _wait(lambda: not workers.exists() or "definitely-not" not in workers.read_text())
+        assert unrelated.poll() is None, "cleanup killed a mismatched process lifetime"
+    finally:
+        unrelated.terminate()
+        unrelated.wait(timeout=5)
+        proc.terminate()
+        proc.wait(timeout=AGENT_EXIT_TIMEOUT)
+
+
+def test_live_sync_restart_cleans_orphaned_fifo_writer(server, tmp_path):
+    """Killing the supervisor must not leave its old FIFO writer behind (#99)."""
+    bait = tmp_path / "bait_aws"
+    Stub.bait_path = str(bait)
+    state = tmp_path / "agent.json"
+    workers = tmp_path / "watcher.workers"
+    proc = subprocess.Popen(
+        [
+            "sh", str(AGENT), "run", "--server",
+            f"http://127.0.0.1:{server.server_port}", "--enroll-token", "e",
+            "--tripwire", "tw_1", "--state-file", str(state),
+            "--heartbeat", "0", "--sync-interval", "1", "--sensor", "fifo",
+        ],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+    )
+
+
+    def worker_pids():
+        if not workers.exists():
+            return []
+        return [int(line.split("\t", 2)[1])
+                for line in workers.read_text().splitlines() if line]
+
+    try:
+        assert _wait(lambda: bait.exists() and worker_pids()), "watcher not ready"
+        assert _wait(lambda: len(_children(proc.pid)) == 1), "supervisor not found"
+        supervisor = _children(proc.pid)[0]
+        old_workers = worker_pids()
+        os.kill(supervisor, 9)
+
+        assert _wait(
+            lambda: worker_pids()
+            and not set(old_workers) & set(worker_pids())
+            and all(not _pid_alive(pid) for pid in old_workers),
+            timeout=15,
+        ), "old FIFO writer survived supervisor restart"
+
+        Stub.callbacks = []
+        assert Path(bait).read_text() == BAIT_BODY
+        assert _wait(lambda: any("event_type=open" in c for c in Stub.callbacks)), \
+            "replacement FIFO writer did not detect a read"
+    finally:
+        proc.terminate()
+        proc.wait(timeout=AGENT_EXIT_TIMEOUT)
+
+
+def _pid_alive(pid):
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+
+
+def _children(pid):
+    result = subprocess.run(
+        ["pgrep", "-P", str(pid)], capture_output=True, text=True
+    )
+    return [int(child) for child in result.stdout.split()]
+
+
 def test_tampered_fifo_is_recovered(server, tmp_path):
     # Roee #123 F1: replacing the FIFO bait with a regular file must RECOVER (rm the
     # impostor + re-create the FIFO), not just report failed forever and go blind.

--- a/tests/test_agent_live_sync.py
+++ b/tests/test_agent_live_sync.py
@@ -176,6 +176,42 @@ def test_live_sync_plants_added_and_removes_dropped(agent):
     assert Path(keep).read_text() == BAIT_BODY, "kept bait disturbed"
 
 
+def test_live_sync_restarts_a_dead_watcher(agent):
+    """A transient sensor crash must not leave a live-sync agent blind forever.
+
+    Kill the atime watcher, wait for the sync loop to notice, then read the bait.
+    A callback proves the replacement watcher is functional rather than merely
+    proving that some short-lived shell child exists (issue #99).
+    """
+    keep = agent["keep"]
+    agent["set"]([{"id": "dep_keep", "path": keep}])
+    proc = agent["start"](
+        "--sensor", "atime", "--poll", "1",
+        "--sync-interval", "1", "--heartbeat", "0",
+    )
+    assert _wait_until(lambda: Path(keep).exists()), "initial bait not planted"
+
+    def direct_children():
+        result = subprocess.run(
+            ["pgrep", "-P", str(proc.pid)], capture_output=True, text=True
+        )
+        return [int(pid) for pid in result.stdout.split()]
+
+    assert _wait_until(lambda: len(direct_children()) == 1), \
+        "watcher child did not start"
+    dead_pid = direct_children()[0]
+    os.kill(dead_pid, signal.SIGKILL)
+    assert _wait_until(lambda: dead_pid not in direct_children()), \
+        "killed watcher did not exit"
+
+    # Give the sync loop one cycle to restart the watcher, then move atime to
+    # "now".  The replacement watcher must observe it and fire the callback.
+    time.sleep(2)
+    os.utime(keep, (time.time(), Path(keep).stat().st_mtime))
+    assert _wait_until(lambda: "/cb/dep_keep" in _StubHandler.seen, timeout=10), \
+        "replacement watcher did not detect a bait read"
+
+
 def test_reconcile_never_deletes_a_file_it_did_not_plant(agent):
     """Un-assigning a tripwire must NEVER delete a real credential sitting at that
     path - reconcile may only remove bait WE planted (issue #29 invariant). A

--- a/tests/test_agent_mixed.py
+++ b/tests/test_agent_mixed.py
@@ -153,6 +153,63 @@ def test_mixed_sensors_plant_and_fire_together(server, tmp_path):
         agent.wait(timeout=5)
 
 
+def test_mixed_watcher_restarts_a_dead_atime_child(server, tmp_path):
+    """The mixed supervisor must recover if only its atime child dies (#99)."""
+    fifo = tmp_path / "credentials"
+    atin = tmp_path / "config"
+    Stub.deployments = [
+        ("dep_fifo", str(fifo), "fifo"),
+        ("dep_atime", str(atin), "atime"),
+    ]
+    agent = _spawn(server, tmp_path)
+
+    def process_tree():
+        result = subprocess.run(
+            ["ps", "-axo", "pid=,ppid=,command="], capture_output=True, text=True
+        )
+        rows = []
+        for line in result.stdout.splitlines():
+            fields = line.strip().split(None, 2)
+            if len(fields) == 3:
+                rows.append((int(fields[0]), int(fields[1]), fields[2]))
+        return rows
+
+    def atime_child():
+        rows = process_tree()
+        children = {}
+        for pid, ppid, command in rows:
+            children.setdefault(ppid, []).append((pid, command))
+        main_children = children.get(agent.pid, [])
+        if len(main_children) != 1:
+            return None
+        watcher = main_children[0][0]
+        # POSIX sh does not expose a portable background-job registry. The atime
+        # child is identifiable by its current `sleep $POLL`; the FIFO writer is
+        # blocked in open() and the supervisor's own sleep is a direct child.
+        return next(
+            (pid for pid, _ in children.get(watcher, [])
+             if any(command.strip() == "sleep 1"
+                    for _, command in children.get(pid, []))),
+            None,
+        )
+
+    try:
+        assert _wait(lambda: fifo.exists() and atin.exists()), "baits not planted"
+        assert _wait(lambda: atime_child() is not None), "atime child not found"
+        dead_pid = atime_child()
+        os.kill(dead_pid, 9)
+        assert _wait(lambda: atime_child() not in (None, dead_pid)), \
+            "mixed supervisor did not replace the dead atime child"
+
+        Stub.callbacks = []
+        os.utime(atin, (time.time(), os.stat(atin).st_mtime))
+        assert _wait(lambda: _fired("/cb/dep_atime")), \
+            "replacement atime child did not detect a read"
+    finally:
+        agent.terminate()
+        agent.wait(timeout=5)
+
+
 def test_explicit_sensor_overrides_server_per_deployment(server, tmp_path):
     # Roee #164 F2: an operator's explicit --sensor atime is an intentional opt-out
     # of FIFOs; it MUST win over the server's sensor=fifo, so the bait is planted as


### PR DESCRIPTION
## Summary

- restart a dead top-level sensor supervisor during live sync, independent of deployment changes
- supervise the mixed-mode atime child alongside FIFO writers
- track sensor-worker process identities so orphaned workers are cleaned before restart without signalling reused or unrelated PIDs
- serialize watcher generations by waiting for the old supervisor before starting its replacement

Closes #99

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Refactor / internal (no user-facing change)
- [ ] Other:

## Checklist

- [x] `pytest -v` passes locally (`pip install -e ".[dev]"` first — see CONTRIBUTING.md)
- [ ] For UI changes: verified with `cd ui && npm install && npm run dev` (not applicable)
- [ ] For a new/changed plugin: follows `docs/plugins.md` (not applicable)
- [ ] For a new honeytoken type: follows `docs/tokens.md` (not applicable)
- [x] Added a one-line entry under `## [Unreleased]` in `CHANGELOG.md`
- [x] PR is scoped to the linked issue — no unrelated changes

## Testing notes

- Added functional regression coverage for a dead top-level atime watcher; the replacement must detect a subsequent read and deliver its callback.
- Added mixed-mode coverage that kills only the atime child while leaving the supervisor/FIFO worker alive.
- Added FIFO coverage that kills the supervisor with `SIGKILL`, verifies orphan workers are removed, and confirms the replacement still serves/detects reads.
- Added stale/poisoned registry coverage to ensure cleanup does not signal unrelated process identities.
- `pytest -q`: **375 passed, 1 skipped**
- `sh -n agent/thumper_agent.sh`
- `git diff --check`

The remaining check/signal TOCTOU is inherent to PID-based POSIX shell process control; process lifetime fingerprints (`lstart` plus full command), owner validation, stale-registry removal, and generation serialization reduce that residual without changing the standalone-agent dependency model.
