### PR TITLE
feat(vault): canary secret templates + generator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /app
 COPY pyproject.toml README.md ./
 COPY server/ ./server/
 COPY plugins/ ./plugins/
+COPY templates/ ./templates/
 COPY agent/ ./agent/
 RUN pip install --no-cache-dir ".[postgres,mysql]"
 

--- a/server/thumper/services/templates.py
+++ b/server/thumper/services/templates.py
@@ -1,0 +1,69 @@
+"""Load and serve canary secret templates from the templates/ directory.
+
+A template describes a realistic-looking (but fake) credential for a popular
+SaaS tool: its display name, category, the value format (prefix/length/charset),
+and suggested vault paths. `generate_value` mints a fresh fake credential from a
+template; the value authenticates to nothing - a read of it in a secrets manager
+is the signal.
+"""
+import secrets
+import string
+
+import yaml
+
+from ..config import REPO_ROOT
+
+_TEMPLATES_DIR = REPO_ROOT / "templates"
+_cache: list[dict] | None = None
+
+_CHARSETS = {
+    "alphanumeric": string.ascii_letters + string.digits,
+    "alphanumeric_dash": string.ascii_letters + string.digits + "-",
+    "alphanumeric_special": string.ascii_letters + string.digits + "-_",
+    "hex": string.hexdigits[:16],
+    "uppercase_alphanumeric": string.ascii_uppercase + string.digits,
+}
+
+
+def _load_all() -> list[dict]:
+    global _cache
+    if _cache is not None:
+        return _cache
+    templates: list[dict] = []
+    for path in sorted(_TEMPLATES_DIR.glob("*.yaml")):
+        with open(path) as f:
+            templates.append(yaml.safe_load(f))
+    templates.sort(key=lambda t: (t.get("category", ""), t.get("name", "")))
+    _cache = templates
+    return _cache
+
+
+def reset_cache() -> None:
+    """Drop the cached template list (mainly for tests)."""
+    global _cache
+    _cache = None
+
+
+def list_templates() -> list[dict]:
+    """Every parsed template, sorted by category then name."""
+    return _load_all()
+
+
+def get_template(slug: str) -> dict | None:
+    """Return the template with the given slug, or None."""
+    for t in _load_all():
+        if t["slug"] == slug:
+            return t
+    return None
+
+
+def generate_value(template: dict) -> str:
+    """Mint a fresh fake credential matching the template's format spec."""
+    fmt = template["format"]
+    prefix = fmt.get("prefix", "")
+    total_length = fmt["length"]
+    charset = _CHARSETS.get(fmt.get("charset", "alphanumeric"),
+                            _CHARSETS["alphanumeric"])
+    suffix_length = total_length - len(prefix)
+    suffix = "".join(secrets.choice(charset) for _ in range(suffix_length))
+    return prefix + suffix

