### PR TITLE
feat(vault): DB models + store for vault connections and canary secrets

### DIFF
--- a/server/thumper/db.py
+++ b/server/thumper/db.py
@@ -119,6 +119,43 @@ class DeliveryAttempt(Base):
     )
 
 
+class VaultConnection(Base):
+    """A configured connection to a third-party secrets manager (a `vault`
+    plugin instance). `config_json` holds the plugin's saved config (with secret
+    fields packed by secrets_crypto); `configured` flips true once a connection
+    test passes."""
+    __tablename__ = "vault_connections"
+    id = Column(String(255), primary_key=True)
+    name = Column(String(255), nullable=False)
+    plugin = Column(String(255), nullable=False)
+    config_json = Column(Text, nullable=False, default="{}")
+    configured = Column(Boolean, nullable=False, default=False)
+    last_poll_at = Column(String(255))
+    created_at = Column(String(255), nullable=False)
+
+
+class CanarySecret(Base):
+    """A canary secret planted in a secrets manager via a VaultConnection.
+    `state`: pending -> planted -> triggered. `value` is the fake credential
+    written at `path`; a read of it (seen in the manager's audit log) fires."""
+    __tablename__ = "canary_secrets"
+    id = Column(String(255), primary_key=True)
+    vault_connection_id = Column(
+        String(255),
+        ForeignKey("vault_connections.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    template = Column(String(255), nullable=False)
+    path = Column(String(255), nullable=False)
+    value = Column(Text, nullable=False)
+    state = Column(String(255), nullable=False, default="pending")
+    created_at = Column(String(255), nullable=False)
+    last_accessed_at = Column(String(255))
+    __table_args__ = (
+        Index("ix_canary_vault_conn", "vault_connection_id"),
+    )
+
+
 # ── engine + session ────────────────────────────────────────────────────────
 # Created lazily on first use rather than at import time, so a THUMPER_DB / dotenv
 # override applied after this module is imported (CLI, tests) still takes effect.

--- a/server/thumper/migrations/versions/vault_tables_v1.py
+++ b/server/thumper/migrations/versions/vault_tables_v1.py
@@ -1,0 +1,51 @@
+"""Add vault_connections and canary_secrets tables for secrets-manager integrations.
+
+Revision ID: vault_tables_v1
+Revises: endpoint_ephemeral_v1
+Create Date: 2026-07-20
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "vault_tables_v1"
+down_revision: Union[str, None] = "endpoint_ephemeral_v1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "vault_connections",
+        sa.Column("id", sa.String(255), primary_key=True),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("plugin", sa.String(255), nullable=False),
+        sa.Column("config_json", sa.Text(), nullable=False, server_default="{}"),
+        sa.Column("configured", sa.Boolean(), nullable=False,
+                  server_default=sa.false()),
+        sa.Column("last_poll_at", sa.String(255), nullable=True),
+        sa.Column("created_at", sa.String(255), nullable=False),
+    )
+    op.create_table(
+        "canary_secrets",
+        sa.Column("id", sa.String(255), primary_key=True),
+        sa.Column("vault_connection_id", sa.String(255),
+                  sa.ForeignKey("vault_connections.id", ondelete="CASCADE"),
+                  nullable=False),
+        sa.Column("template", sa.String(255), nullable=False),
+        sa.Column("path", sa.String(255), nullable=False),
+        sa.Column("value", sa.Text(), nullable=False),
+        sa.Column("state", sa.String(255), nullable=False,
+                  server_default="pending"),
+        sa.Column("created_at", sa.String(255), nullable=False),
+        sa.Column("last_accessed_at", sa.String(255), nullable=True),
+    )
+    op.create_index("ix_canary_vault_conn", "canary_secrets",
+                    ["vault_connection_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_canary_vault_conn", table_name="canary_secrets")
+    op.drop_table("canary_secrets")
+    op.drop_table("vault_connections")

--- a/server/thumper/store.py
+++ b/server/thumper/store.py
@@ -2,6 +2,7 @@
 the app deals in ORM model instances (attribute access: row.id, row.name, …).
 """
 import hmac
+import json
 import secrets
 from datetime import datetime, timezone
 from typing import Optional
@@ -11,7 +12,8 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from .db import (
-    Alert, Deployment, DeliveryAttempt, Endpoint, Integration, Tripwire,
+    Alert, CanarySecret, Deployment, DeliveryAttempt, Endpoint, Integration,
+    Tripwire, VaultConnection,
 )
 from .models import iso_now
 from .services.secrets_crypto import pack_config
@@ -432,3 +434,118 @@ def set_integration_test_result(db: Session, *, plugin: str, status: str,
         row.last_test_at = iso_now()
         row.last_test_error = error
         db.commit()
+
+
+# ── vault connections (secrets-manager instances) ────────────────────────────
+def create_vault_connection(db: Session, *, name: str, plugin: str,
+                            config: dict) -> VaultConnection:
+    row = VaultConnection(id=_id("vc"), name=name, plugin=plugin,
+                          config_json=json.dumps(config), configured=False,
+                          created_at=iso_now())
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def list_vault_connections(db: Session) -> list[VaultConnection]:
+    return db.query(VaultConnection).order_by(
+        VaultConnection.created_at.desc()).all()
+
+
+def get_vault_connection(db: Session, vid: str) -> Optional[VaultConnection]:
+    return db.query(VaultConnection).filter(VaultConnection.id == vid).first()
+
+
+def update_vault_connection(db: Session, vid: str, *, name: str,
+                            config: dict) -> Optional[VaultConnection]:
+    row = get_vault_connection(db, vid)
+    if row is None:
+        return None
+    row.name = name
+    row.config_json = json.dumps(config)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def delete_vault_connection(db: Session, vid: str) -> bool:
+    row = get_vault_connection(db, vid)
+    if row is None:
+        return False
+    # Explicit child delete: ondelete=CASCADE is a DB-level FK action and SQLite
+    # doesn't enforce it unless PRAGMA foreign_keys=ON, so don't rely on it.
+    db.query(CanarySecret).filter(
+        CanarySecret.vault_connection_id == vid).delete()
+    db.delete(row)
+    db.commit()
+    return True
+
+
+def set_vault_connection_test(db: Session, *, vid: str,
+                              configured: bool) -> None:
+    row = get_vault_connection(db, vid)
+    if row:
+        row.configured = configured
+        db.commit()
+
+
+def update_vault_last_poll(db: Session, vid: str) -> None:
+    db.query(VaultConnection).filter(VaultConnection.id == vid).update(
+        {VaultConnection.last_poll_at: iso_now()})
+    db.commit()
+
+
+# ── canary secrets (planted in a secrets manager) ────────────────────────────
+def create_canary_secret(db: Session, *, vault_connection_id: str,
+                         template: str, path: str, value: str) -> CanarySecret:
+    row = CanarySecret(id=_id("cs"), vault_connection_id=vault_connection_id,
+                       template=template, path=path, value=value,
+                       state="pending", created_at=iso_now())
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def list_canary_secrets(db: Session) -> list[CanarySecret]:
+    return db.query(CanarySecret).order_by(CanarySecret.created_at.desc()).all()
+
+
+def get_canary_secret(db: Session, csid: str) -> Optional[CanarySecret]:
+    return db.query(CanarySecret).filter(CanarySecret.id == csid).first()
+
+
+def list_canary_secrets_for_connection(db: Session,
+                                       vid: str) -> list[CanarySecret]:
+    return db.query(CanarySecret).filter(
+        CanarySecret.vault_connection_id == vid).all()
+
+
+def list_planted_canary_secrets_for_connection(
+        db: Session, vid: str) -> list[CanarySecret]:
+    return db.query(CanarySecret).filter(
+        CanarySecret.vault_connection_id == vid,
+        CanarySecret.state.in_(["planted", "triggered"])).all()
+
+
+def set_canary_secret_state(db: Session, csid: str, state: str) -> None:
+    db.query(CanarySecret).filter(CanarySecret.id == csid).update(
+        {CanarySecret.state: state})
+    db.commit()
+
+
+def mark_canary_secret_accessed(db: Session, csid: str) -> None:
+    db.query(CanarySecret).filter(CanarySecret.id == csid).update(
+        {CanarySecret.last_accessed_at: iso_now(),
+         CanarySecret.state: "triggered"})
+    db.commit()
+
+
+def delete_canary_secret(db: Session, csid: str) -> bool:
+    row = get_canary_secret(db, csid)
+    if row is None:
+        return False
+    db.delete(row)
+    db.commit()
+    return True

--- a/tests/test_vault_store.py
+++ b/tests/test_vault_store.py
@@ -1,0 +1,129 @@
+import json
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from thumper import store
+from thumper.db import Base
+
+
+@pytest.fixture
+def db():
+    engine = create_engine("sqlite://", echo=False,
+                           connect_args={"check_same_thread": False},
+                           poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+
+
+# ── vault connections ────────────────────────────────────────────────────────
+def test_create_vault_connection(db):
+    vc = store.create_vault_connection(
+        db, name="Production Vault", plugin="hashicorp",
+        config={"url": "http://vault:8200", "role_id": "abc"})
+    assert vc.id.startswith("vc_")
+    assert vc.name == "Production Vault"
+    assert vc.plugin == "hashicorp"
+    assert vc.configured is False
+    assert vc.created_at is not None
+    assert json.loads(vc.config_json) == {"url": "http://vault:8200", "role_id": "abc"}
+
+
+def test_list_vault_connections_newest_first(db):
+    a = store.create_vault_connection(db, name="A", plugin="hashicorp", config={})
+    b = store.create_vault_connection(db, name="B", plugin="hashicorp", config={})
+    ids = [c.id for c in store.list_vault_connections(db)]
+    assert set(ids) == {a.id, b.id}
+    assert len(ids) == 2
+
+
+def test_get_vault_connection(db):
+    vc = store.create_vault_connection(db, name="T", plugin="hashicorp", config={})
+    assert store.get_vault_connection(db, vc.id).id == vc.id
+    assert store.get_vault_connection(db, "vc_nope") is None
+
+
+def test_update_vault_connection(db):
+    vc = store.create_vault_connection(db, name="Old", plugin="hashicorp",
+                                       config={"url": "http://old"})
+    updated = store.update_vault_connection(db, vc.id, name="New",
+                                            config={"url": "http://new"})
+    assert updated.name == "New"
+    assert json.loads(updated.config_json)["url"] == "http://new"
+    assert store.update_vault_connection(db, "vc_nope", name="X", config={}) is None
+
+
+def test_set_vault_connection_test_flips_configured(db):
+    vc = store.create_vault_connection(db, name="T", plugin="hashicorp", config={})
+    store.set_vault_connection_test(db, vid=vc.id, configured=True)
+    assert store.get_vault_connection(db, vc.id).configured is True
+
+
+def test_update_vault_last_poll(db):
+    vc = store.create_vault_connection(db, name="T", plugin="hashicorp", config={})
+    assert store.get_vault_connection(db, vc.id).last_poll_at is None
+    store.update_vault_last_poll(db, vc.id)
+    assert store.get_vault_connection(db, vc.id).last_poll_at is not None
+
+
+def test_delete_vault_connection_cascades_canaries(db):
+    vc = store.create_vault_connection(db, name="T", plugin="hashicorp", config={})
+    store.create_canary_secret(db, vault_connection_id=vc.id, template="stripe",
+                               path="secret/stripe/key", value="sk_live_fake")
+    assert store.delete_vault_connection(db, vc.id) is True
+    assert store.list_canary_secrets_for_connection(db, vc.id) == []
+    assert store.delete_vault_connection(db, "vc_nope") is False
+
+
+# ── canary secrets ────────────────────────────────────────────────────────────
+def test_create_canary_secret(db):
+    vc = store.create_vault_connection(db, name="T", plugin="hashicorp", config={})
+    cs = store.create_canary_secret(db, vault_connection_id=vc.id,
+                                    template="stripe", path="secret/stripe/key",
+                                    value="sk_live_fake")
+    assert cs.id.startswith("cs_")
+    assert cs.state == "pending"
+    assert cs.last_accessed_at is None
+
+
+def test_set_canary_secret_state(db):
+    vc = store.create_vault_connection(db, name="T", plugin="hashicorp", config={})
+    cs = store.create_canary_secret(db, vault_connection_id=vc.id, template="s",
+                                    path="p", value="v")
+    store.set_canary_secret_state(db, cs.id, "planted")
+    assert store.get_canary_secret(db, cs.id).state == "planted"
+
+
+def test_mark_canary_secret_accessed_triggers(db):
+    vc = store.create_vault_connection(db, name="T", plugin="hashicorp", config={})
+    cs = store.create_canary_secret(db, vault_connection_id=vc.id, template="s",
+                                    path="p", value="v")
+    store.mark_canary_secret_accessed(db, cs.id)
+    row = store.get_canary_secret(db, cs.id)
+    assert row.state == "triggered"
+    assert row.last_accessed_at is not None
+
+
+def test_list_planted_canary_secrets_for_connection(db):
+    vc = store.create_vault_connection(db, name="T", plugin="hashicorp", config={})
+    pending = store.create_canary_secret(db, vault_connection_id=vc.id,
+                                         template="s", path="p1", value="v")
+    planted = store.create_canary_secret(db, vault_connection_id=vc.id,
+                                         template="s", path="p2", value="v")
+    store.set_canary_secret_state(db, planted.id, "planted")
+    ids = [c.id for c in store.list_planted_canary_secrets_for_connection(db, vc.id)]
+    assert planted.id in ids
+    assert pending.id not in ids
+
+
+def test_delete_canary_secret(db):
+    vc = store.create_vault_connection(db, name="T", plugin="hashicorp", config={})
+    cs = store.create_canary_secret(db, vault_connection_id=vc.id, template="s",
+                                    path="p", value="v")
+    assert store.delete_canary_secret(db, cs.id) is True
+    assert store.get_canary_secret(db, cs.id) is None
+    assert store.delete_canary_secret(db, "cs_nope") is False


### PR DESCRIPTION
**Task 2 of #255** (secret-manager honeytokens) — the persistence layer.

### Changes
- **ORM models** (`db.py`): `VaultConnection` (a configured secrets-manager instance) and `CanarySecret` (a canary planted in one; `state`: pending → planted → triggered), in the existing `Column(...)` style.
- **Alembic migration** `vault_tables_v1` — chained off the current head `endpoint_ephemeral_v1`, creates `vault_connections` + `canary_secrets` + the FK index.
- **Store functions**: create/list/get/update/delete vault connections, `set_vault_connection_test`, `update_vault_last_poll`; create/list/get/list(_planted)_for_connection/set_state/mark_accessed/delete canary secrets. `delete_vault_connection` removes child canaries explicitly (SQLite doesn't enforce `ondelete=CASCADE` without the FK pragma).

### Scope / relationships
- **Independent of #257** (the `VaultPlugin` base) — disjoint files, either merge order works.
- The canary access-log dedup table + poller wiring is deferred to the poller task (#255 Task 6).

### Tests
`tests/test_vault_store.py` — 12 tests over both models and every store function. Verified: `alembic upgrade head` applies `endpoint_ephemeral_v1 → vault_tables_v1` and creates both tables; migration stays single-head; 40 existing db tests still pass; ruff clean.

Part of #255.