### PR TITLE
feat(vault): HashiCorp Vault + AWS Secrets Manager plugins

### DIFF
--- a/plugins/vault/aws/manifest.yaml
+++ b/plugins/vault/aws/manifest.yaml
@@ -1,0 +1,36 @@
+name: aws
+kind: vault
+display_name: "AWS Secrets Manager"
+version: "0.1.0"
+author: thumper-core
+description: >
+  Connect to AWS Secrets Manager to plant and monitor canary secrets.
+  Uses IAM access keys and polls CloudTrail for secret read events.
+
+config_schema:
+  - key: region
+    label: "AWS Region"
+    type: string
+    required: true
+    placeholder: "us-east-1"
+    help: "The AWS region where secrets will be stored."
+
+  - key: access_key_id
+    label: "Access Key ID"
+    type: string
+    required: true
+    placeholder: "AKIA..."
+    help: "IAM access key with SecretsManager and CloudTrail read permissions."
+
+  - key: secret_access_key
+    label: "Secret Access Key"
+    type: secret
+    required: true
+    help: "The secret access key paired with the access key ID."
+
+  - key: prefix
+    label: "Secret Name Prefix"
+    type: string
+    required: false
+    placeholder: "thumper/"
+    help: "Optional prefix for all canary secret names in AWS. Helps organize secrets."