--- a/templates/adp.yaml
+++ b/templates/adp.yaml
@@ -1,0 +1,13 @@
+name: "ADP Client Secret"
+slug: adp
+category: "HR"
+format:
+  prefix: ""
+  length: 64
+  charset: alphanumeric
+suggested_paths:
+  - "production/adp/client_secret"
+  - "services/hr/adp_secret"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/asana.yaml
+++ b/templates/asana.yaml
@@ -1,0 +1,13 @@
+name: "Asana Personal Access Token"
+slug: asana
+category: "Project Management"
+format:
+  prefix: ""
+  length: 32
+  charset: alphanumeric
+suggested_paths:
+  - "production/asana/pat"
+  - "services/pm/asana_token"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/auth0.yaml
+++ b/templates/auth0.yaml
@@ -1,0 +1,13 @@
+name: "Auth0 Client Secret"
+slug: auth0
+category: "Identity"
+format:
+  prefix: ""
+  length: 64
+  charset: alphanumeric_special
+suggested_paths:
+  - "production/auth0/client_secret"
+  - "services/identity/auth0_secret"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/aws.yaml
+++ b/templates/aws.yaml
@@ -1,0 +1,13 @@
+name: "AWS Access Key"
+slug: aws
+category: "Cloud"
+format:
+  prefix: "AKIA"
+  length: 20
+  charset: uppercase_alphanumeric
+suggested_paths:
+  - "production/aws/access_key_id"
+  - "services/infra/aws_credentials"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/azure_client.yaml
+++ b/templates/azure_client.yaml
@@ -1,0 +1,13 @@
+name: "Azure Client Secret"
+slug: azure_client
+category: "Cloud"
+format:
+  prefix: ""
+  length: 40
+  charset: alphanumeric_special
+suggested_paths:
+  - "production/azure/client_secret"
+  - "services/infra/azure_credentials"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/bamboohr.yaml
+++ b/templates/bamboohr.yaml
@@ -1,0 +1,13 @@
+name: "BambooHR API Key"
+slug: bamboohr
+category: "HR"
+format:
+  prefix: ""
+  length: 40
+  charset: alphanumeric
+suggested_paths:
+  - "production/bamboohr/api_key"
+  - "services/hr/bamboohr_key"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/bitbucket.yaml
+++ b/templates/bitbucket.yaml
@@ -1,0 +1,13 @@
+name: "Bitbucket App Password"
+slug: bitbucket
+category: "R&D"
+format:
+  prefix: ""
+  length: 20
+  charset: alphanumeric
+suggested_paths:
+  - "production/bitbucket/app_password"
+  - "ci/bitbucket/access_token"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/brex.yaml
+++ b/templates/brex.yaml
@@ -1,0 +1,13 @@
+name: "Brex API Token"
+slug: brex
+category: Finance
+format:
+  prefix: ""
+  length: 64
+  charset: alphanumeric
+suggested_paths:
+  - "production/brex/api_token"
+  - "services/finance/brex_token"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/cloudflare.yaml
+++ b/templates/cloudflare.yaml
@@ -1,0 +1,13 @@
+name: "Cloudflare API Token"
+slug: cloudflare
+category: "Cloud"
+format:
+  prefix: ""
+  length: 40
+  charset: alphanumeric_special
+suggested_paths:
+  - "production/cloudflare/api_token"
+  - "services/infra/cloudflare_key"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/confluence.yaml
+++ b/templates/confluence.yaml
@@ -1,0 +1,13 @@
+name: "Confluence API Token"
+slug: confluence
+category: "Project Management"
+format:
+  prefix: ""
+  length: 24
+  charset: alphanumeric
+suggested_paths:
+  - "production/confluence/api_token"
+  - "services/pm/confluence_token"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/crowdstrike.yaml
+++ b/templates/crowdstrike.yaml
@@ -1,0 +1,13 @@
+name: "CrowdStrike API Secret"
+slug: crowdstrike
+category: "Identity"
+format:
+  prefix: ""
+  length: 40
+  charset: alphanumeric_special
+suggested_paths:
+  - "production/crowdstrike/api_secret"
+  - "services/identity/crowdstrike_secret"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/datadog.yaml
+++ b/templates/datadog.yaml
@@ -1,0 +1,13 @@
+name: "Datadog API Key"
+slug: datadog
+category: "R&D"
+format:
+  prefix: ""
+  length: 32
+  charset: hex
+suggested_paths:
+  - "production/datadog/api_key"
+  - "services/monitoring/datadog_key"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/docusign.yaml
+++ b/templates/docusign.yaml
@@ -1,0 +1,13 @@
+name: "DocuSign Integration Key"
+slug: docusign
+category: Legal
+format:
+  prefix: ""
+  length: 36
+  charset: hex
+suggested_paths:
+  - "production/docusign/integration_key"
+  - "services/legal/docusign_key"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/gcp.yaml
+++ b/templates/gcp.yaml
@@ -1,0 +1,13 @@
+name: "GCP Service Account Key"
+slug: gcp
+category: "Cloud"
+format:
+  prefix: ""
+  length: 40
+  charset: alphanumeric_special
+suggested_paths:
+  - "production/gcp/service_account_key"
+  - "services/infra/gcp_credentials"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/github.yaml
+++ b/templates/github.yaml
@@ -1,0 +1,13 @@
+name: "GitHub Personal Access Token"
+slug: github
+category: "R&D"
+format:
+  prefix: "ghp_"
+  length: 40
+  charset: alphanumeric
+suggested_paths:
+  - "production/github/pat"
+  - "ci/github/access_token"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/gitlab.yaml
+++ b/templates/gitlab.yaml
@@ -1,0 +1,13 @@
+name: "GitLab Personal Access Token"
+slug: gitlab
+category: "R&D"
+format:
+  prefix: "glpat-"
+  length: 26
+  charset: alphanumeric_dash
+suggested_paths:
+  - "production/gitlab/pat"
+  - "ci/gitlab/access_token"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/google_workspace.yaml
+++ b/templates/google_workspace.yaml
@@ -1,0 +1,13 @@
+name: "Google Workspace API Key"
+slug: google_workspace
+category: Collaboration
+format:
+  prefix: ""
+  length: 39
+  charset: alphanumeric_special
+suggested_paths:
+  - "production/google_workspace/api_key"
+  - "services/collaboration/google_key"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/hubspot.yaml
+++ b/templates/hubspot.yaml
@@ -1,0 +1,13 @@
+name: "HubSpot API Key"
+slug: hubspot
+category: "CRM"
+format:
+  prefix: ""
+  length: 36
+  charset: hex
+suggested_paths:
+  - "production/hubspot/api_key"
+  - "services/crm/hubspot_key"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/jira.yaml
+++ b/templates/jira.yaml
@@ -1,0 +1,13 @@
+name: "Jira API Token"
+slug: jira
+category: "Project Management"
+format:
+  prefix: ""
+  length: 24
+  charset: alphanumeric
+suggested_paths:
+  - "production/jira/api_token"
+  - "services/pm/jira_token"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/jumpcloud.yaml
+++ b/templates/jumpcloud.yaml
@@ -1,0 +1,13 @@
+name: "JumpCloud API Key"
+slug: jumpcloud
+category: "Identity"
+format:
+  prefix: ""
+  length: 40
+  charset: hex
+suggested_paths:
+  - "production/jumpcloud/api_key"
+  - "services/identity/jumpcloud_key"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/linear.yaml
+++ b/templates/linear.yaml
@@ -1,0 +1,13 @@
+name: "Linear API Key"
+slug: linear
+category: "Project Management"
+format:
+  prefix: "lin_api_"
+  length: 48
+  charset: alphanumeric
+suggested_paths:
+  - "production/linear/api_key"
+  - "services/pm/linear_key"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/mailchimp.yaml
+++ b/templates/mailchimp.yaml
@@ -1,0 +1,13 @@
+name: "Mailchimp API Key"
+slug: mailchimp
+category: Marketing
+format:
+  prefix: ""
+  length: 36
+  charset: alphanumeric_dash
+suggested_paths:
+  - "production/mailchimp/api_key"
+  - "services/email/mailchimp_key"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/mongodb.yaml
+++ b/templates/mongodb.yaml
@@ -1,0 +1,13 @@
+name: "MongoDB Atlas API Key"
+slug: mongodb
+category: "Cloud"
+format:
+  prefix: ""
+  length: 36
+  charset: hex
+suggested_paths:
+  - "production/mongodb/api_key"
+  - "services/data/mongodb_key"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/netsuite.yaml
+++ b/templates/netsuite.yaml
@@ -1,0 +1,13 @@
+name: "NetSuite Consumer Secret"
+slug: netsuite
+category: Finance
+format:
+  prefix: ""
+  length: 64
+  charset: alphanumeric
+suggested_paths:
+  - "production/netsuite/consumer_secret"
+  - "services/finance/netsuite_secret"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/newrelic.yaml
+++ b/templates/newrelic.yaml
@@ -1,0 +1,13 @@
+name: "New Relic API Key"
+slug: newrelic
+category: "R&D"
+format:
+  prefix: "NRAK-"
+  length: 32
+  charset: uppercase_alphanumeric
+suggested_paths:
+  - "production/newrelic/api_key"
+  - "services/monitoring/newrelic_key"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/notion.yaml
+++ b/templates/notion.yaml
@@ -1,0 +1,13 @@
+name: "Notion Integration Token"
+slug: notion
+category: "Project Management"
+format:
+  prefix: "secret_"
+  length: 50
+  charset: alphanumeric
+suggested_paths:
+  - "production/notion/integration_token"
+  - "services/pm/notion_secret"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/okta.yaml
+++ b/templates/okta.yaml
@@ -1,0 +1,13 @@
+name: "Okta API Token"
+slug: okta
+category: "Identity"
+format:
+  prefix: "00"
+  length: 42
+  charset: alphanumeric
+suggested_paths:
+  - "production/okta/api_token"
+  - "services/identity/okta_secret"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/pagerduty.yaml
+++ b/templates/pagerduty.yaml
@@ -1,0 +1,13 @@
+name: "PagerDuty API Key"
+slug: pagerduty
+category: "R&D"
+format:
+  prefix: ""
+  length: 20
+  charset: alphanumeric
+suggested_paths:
+  - "production/pagerduty/api_key"
+  - "services/oncall/pagerduty_key"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/plaid.yaml
+++ b/templates/plaid.yaml
@@ -1,0 +1,13 @@
+name: "Plaid Secret Key"
+slug: plaid
+category: Finance
+format:
+  prefix: ""
+  length: 30
+  charset: alphanumeric
+suggested_paths:
+  - "production/plaid/secret_key"
+  - "services/finance/plaid_secret"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/quickbooks.yaml
+++ b/templates/quickbooks.yaml
@@ -1,0 +1,13 @@
+name: "QuickBooks Client Secret"
+slug: quickbooks
+category: Finance
+format:
+  prefix: ""
+  length: 32
+  charset: alphanumeric
+suggested_paths:
+  - "production/quickbooks/client_secret"
+  - "services/finance/quickbooks_secret"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/rippling.yaml
+++ b/templates/rippling.yaml
@@ -1,0 +1,13 @@
+name: "Rippling API Key"
+slug: rippling
+category: "HR"
+format:
+  prefix: ""
+  length: 48
+  charset: alphanumeric
+suggested_paths:
+  - "production/rippling/api_key"
+  - "services/hr/rippling_key"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/salesforce.yaml
+++ b/templates/salesforce.yaml
@@ -1,0 +1,13 @@
+name: "Salesforce Connected App Secret"
+slug: salesforce
+category: "CRM"
+format:
+  prefix: ""
+  length: 64
+  charset: alphanumeric
+suggested_paths:
+  - "production/salesforce/client_secret"
+  - "services/crm/salesforce_secret"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/sendgrid.yaml
+++ b/templates/sendgrid.yaml
@@ -1,0 +1,13 @@
+name: "SendGrid API Key"
+slug: sendgrid
+category: Marketing
+format:
+  prefix: "SG."
+  length: 69
+  charset: alphanumeric_special
+suggested_paths:
+  - "production/sendgrid/api_key"
+  - "services/email/sendgrid_key"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/sentinelone.yaml
+++ b/templates/sentinelone.yaml
@@ -1,0 +1,13 @@
+name: "SentinelOne API Token"
+slug: sentinelone
+category: "Identity"
+format:
+  prefix: ""
+  length: 80
+  charset: alphanumeric
+suggested_paths:
+  - "production/sentinelone/api_token"
+  - "services/identity/sentinelone_token"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/sentry.yaml
+++ b/templates/sentry.yaml
@@ -1,0 +1,13 @@
+name: "Sentry Auth Token"
+slug: sentry
+category: "R&D"
+format:
+  prefix: "sntrys_"
+  length: 64
+  charset: alphanumeric
+suggested_paths:
+  - "production/sentry/auth_token"
+  - "services/monitoring/sentry_token"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/slack.yaml
+++ b/templates/slack.yaml
@@ -1,0 +1,13 @@
+name: "Slack Bot Token"
+slug: slack
+category: Collaboration
+format:
+  prefix: "xoxb-"
+  length: 72
+  charset: alphanumeric_dash
+suggested_paths:
+  - "production/slack/bot_token"
+  - "services/notifications/slack_token"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/snowflake.yaml
+++ b/templates/snowflake.yaml
@@ -1,0 +1,13 @@
+name: "Snowflake Account Key"
+slug: snowflake
+category: "Cloud"
+format:
+  prefix: ""
+  length: 64
+  charset: alphanumeric_special
+suggested_paths:
+  - "production/snowflake/account_key"
+  - "services/data/snowflake_secret"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/snyk.yaml
+++ b/templates/snyk.yaml
@@ -1,0 +1,13 @@
+name: "Snyk API Token"
+slug: snyk
+category: "R&D"
+format:
+  prefix: ""
+  length: 36
+  charset: hex
+suggested_paths:
+  - "production/snyk/api_token"
+  - "ci/snyk/auth_token"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/stripe.yaml
+++ b/templates/stripe.yaml
@@ -1,0 +1,13 @@
+name: "Stripe API Key"
+slug: stripe
+category: Finance
+format:
+  prefix: "sk_live_"
+  length: 48
+  charset: alphanumeric
+suggested_paths:
+  - "production/stripe/api_key"
+  - "services/payments/stripe_secret"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/teams.yaml
+++ b/templates/teams.yaml
@@ -1,0 +1,13 @@
+name: "Microsoft Teams Webhook"
+slug: teams
+category: Collaboration
+format:
+  prefix: ""
+  length: 64
+  charset: alphanumeric_special
+suggested_paths:
+  - "production/teams/webhook_url"
+  - "services/notifications/teams_webhook"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/terraform.yaml
+++ b/templates/terraform.yaml
@@ -1,0 +1,13 @@
+name: "Terraform Cloud Token"
+slug: terraform
+category: "Cloud"
+format:
+  prefix: ""
+  length: 14
+  charset: alphanumeric
+suggested_paths:
+  - "production/terraform/api_token"
+  - "services/infra/terraform_token"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/twilio.yaml
+++ b/templates/twilio.yaml
@@ -1,0 +1,13 @@
+name: "Twilio Auth Token"
+slug: twilio
+category: Marketing
+format:
+  prefix: ""
+  length: 32
+  charset: hex
+suggested_paths:
+  - "production/twilio/auth_token"
+  - "services/communications/twilio_token"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/workday.yaml
+++ b/templates/workday.yaml
@@ -1,0 +1,13 @@
+name: "Workday API Client Secret"
+slug: workday
+category: "HR"
+format:
+  prefix: ""
+  length: 64
+  charset: alphanumeric
+suggested_paths:
+  - "production/workday/client_secret"
+  - "services/hr/workday_secret"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/zendesk.yaml
+++ b/templates/zendesk.yaml
@@ -1,0 +1,13 @@
+name: "Zendesk API Token"
+slug: zendesk
+category: "CRM"
+format:
+  prefix: ""
+  length: 40
+  charset: alphanumeric
+suggested_paths:
+  - "production/zendesk/api_token"
+  - "services/crm/zendesk_token"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/zoom.yaml
+++ b/templates/zoom.yaml
@@ -1,0 +1,13 @@
+name: "Zoom JWT Token"
+slug: zoom
+category: Collaboration
+format:
+  prefix: ""
+  length: 32
+  charset: alphanumeric
+suggested_paths:
+  - "production/zoom/jwt_token"
+  - "services/collaboration/zoom_secret"
+metadata:
+  created_by: terraform
+  environment: production

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,76 @@
+from thumper.services.templates import (
+    generate_value,
+    get_template,
+    list_templates,
+    reset_cache,
+)
+
+
+def setup_function():
+    reset_cache()
+
+
+def test_list_templates_returns_all():
+    templates = list_templates()
+    slugs = {t["slug"] for t in templates}
+    assert {"stripe", "github", "slack", "aws"} <= slugs
+    assert len(templates) >= 10
+
+
+def test_list_templates_sorted_by_category_then_name():
+    templates = list_templates()
+    categories = [t["category"] for t in templates]
+    assert categories == sorted(categories)
+
+
+def test_every_template_has_the_required_shape():
+    for t in list_templates():
+        assert t["slug"] and t["name"] and t["category"]
+        assert "prefix" in t["format"] or t["format"].get("prefix", "") == ""
+        assert isinstance(t["format"]["length"], int)
+        assert isinstance(t["suggested_paths"], list) and t["suggested_paths"]
+
+
+def test_get_template_by_slug():
+    t = get_template("stripe")
+    assert t is not None
+    assert t["name"] == "Stripe API Key"
+    assert t["category"] == "Finance"
+    assert "format" in t and "suggested_paths" in t
+
+
+def test_get_template_unknown_returns_none():
+    assert get_template("nonexistent") is None
+
+
+def test_generate_value_with_prefix_and_length():
+    t = get_template("stripe")
+    value = generate_value(t)
+    assert value.startswith("sk_live_")
+    assert len(value) == t["format"]["length"] == 48
+
+
+def test_generate_value_alphanumeric():
+    t = get_template("github")
+    value = generate_value(t)
+    assert value.startswith("ghp_")
+    assert value[len("ghp_"):].isalnum()
+
+
+def test_generate_value_hex():
+    t = get_template("datadog")
+    value = generate_value(t)
+    int(value, 16)  # hex charset -> parses as hex, must not raise
+
+
+def test_generate_value_uppercase():
+    t = get_template("aws")
+    value = generate_value(t)
+    assert value.startswith("AKIA")
+    suffix = value[len("AKIA"):]
+    assert suffix == suffix.upper() and suffix.isalnum()
+
+
+def test_generate_value_is_unique_each_call():
+    t = get_template("stripe")
+    assert generate_value(t) != generate_value(t)