--- a/plugins/vault/aws/plugin.py
+++ b/plugins/vault/aws/plugin.py
@@ -1,0 +1,151 @@
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+
+import boto3
+from botocore.exceptions import ClientError
+
+from thumper.plugins.base import AccessEvent, PluginError, VaultPlugin
+
+log = logging.getLogger("thumper.plugin.aws")
+
+
+class Plugin(VaultPlugin):
+    def __init__(self, config: dict):
+        super().__init__(config)
+        self._sm_client = None
+        self._ct_client = None
+        self._last_poll_time: str | None = None
+
+    def connect(self) -> None:
+        region = self.config.get("region")
+        if not region:
+            raise PluginError("region is required")
+        access_key = self.config.get("access_key_id")
+        secret_key = self.config.get("secret_access_key")
+        if not access_key or not secret_key:
+            raise PluginError("access_key_id and secret_access_key are required")
+        try:
+            session = boto3.Session(
+                aws_access_key_id=access_key,
+                aws_secret_access_key=secret_key,
+                region_name=region,
+            )
+            self._sm_client = session.client("secretsmanager")
+            self._ct_client = session.client("cloudtrail")
+            self._sm_client.list_secrets(MaxResults=1)
+        except ClientError as exc:
+            raise PluginError(f"AWS authentication failed: {exc}") from exc
+        except Exception as exc:
+            raise PluginError(f"AWS connection failed: {exc}") from exc
+
+    def _ensure_connected(self) -> None:
+        if self._sm_client is None:
+            self.connect()
+
+    def plant(self, path: str, value: str, metadata: dict) -> None:
+        self._ensure_connected()
+        prefix = self.config.get("prefix", "")
+        full_name = f"{prefix}{path}" if prefix else path
+        tags = [{"Key": k, "Value": str(v)} for k, v in metadata.items()]
+        try:
+            self._sm_client.create_secret(
+                Name=full_name,
+                SecretString=value,
+                Description="Thumper canary secret",
+                Tags=tags,
+            )
+        except ClientError as exc:
+            if exc.response["Error"]["Code"] == "ResourceExistsException":
+                try:
+                    self._sm_client.put_secret_value(
+                        SecretId=full_name, SecretString=value)
+                except ClientError as update_exc:
+                    raise PluginError(
+                        f"Failed to update secret {full_name}: {update_exc}"
+                    ) from update_exc
+            else:
+                raise PluginError(
+                    f"Failed to create secret {full_name}: {exc}"
+                ) from exc
+
+    def delete(self, path: str) -> None:
+        self._ensure_connected()
+        prefix = self.config.get("prefix", "")
+        full_name = f"{prefix}{path}" if prefix else path
+        try:
+            self._sm_client.delete_secret(
+                SecretId=full_name,
+                ForceDeleteWithoutRecovery=True,
+            )
+        except ClientError as exc:
+            if exc.response["Error"]["Code"] != "ResourceNotFoundException":
+                raise PluginError(
+                    f"Failed to delete secret {full_name}: {exc}"
+                ) from exc
+
+    def poll(self, paths: list[str], since: str | None = None) -> list[AccessEvent]:
+        self._ensure_connected()
+        prefix = self.config.get("prefix", "")
+        watched = {}
+        for p in paths:
+            full_name = f"{prefix}{p}" if prefix else p
+            watched[full_name] = p
+
+        now = datetime.now(timezone.utc)
+        # CloudTrail delivers events 5-15 min after they occur, but timestamps
+        # reflect the original event time. Look back an extra 20 min so we
+        # don't miss events that arrived after our last poll window closed.
+        # Deduplication via event_id prevents double-processing.
+        lookback = timedelta(minutes=20)
+        if since:
+            start = datetime.fromisoformat(since) - lookback
+        elif self._last_poll_time:
+            start = datetime.fromisoformat(self._last_poll_time) - lookback
+        else:
+            start = now - timedelta(minutes=30)
+
+        events = []
+        try:
+            paginator = self._ct_client.get_paginator("lookup_events")
+            pages = paginator.paginate(
+                LookupAttributes=[{
+                    "AttributeKey": "EventName",
+                    "AttributeValue": "GetSecretValue",
+                }],
+                StartTime=start,
+                EndTime=now,
+            )
+            for page in pages:
+                for event in page.get("Events", []):
+                    resources = event.get("Resources", [])
+                    secret_name = None
+                    for r in resources:
+                        if r.get("ResourceType") == "AWS::SecretsManager::Secret":
+                            secret_name = r.get("ResourceName")
+                            break
+                    if not secret_name:
+                        ct_event = json.loads(event.get("CloudTrailEvent", "{}"))
+                        req_params = ct_event.get("requestParameters", {})
+                        secret_name = req_params.get("secretId")
+                    if secret_name and secret_name not in watched and ":secret:" in secret_name:
+                        short = secret_name.split(":secret:")[-1].rsplit("-", 1)[0]
+                        if short in watched:
+                            secret_name = short
+                    if secret_name and secret_name in watched:
+                        ct_event = json.loads(event.get("CloudTrailEvent", "{}"))
+                        events.append(AccessEvent(
+                            path=watched[secret_name],
+                            timestamp=event.get("EventTime", now).isoformat()
+                            if isinstance(event.get("EventTime"), datetime)
+                            else str(event.get("EventTime", "")),
+                            accessor=event.get("Username"),
+                            source_ip=ct_event.get("sourceIPAddress"),
+                            policy=None,
+                            extra={"event_id": event.get("EventId")},
+                        ))
+        except ClientError as exc:
+            log.warning("CloudTrail lookup failed: %s", exc)
+
+        self._last_poll_time = now.isoformat()
+        return events

--- a/plugins/vault/hashicorp/manifest.yaml
+++ b/plugins/vault/hashicorp/manifest.yaml
@@ -1,0 +1,43 @@
+name: hashicorp
+kind: vault
+display_name: "HashiCorp Vault"
+version: "0.1.0"
+author: thumper-core
+description: >
+  Connect to a HashiCorp Vault instance to plant and monitor canary secrets.
+  Uses AppRole authentication and polls the audit log for secret read events.
+
+config_schema:
+  - key: url
+    label: "Vault URL"
+    type: string
+    required: true
+    placeholder: "https://vault.example.com:8200"
+    help: "The base URL of your Vault server."
+
+  - key: mount
+    label: "KV mount path"
+    type: string
+    required: true
+    placeholder: "secret"
+    help: "The KV v2 secrets engine mount path."
+
+  - key: role_id
+    label: "AppRole Role ID"
+    type: string
+    required: true
+    placeholder: ""
+    help: "The role_id for AppRole authentication."
+
+  - key: secret_id
+    label: "AppRole Secret ID"
+    type: secret
+    required: true
+    help: "The secret_id for AppRole authentication."
+
+  - key: namespace
+    label: "Namespace"
+    type: string
+    required: false
+    placeholder: ""
+    help: "Vault namespace (Enterprise only). Leave blank for OSS Vault."

--- a/plugins/vault/hashicorp/plugin.py
+++ b/plugins/vault/hashicorp/plugin.py
@@ -1,0 +1,131 @@
+import json
+import logging
+
+import hvac
+
+from thumper.plugins.base import AccessEvent, PluginError, VaultPlugin
+
+log = logging.getLogger("thumper.plugin.hashicorp")
+
+
+class Plugin(VaultPlugin):
+    def __init__(self, config: dict):
+        super().__init__(config)
+        self._client: hvac.Client | None = None
+        self._last_audit_time: str | None = None
+
+    def connect(self) -> None:
+        url = self.config.get("url")
+        if not url:
+            raise PluginError("url is required")
+        role_id = self.config.get("role_id")
+        secret_id = self.config.get("secret_id")
+        if not role_id or not secret_id:
+            raise PluginError("role_id and secret_id are required")
+        namespace = self.config.get("namespace") or None
+        self._client = hvac.Client(url=url, namespace=namespace)
+        try:
+            resp = self._client.auth.approle.login(
+                role_id=role_id, secret_id=secret_id)
+            self._client.token = resp["auth"]["client_token"]
+        except Exception as exc:
+            raise PluginError(f"Vault authentication failed: {exc}") from exc
+        if not self._client.is_authenticated():
+            raise PluginError("Vault authentication failed: not authenticated")
+
+    def _ensure_connected(self) -> None:
+        if self._client is None:
+            self.connect()
+
+    def plant(self, path: str, value: str, metadata: dict) -> None:
+        self._ensure_connected()
+        mount = self.config.get("mount", "secret")
+        secret_data = {"value": value, **metadata}
+        try:
+            self._client.secrets.kv.v2.create_or_update_secret(
+                path=path, secret=secret_data, mount_point=mount)
+        except Exception as exc:
+            raise PluginError(f"Failed to plant secret at {path}: {exc}") from exc
+
+    def delete(self, path: str) -> None:
+        self._ensure_connected()
+        mount = self.config.get("mount", "secret")
+        try:
+            self._client.secrets.kv.v2.delete_metadata_and_all_versions(
+                path=path, mount_point=mount)
+        except Exception as exc:
+            raise PluginError(f"Failed to delete secret at {path}: {exc}") from exc
+
+    def poll(self, paths: list[str], since: str | None = None) -> list[AccessEvent]:
+        self._ensure_connected()
+        # Seed the audit cutoff from the caller's `since` (the connection's last
+        # poll time) on the first poll, so we don't re-scan the whole log.
+        if since and not self._last_audit_time:
+            self._last_audit_time = since
+        mount = self.config.get("mount", "secret")
+        entries = self._fetch_audit_entries()
+        watched = {f"{mount}/data/{p}" for p in paths}
+        events = []
+        for entry in entries:
+            if entry.get("type") != "response":
+                continue
+            req = entry.get("request", {})
+            if req.get("operation") != "read":
+                continue
+            entry_path = req.get("path", "")
+            if entry_path not in watched:
+                continue
+            auth = entry.get("auth", {})
+            req_meta = entry.get("request_metadata", {})
+            clean_path = entry_path.removeprefix(f"{mount}/data/")
+            events.append(AccessEvent(
+                path=clean_path,
+                timestamp=entry.get("time", ""),
+                accessor=auth.get("display_name"),
+                source_ip=req_meta.get("remote_address"),
+                policy=",".join(auth.get("policies", [])),
+            ))
+        if entries:
+            last = entries[-1].get("time")
+            if last:
+                self._last_audit_time = last
+        return events
+
+    def _fetch_audit_entries(self) -> list[dict]:
+        """Read audit log entries. This implementation reads from the file-based
+        audit device. Override or extend for syslog/socket audit devices."""
+        try:
+            devices = self._client.sys.list_enabled_audit_devices()
+        except Exception as exc:
+            log.warning("Failed to list audit devices: %s", exc)
+            return []
+        for _name, device in devices.get("data", {}).items():
+            if device.get("type") == "file":
+                file_path = device.get("options", {}).get("file_path")
+                if file_path:
+                    return self._read_audit_file(file_path)
+        return []
+
+    def _read_audit_file(self, file_path: str) -> list[dict]:
+        """Read the NDJSON audit log file, returning entries newer than the last
+        poll."""
+        entries = []
+        try:
+            with open(file_path) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        entry = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    ts = entry.get("time", "")
+                    if self._last_audit_time and ts <= self._last_audit_time:
+                        continue
+                    entries.append(entry)
+        except FileNotFoundError:
+            log.warning("Audit log file not found: %s", file_path)
+        except PermissionError:
+            log.warning("Cannot read audit log file: %s", file_path)
+        return entries

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = [
   "sqlalchemy>=2.0.51",
   "alembic>=1.18.5",
   "cryptography>=49.0.0",
+  "hvac>=2.0",           # HashiCorp Vault HTTP client (vault plugin)
+  "boto3>=1.34",         # AWS SDK (aws secrets-manager vault plugin)
 ]
 
 [project.optional-dependencies]