### PR DESCRIPTION
**Task 3 of #255** (secret-manager honeytokens) — the canary credential templates.

### Changes
- **45 template YAMLs** under `templates/` (stripe, github, slack, aws, datadog, okta, salesforce, gcp, azure, snowflake, ...). Each declares `name`/`slug`/`category`, a value `format` (`prefix`/`length`/`charset`), `suggested_paths`, and `metadata`. **Pure format specs — no real secrets**; actual values are minted at runtime.
- **`services/templates.py`** — `list_templates()` / `get_template(slug)` / `generate_value(template)`, loading `templates/` under `REPO_ROOT` (cached, sorted by category→name). `generate_value` mints a fresh fake credential matching the format (charsets: alphanumeric, dash, special, hex, uppercase).
- **Dockerfile** — `COPY templates/` so the loader finds them in the image (it previously only copied `server/`, `plugins/`, `agent/`).

### Scope
Independent of the other vault tasks (#257 framework, #259 models). Consumed later by the vault routes/UI to offer canary formats.

### Safety
I scanned all 45 templates — they contain only format descriptors (prefix/length/charset) and example paths, no literal credentials. The only "password" match is the credential-type *name* "Bitbucket App Password".

### Tests
`tests/test_templates.py` — 10 tests: listing, category sort, required shape on every template, get-by-slug, and `generate_value` across prefix/length/alphanumeric/hex/uppercase + uniqueness. ruff clean.

Part of #255.