--- a/tests/test_aws_vault_plugin.py
+++ b/tests/test_aws_vault_plugin.py
@@ -1,0 +1,129 @@
+import importlib.util
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from thumper.plugins.base import AccessEvent, PluginError
+
+PLUGIN_FILE = (Path(__file__).resolve().parents[1]
+               / "plugins" / "vault" / "aws" / "plugin.py")
+
+
+def load_plugin_module():
+    spec = importlib.util.spec_from_file_location(
+        "thumper_plugin_aws_vault_test", PLUGIN_FILE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeSecretsManager:
+    def __init__(self):
+        self.created = []
+        self.deleted = []
+
+    def list_secrets(self, MaxResults=None):
+        return {"SecretList": []}
+
+    def create_secret(self, Name, SecretString, Description=None, Tags=None):
+        self.created.append({"Name": Name, "SecretString": SecretString,
+                             "Tags": Tags})
+
+    def delete_secret(self, SecretId, ForceDeleteWithoutRecovery=None):
+        self.deleted.append(SecretId)
+
+
+class FakePaginator:
+    def __init__(self, events):
+        self._events = events
+
+    def paginate(self, **kwargs):
+        return [{"Events": self._events}]
+
+
+class FakeCloudTrail:
+    def __init__(self, events=None):
+        self._events = events or []
+
+    def get_paginator(self, name):
+        return FakePaginator(self._events)
+
+
+class FakeSession:
+    def __init__(self, sm, ct, **kwargs):
+        self._sm, self._ct = sm, ct
+
+    def client(self, name):
+        return self._sm if name == "secretsmanager" else self._ct
+
+
+@pytest.fixture
+def module():
+    return load_plugin_module()
+
+
+def _connect(module, ct_events=None):
+    sm = FakeSecretsManager()
+    ct = FakeCloudTrail(ct_events)
+    plugin = module.Plugin({
+        "region": "us-east-1", "access_key_id": "AKIAFAKE",
+        "secret_access_key": "secret", "prefix": "",
+    })
+    module.boto3.Session = lambda **kw: FakeSession(sm, ct, **kw)
+    plugin.connect()
+    return plugin, sm, ct
+
+
+def test_connect_requires_region(module):
+    plugin = module.Plugin({"access_key_id": "a", "secret_access_key": "s"})
+    with pytest.raises(PluginError, match="region"):
+        plugin.connect()
+
+
+def test_connect_requires_keys(module):
+    plugin = module.Plugin({"region": "us-east-1"})
+    with pytest.raises(PluginError, match="access_key_id"):
+        plugin.connect()
+
+
+def test_plant_creates_secret(module):
+    plugin, sm, _ = _connect(module)
+    plugin.plant("production/stripe/key", "sk_live_fake",
+                 {"created_by": "terraform"})
+    assert len(sm.created) == 1
+    assert sm.created[0]["Name"] == "production/stripe/key"
+    assert sm.created[0]["SecretString"] == "sk_live_fake"
+    assert {"Key": "created_by", "Value": "terraform"} in sm.created[0]["Tags"]
+
+
+def test_delete_removes_secret(module):
+    plugin, sm, _ = _connect(module)
+    plugin.delete("production/stripe/key")
+    assert sm.deleted == ["production/stripe/key"]
+
+
+def test_poll_empty_when_no_events(module):
+    plugin, _, _ = _connect(module, ct_events=[])
+    assert plugin.poll(["production/stripe/key"]) == []
+
+
+def test_poll_parses_getsecretvalue_into_access_event(module):
+    ct_event = {
+        "EventTime": datetime(2026, 6, 22, 10, 0, tzinfo=timezone.utc),
+        "Username": "attacker",
+        "EventId": "evt-1",
+        "Resources": [{"ResourceType": "AWS::SecretsManager::Secret",
+                       "ResourceName": "production/stripe/key"}],
+        "CloudTrailEvent": '{"sourceIPAddress": "10.0.0.5", '
+                           '"requestParameters": {"secretId": "production/stripe/key"}}',
+    }
+    plugin, _, _ = _connect(module, ct_events=[ct_event])
+    events = plugin.poll(["production/stripe/key"])
+    assert len(events) == 1
+    ev = events[0]
+    assert isinstance(ev, AccessEvent)
+    assert ev.path == "production/stripe/key"
+    assert ev.accessor == "attacker"
+    assert ev.source_ip == "10.0.0.5"
+    assert ev.extra["event_id"] == "evt-1"

--- a/tests/test_hashicorp_plugin.py
+++ b/tests/test_hashicorp_plugin.py
@@ -1,0 +1,160 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from thumper.plugins.base import AccessEvent, PluginError
+
+PLUGIN_FILE = Path(__file__).resolve().parents[1] / "plugins" / "vault" / "hashicorp" / "plugin.py"
+
+
+def load_plugin_module():
+    spec = importlib.util.spec_from_file_location("thumper_plugin_hashicorp_test", PLUGIN_FILE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeKVv2:
+    def __init__(self):
+        self.created = []
+        self.deleted = []
+
+    def create_or_update_secret(self, path, secret, mount_point=None):
+        self.created.append({"path": path, "secret": secret, "mount_point": mount_point})
+
+    def delete_metadata_and_all_versions(self, path, mount_point=None):
+        self.deleted.append({"path": path, "mount_point": mount_point})
+
+
+class FakeAuditLogs:
+    def __init__(self, entries=None):
+        self.entries = entries or []
+
+    def list_enabled_audit_devices(self):
+        return {"data": {"file/": {"type": "file", "options": {"file_path": "/tmp/audit.log"}}}}
+
+
+class FakeAuth:
+    def __init__(self):
+        self.token = "s.faketoken"
+
+    class approle:
+        @staticmethod
+        def login(role_id, secret_id):
+            return {"auth": {"client_token": "s.faketoken"}}
+
+
+class FakeHvacClient:
+    def __init__(self, url=None, token=None, namespace=None):
+        self.url = url
+        self.token = token
+        self.namespace = namespace
+        self.secrets = type("secrets", (), {"kv": type("kv", (), {"v2": FakeKVv2()})()})()
+        self.sys = FakeAuditLogs()
+        self.auth = FakeAuth()
+        self._is_authenticated = True
+
+    def is_authenticated(self):
+        return self._is_authenticated
+
+
+@pytest.fixture
+def module(monkeypatch):
+    mod = load_plugin_module()
+    monkeypatch.setattr(mod, "hvac", type("hvac", (), {"Client": FakeHvacClient}))
+    return mod
+
+
+def test_connect_succeeds(module):
+    plugin = module.Plugin({
+        "url": "http://vault:8200",
+        "mount": "secret",
+        "role_id": "role123",
+        "secret_id": "secret456",
+    })
+    plugin.connect()
+    assert plugin._client is not None
+
+
+def test_connect_fails_without_url(module):
+    plugin = module.Plugin({"mount": "secret", "role_id": "r", "secret_id": "s"})
+    with pytest.raises(PluginError, match="url"):
+        plugin.connect()
+
+
+def test_plant_writes_secret(module):
+    plugin = module.Plugin({
+        "url": "http://vault:8200",
+        "mount": "secret",
+        "role_id": "r",
+        "secret_id": "s",
+    })
+    plugin.connect()
+    plugin.plant("production/stripe/key", "sk_live_fake", {"created_by": "terraform"})
+    kv = plugin._client.secrets.kv.v2
+    assert len(kv.created) == 1
+    assert kv.created[0]["path"] == "production/stripe/key"
+    assert kv.created[0]["secret"]["value"] == "sk_live_fake"
+    assert kv.created[0]["secret"]["created_by"] == "terraform"
+
+
+def test_delete_removes_secret(module):
+    plugin = module.Plugin({
+        "url": "http://vault:8200",
+        "mount": "secret",
+        "role_id": "r",
+        "secret_id": "s",
+    })
+    plugin.connect()
+    plugin.delete("production/stripe/key")
+    kv = plugin._client.secrets.kv.v2
+    assert len(kv.deleted) == 1
+    assert kv.deleted[0]["path"] == "production/stripe/key"
+
+
+def test_poll_returns_empty_when_no_reads(module, monkeypatch):
+    plugin = module.Plugin({
+        "url": "http://vault:8200",
+        "mount": "secret",
+        "role_id": "r",
+        "secret_id": "s",
+    })
+    plugin.connect()
+    monkeypatch.setattr(plugin, "_fetch_audit_entries", lambda: [])
+    events = plugin.poll(["production/stripe/key"])
+    assert events == []
+
+
+def test_poll_returns_access_events(module, monkeypatch):
+    plugin = module.Plugin({
+        "url": "http://vault:8200",
+        "mount": "secret",
+        "role_id": "r",
+        "secret_id": "s",
+    })
+    plugin.connect()
+    monkeypatch.setattr(plugin, "_fetch_audit_entries", lambda: [
+        {
+            "type": "response",
+            "time": "2026-06-22T10:00:00Z",
+            "request": {
+                "path": "secret/data/production/stripe/key",
+                "operation": "read",
+            },
+            "auth": {
+                "display_name": "approle-canary-reader",
+                "policies": ["default", "reader"],
+                "metadata": {"role_name": "canary-reader"},
+            },
+            "request_metadata": {
+                "remote_address": "10.0.0.5",
+            },
+        },
+    ])
+    events = plugin.poll(["production/stripe/key"])
+    assert len(events) == 1
+    assert isinstance(events[0], AccessEvent)
+    assert events[0].path == "production/stripe/key"
+    assert events[0].accessor == "approle-canary-reader"
+    assert events[0].source_ip == "10.0.0.5"


### PR DESCRIPTION
**Task 4 of #255** (secret-manager honeytokens) — the two secret-manager plugins. **Stacked on #257** (base = `feat/vault-plugin-framework`), so this diff is just the plugins; it retargets to `main` once #257 lands.

### Changes
- **`plugins/vault/hashicorp`** — AppRole auth (`hvac`), KV v2 `create_or_update`/`delete`, read detection by parsing the **file audit device**'s NDJSON log. `poll(paths, since)` seeds its cutoff from the connection's last poll.
- **`plugins/vault/aws`** — IAM-key auth (`boto3`), Secrets Manager `create`/`put`/`delete`, read detection via **CloudTrail `GetSecretValue`** lookup (20-min lookback for CloudTrail's delivery lag; the poller dedups by `event_id`).
- **New runtime deps:** `hvac>=2.0`, `boto3>=1.34`.

### Note on dependencies
This is the flagged dependency expansion — `hvac` (Vault HTTP client) and `boto3` (AWS SDK). Both are the standard clients for their respective services.

### Tests
- `tests/test_hashicorp_plugin.py` (ported) — connect/plant/delete/poll with a faked `hvac` client + audit entries.
- `tests/test_aws_vault_plugin.py` (new) — connect validation, plant/delete, and CloudTrail→`AccessEvent` parsing with a faked `boto3` session.
- 16 tests pass; plugin discovery + manifests API unaffected; both plugins load via the loader; ruff clean.

Part of #255.