### PR TITLE
feat(vault): API routes for connections, templates, and canary secrets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /app
 COPY pyproject.toml README.md ./
 COPY server/ ./server/
 COPY plugins/ ./plugins/
+COPY templates/ ./templates/
 COPY agent/ ./agent/
 RUN pip install --no-cache-dir ".[postgres,mysql]"
 

--- a/plugins/vault/aws/manifest.yaml
+++ b/plugins/vault/aws/manifest.yaml
@@ -1,0 +1,36 @@
+name: aws
+kind: vault
+display_name: "AWS Secrets Manager"
+version: "0.1.0"
+author: thumper-core
+description: >
+  Connect to AWS Secrets Manager to plant and monitor canary secrets.
+  Uses IAM access keys and polls CloudTrail for secret read events.
+
+config_schema:
+  - key: region
+    label: "AWS Region"
+    type: string
+    required: true
+    placeholder: "us-east-1"
+    help: "The AWS region where secrets will be stored."
+
+  - key: access_key_id
+    label: "Access Key ID"
+    type: string
+    required: true
+    placeholder: "AKIA..."
+    help: "IAM access key with SecretsManager and CloudTrail read permissions."
+
+  - key: secret_access_key
+    label: "Secret Access Key"
+    type: secret
+    required: true
+    help: "The secret access key paired with the access key ID."
+
+  - key: prefix
+    label: "Secret Name Prefix"
+    type: string
+    required: false
+    placeholder: "thumper/"
+    help: "Optional prefix for all canary secret names in AWS. Helps organize secrets."

--- a/plugins/vault/aws/plugin.py
+++ b/plugins/vault/aws/plugin.py
@@ -1,0 +1,151 @@
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+
+import boto3
+from botocore.exceptions import ClientError
+
+from thumper.plugins.base import AccessEvent, PluginError, VaultPlugin
+
+log = logging.getLogger("thumper.plugin.aws")
+
+
+class Plugin(VaultPlugin):
+    def __init__(self, config: dict):
+        super().__init__(config)
+        self._sm_client = None
+        self._ct_client = None
+        self._last_poll_time: str | None = None
+
+    def connect(self) -> None:
+        region = self.config.get("region")
+        if not region:
+            raise PluginError("region is required")
+        access_key = self.config.get("access_key_id")
+        secret_key = self.config.get("secret_access_key")
+        if not access_key or not secret_key:
+            raise PluginError("access_key_id and secret_access_key are required")
+        try:
+            session = boto3.Session(
+                aws_access_key_id=access_key,
+                aws_secret_access_key=secret_key,
+                region_name=region,
+            )
+            self._sm_client = session.client("secretsmanager")
+            self._ct_client = session.client("cloudtrail")
+            self._sm_client.list_secrets(MaxResults=1)
+        except ClientError as exc:
+            raise PluginError(f"AWS authentication failed: {exc}") from exc
+        except Exception as exc:
+            raise PluginError(f"AWS connection failed: {exc}") from exc
+
+    def _ensure_connected(self) -> None:
+        if self._sm_client is None:
+            self.connect()
+
+    def plant(self, path: str, value: str, metadata: dict) -> None:
+        self._ensure_connected()
+        prefix = self.config.get("prefix", "")
+        full_name = f"{prefix}{path}" if prefix else path
+        tags = [{"Key": k, "Value": str(v)} for k, v in metadata.items()]
+        try:
+            self._sm_client.create_secret(
+                Name=full_name,
+                SecretString=value,
+                Description="Thumper canary secret",
+                Tags=tags,
+            )
+        except ClientError as exc:
+            if exc.response["Error"]["Code"] == "ResourceExistsException":
+                try:
+                    self._sm_client.put_secret_value(
+                        SecretId=full_name, SecretString=value)
+                except ClientError as update_exc:
+                    raise PluginError(
+                        f"Failed to update secret {full_name}: {update_exc}"
+                    ) from update_exc
+            else:
+                raise PluginError(
+                    f"Failed to create secret {full_name}: {exc}"
+                ) from exc
+
+    def delete(self, path: str) -> None:
+        self._ensure_connected()
+        prefix = self.config.get("prefix", "")
+        full_name = f"{prefix}{path}" if prefix else path
+        try:
+            self._sm_client.delete_secret(
+                SecretId=full_name,
+                ForceDeleteWithoutRecovery=True,
+            )
+        except ClientError as exc:
+            if exc.response["Error"]["Code"] != "ResourceNotFoundException":
+                raise PluginError(
+                    f"Failed to delete secret {full_name}: {exc}"
+                ) from exc
+
+    def poll(self, paths: list[str], since: str | None = None) -> list[AccessEvent]:
+        self._ensure_connected()
+        prefix = self.config.get("prefix", "")
+        watched = {}
+        for p in paths:
+            full_name = f"{prefix}{p}" if prefix else p
+            watched[full_name] = p
+
+        now = datetime.now(timezone.utc)
+        # CloudTrail delivers events 5-15 min after they occur, but timestamps
+        # reflect the original event time. Look back an extra 20 min so we
+        # don't miss events that arrived after our last poll window closed.
+        # Deduplication via event_id prevents double-processing.
+        lookback = timedelta(minutes=20)
+        if since:
+            start = datetime.fromisoformat(since) - lookback
+        elif self._last_poll_time:
+            start = datetime.fromisoformat(self._last_poll_time) - lookback
+        else:
+            start = now - timedelta(minutes=30)
+
+        events = []
+        try:
+            paginator = self._ct_client.get_paginator("lookup_events")
+            pages = paginator.paginate(
+                LookupAttributes=[{
+                    "AttributeKey": "EventName",
+                    "AttributeValue": "GetSecretValue",
+                }],
+                StartTime=start,
+                EndTime=now,
+            )
+            for page in pages:
+                for event in page.get("Events", []):
+                    resources = event.get("Resources", [])
+                    secret_name = None
+                    for r in resources:
+                        if r.get("ResourceType") == "AWS::SecretsManager::Secret":
+                            secret_name = r.get("ResourceName")
+                            break
+                    if not secret_name:
+                        ct_event = json.loads(event.get("CloudTrailEvent", "{}"))
+                        req_params = ct_event.get("requestParameters", {})
+                        secret_name = req_params.get("secretId")
+                    if secret_name and secret_name not in watched and ":secret:" in secret_name:
+                        short = secret_name.split(":secret:")[-1].rsplit("-", 1)[0]
+                        if short in watched:
+                            secret_name = short
+                    if secret_name and secret_name in watched:
+                        ct_event = json.loads(event.get("CloudTrailEvent", "{}"))
+                        events.append(AccessEvent(
+                            path=watched[secret_name],
+                            timestamp=event.get("EventTime", now).isoformat()
+                            if isinstance(event.get("EventTime"), datetime)
+                            else str(event.get("EventTime", "")),
+                            accessor=event.get("Username"),
+                            source_ip=ct_event.get("sourceIPAddress"),
+                            policy=None,
+                            extra={"event_id": event.get("EventId")},
+                        ))
+        except ClientError as exc:
+            log.warning("CloudTrail lookup failed: %s", exc)
+
+        self._last_poll_time = now.isoformat()
+        return events

--- a/plugins/vault/hashicorp/manifest.yaml
+++ b/plugins/vault/hashicorp/manifest.yaml
@@ -1,0 +1,43 @@
+name: hashicorp
+kind: vault
+display_name: "HashiCorp Vault"
+version: "0.1.0"
+author: thumper-core
+description: >
+  Connect to a HashiCorp Vault instance to plant and monitor canary secrets.
+  Uses AppRole authentication and polls the audit log for secret read events.
+
+config_schema:
+  - key: url
+    label: "Vault URL"
+    type: string
+    required: true
+    placeholder: "https://vault.example.com:8200"
+    help: "The base URL of your Vault server."
+
+  - key: mount
+    label: "KV mount path"
+    type: string
+    required: true
+    placeholder: "secret"
+    help: "The KV v2 secrets engine mount path."
+
+  - key: role_id
+    label: "AppRole Role ID"
+    type: string
+    required: true
+    placeholder: ""
+    help: "The role_id for AppRole authentication."
+
+  - key: secret_id
+    label: "AppRole Secret ID"
+    type: secret
+    required: true
+    help: "The secret_id for AppRole authentication."
+
+  - key: namespace
+    label: "Namespace"
+    type: string
+    required: false
+    placeholder: ""
+    help: "Vault namespace (Enterprise only). Leave blank for OSS Vault."

--- a/plugins/vault/hashicorp/plugin.py
+++ b/plugins/vault/hashicorp/plugin.py
@@ -1,0 +1,131 @@
+import json
+import logging
+
+import hvac
+
+from thumper.plugins.base import AccessEvent, PluginError, VaultPlugin
+
+log = logging.getLogger("thumper.plugin.hashicorp")
+
+
+class Plugin(VaultPlugin):
+    def __init__(self, config: dict):
+        super().__init__(config)
+        self._client: hvac.Client | None = None
+        self._last_audit_time: str | None = None
+
+    def connect(self) -> None:
+        url = self.config.get("url")
+        if not url:
+            raise PluginError("url is required")
+        role_id = self.config.get("role_id")
+        secret_id = self.config.get("secret_id")
+        if not role_id or not secret_id:
+            raise PluginError("role_id and secret_id are required")
+        namespace = self.config.get("namespace") or None
+        self._client = hvac.Client(url=url, namespace=namespace)
+        try:
+            resp = self._client.auth.approle.login(
+                role_id=role_id, secret_id=secret_id)
+            self._client.token = resp["auth"]["client_token"]
+        except Exception as exc:
+            raise PluginError(f"Vault authentication failed: {exc}") from exc
+        if not self._client.is_authenticated():
+            raise PluginError("Vault authentication failed: not authenticated")
+
+    def _ensure_connected(self) -> None:
+        if self._client is None:
+            self.connect()
+
+    def plant(self, path: str, value: str, metadata: dict) -> None:
+        self._ensure_connected()
+        mount = self.config.get("mount", "secret")
+        secret_data = {"value": value, **metadata}
+        try:
+            self._client.secrets.kv.v2.create_or_update_secret(
+                path=path, secret=secret_data, mount_point=mount)
+        except Exception as exc:
+            raise PluginError(f"Failed to plant secret at {path}: {exc}") from exc
+
+    def delete(self, path: str) -> None:
+        self._ensure_connected()
+        mount = self.config.get("mount", "secret")
+        try:
+            self._client.secrets.kv.v2.delete_metadata_and_all_versions(
+                path=path, mount_point=mount)
+        except Exception as exc:
+            raise PluginError(f"Failed to delete secret at {path}: {exc}") from exc
+
+    def poll(self, paths: list[str], since: str | None = None) -> list[AccessEvent]:
+        self._ensure_connected()
+        # Seed the audit cutoff from the caller's `since` (the connection's last
+        # poll time) on the first poll, so we don't re-scan the whole log.
+        if since and not self._last_audit_time:
+            self._last_audit_time = since
+        mount = self.config.get("mount", "secret")
+        entries = self._fetch_audit_entries()
+        watched = {f"{mount}/data/{p}" for p in paths}
+        events = []
+        for entry in entries:
+            if entry.get("type") != "response":
+                continue
+            req = entry.get("request", {})
+            if req.get("operation") != "read":
+                continue
+            entry_path = req.get("path", "")
+            if entry_path not in watched:
+                continue
+            auth = entry.get("auth", {})
+            req_meta = entry.get("request_metadata", {})
+            clean_path = entry_path.removeprefix(f"{mount}/data/")
+            events.append(AccessEvent(
+                path=clean_path,
+                timestamp=entry.get("time", ""),
+                accessor=auth.get("display_name"),
+                source_ip=req_meta.get("remote_address"),
+                policy=",".join(auth.get("policies", [])),
+            ))
+        if entries:
+            last = entries[-1].get("time")
+            if last:
+                self._last_audit_time = last
+        return events
+
+    def _fetch_audit_entries(self) -> list[dict]:
+        """Read audit log entries. This implementation reads from the file-based
+        audit device. Override or extend for syslog/socket audit devices."""
+        try:
+            devices = self._client.sys.list_enabled_audit_devices()
+        except Exception as exc:
+            log.warning("Failed to list audit devices: %s", exc)
+            return []
+        for _name, device in devices.get("data", {}).items():
+            if device.get("type") == "file":
+                file_path = device.get("options", {}).get("file_path")
+                if file_path:
+                    return self._read_audit_file(file_path)
+        return []
+
+    def _read_audit_file(self, file_path: str) -> list[dict]:
+        """Read the NDJSON audit log file, returning entries newer than the last
+        poll."""
+        entries = []
+        try:
+            with open(file_path) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        entry = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    ts = entry.get("time", "")
+                    if self._last_audit_time and ts <= self._last_audit_time:
+                        continue
+                    entries.append(entry)
+        except FileNotFoundError:
+            log.warning("Audit log file not found: %s", file_path)
+        except PermissionError:
+            log.warning("Cannot read audit log file: %s", file_path)
+        return entries

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = [
   "sqlalchemy>=2.0.51",
   "alembic>=1.18.5",
   "cryptography>=49.0.0",
+  "hvac>=2.0",           # HashiCorp Vault HTTP client (vault plugin)
+  "boto3>=1.34",         # AWS SDK (aws secrets-manager vault plugin)
 ]
 
 [project.optional-dependencies]

--- a/server/thumper/api/routes.py
+++ b/server/thumper/api/routes.py
@@ -52,6 +52,7 @@ from ..services.secrets_crypto import ConfigDecryptError, unpack_config
 from ..services.signing import verify
 from ..services.ssrf import SsrfError, assert_config_urls_allowed
 from ..tokens import TOKEN_TYPES
+from .vault_routes import vault_router
 
 log = logging.getLogger("thumper.api")
 
@@ -88,6 +89,10 @@ def require_admin(authorization: str = Header(default="")):
 # token - a route is public ONLY by explicitly opting onto agent_router.
 router = APIRouter(prefix="/api", dependencies=[Depends(require_admin)])
 agent_router = APIRouter(prefix="/api")
+
+# Secrets-manager (vault) endpoints live in their own module; mount them under
+# the admin-gated management router so every /api/vault/... path is admin-gated.
+router.include_router(vault_router)
 
 
 def _validate_bait_path(path: str) -> str:

--- a/server/thumper/api/vault_routes.py
+++ b/server/thumper/api/vault_routes.py
@@ -1,0 +1,184 @@
+"""API routes for vault connections, canary secret templates, and canary secrets.
+
+Mounted under the admin-gated /api router (see routes.py), so every path here is
+/api/vault/... and inherits the management-API admin-token gate.
+"""
+import json
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from .. import store
+from ..db import get_db
+from ..models import (
+    CanarySecretOut, CreateCanarySecretIn, CreateVaultConnectionIn,
+    UpdateVaultConnectionIn, VaultConnectionOut,
+)
+from ..plugins.registry import get_manifest, load_plugin
+from ..services.integrations import mask_config, merge_config
+from ..services.templates import generate_value, get_template, list_templates
+
+log = logging.getLogger("thumper.vault")
+
+vault_router = APIRouter(prefix="/vault", tags=["vault"])
+
+
+def _connection_out(row, manifest) -> dict:
+    config = json.loads(row.config_json)
+    masked = mask_config(manifest, config) if manifest else config
+    return VaultConnectionOut(
+        id=row.id, name=row.name, plugin=row.plugin,
+        configured=row.configured, config=masked,
+        last_poll_at=row.last_poll_at, created_at=row.created_at,
+    ).model_dump()
+
+
+def _secret_out(row) -> dict:
+    tpl = get_template(row.template)
+    tpl_name = tpl["name"] if tpl else row.template
+    return CanarySecretOut(
+        id=row.id, vault_connection_id=row.vault_connection_id,
+        vault_connection_name="", template=row.template,
+        template_name=tpl_name, path=row.path, state=row.state,
+        created_at=row.created_at, last_accessed_at=row.last_accessed_at,
+    ).model_dump()
+
+
+# ── vault connections ───────────────────────────────────────────────────────
+
+@vault_router.get("/connections")
+def list_connections(db: Session = Depends(get_db)):
+    return [_connection_out(row, get_manifest(row.plugin))
+            for row in store.list_vault_connections(db)]
+
+
+@vault_router.post("/connections")
+def create_connection(body: CreateVaultConnectionIn,
+                      db: Session = Depends(get_db)):
+    manifest = get_manifest(body.plugin)
+    if manifest is None:
+        raise HTTPException(400, f"Unknown vault plugin: {body.plugin}")
+    row = store.create_vault_connection(
+        db, name=body.name, plugin=body.plugin, config=body.config)
+    return _connection_out(row, manifest)
+
+
+@vault_router.put("/connections/{vid}")
+def update_connection(vid: str, body: UpdateVaultConnectionIn,
+                      db: Session = Depends(get_db)):
+    row = store.get_vault_connection(db, vid)
+    if row is None:
+        raise HTTPException(404, "Vault connection not found")
+    # Merge so a masked secret field the UI didn't re-enter keeps its stored value.
+    merged = merge_config(json.loads(row.config_json), body.config)
+    updated = store.update_vault_connection(db, vid, name=body.name,
+                                            config=merged)
+    return _connection_out(updated, get_manifest(updated.plugin))
+
+
+@vault_router.delete("/connections/{vid}")
+def delete_connection(vid: str, db: Session = Depends(get_db)):
+    secrets = store.list_canary_secrets_for_connection(db, vid)
+    if secrets:
+        row = store.get_vault_connection(db, vid)
+        if row:
+            try:
+                plugin = load_plugin(row.plugin, json.loads(row.config_json))
+                for cs in secrets:
+                    if cs.state == "planted":
+                        try:
+                            plugin.delete(cs.path)
+                        except Exception:
+                            log.warning(
+                                "Failed to delete canary secret %s from vault",
+                                cs.path)
+            except Exception:
+                log.warning("Failed to load plugin to clean up secrets")
+    if not store.delete_vault_connection(db, vid):
+        raise HTTPException(404, "Vault connection not found")
+    return {"status": "ok"}
+
+
+@vault_router.post("/connections/{vid}/test")
+def test_connection(vid: str, db: Session = Depends(get_db)):
+    row = store.get_vault_connection(db, vid)
+    if row is None:
+        raise HTTPException(404, "Vault connection not found")
+    try:
+        plugin = load_plugin(row.plugin, json.loads(row.config_json))
+        plugin.test()
+        store.set_vault_connection_test(db, vid=vid, configured=True)
+        return {"ok": True, "error": None}
+    except Exception as exc:
+        store.set_vault_connection_test(db, vid=vid, configured=False)
+        return {"ok": False, "error": str(exc)}
+
+
+# ── templates ───────────────────────────────────────────────────────────────
+
+@vault_router.get("/templates")
+def get_templates():
+    return list_templates()
+
+
+# ── canary secrets ──────────────────────────────────────────────────────────
+
+@vault_router.get("/secrets")
+def list_secrets(db: Session = Depends(get_db)):
+    vc_map = {vc.id: vc.name for vc in store.list_vault_connections(db)}
+    result = []
+    for row in store.list_canary_secrets(db):
+        out = _secret_out(row)
+        out["vault_connection_name"] = vc_map.get(row.vault_connection_id, "")
+        result.append(out)
+    return result
+
+
+@vault_router.post("/secrets")
+def create_secret(body: CreateCanarySecretIn, db: Session = Depends(get_db)):
+    vc = store.get_vault_connection(db, body.vault_connection_id)
+    if vc is None:
+        raise HTTPException(404, "Vault connection not found")
+    if not vc.configured:
+        raise HTTPException(400, "Vault connection not tested/configured yet")
+    tpl = get_template(body.template)
+    if tpl is None:
+        raise HTTPException(400, f"Unknown template: {body.template}")
+    value = generate_value(tpl)
+    metadata = tpl.get("metadata", {})
+    cs = store.create_canary_secret(
+        db, vault_connection_id=vc.id, template=body.template,
+        path=body.path, value=value)
+    plant_error = None
+    try:
+        plugin = load_plugin(vc.plugin, json.loads(vc.config_json))
+        plugin.plant(body.path, value, metadata)
+        store.set_canary_secret_state(db, cs.id, "planted")
+    except Exception as exc:
+        store.set_canary_secret_state(db, cs.id, "failed")
+        plant_error = str(exc)
+        log.warning("Failed to plant canary secret: %s", exc)
+    db.expire_all()
+    out = _secret_out(store.get_canary_secret(db, cs.id))
+    out["vault_connection_name"] = vc.name
+    if plant_error:
+        out["error"] = plant_error
+    return out
+
+
+@vault_router.delete("/secrets/{csid}")
+def delete_secret(csid: str, db: Session = Depends(get_db)):
+    cs = store.get_canary_secret(db, csid)
+    if cs is None:
+        raise HTTPException(404, "Canary secret not found")
+    if cs.state in ("planted", "triggered"):
+        vc = store.get_vault_connection(db, cs.vault_connection_id)
+        if vc:
+            try:
+                plugin = load_plugin(vc.plugin, json.loads(vc.config_json))
+                plugin.delete(cs.path)
+            except Exception:
+                log.warning("Failed to delete secret %s from vault", cs.path)
+    store.delete_canary_secret(db, csid)
+    return {"status": "ok"}

--- a/server/thumper/db.py
+++ b/server/thumper/db.py
@@ -119,6 +119,43 @@ class DeliveryAttempt(Base):
     )
 
 
+class VaultConnection(Base):
+    """A configured connection to a third-party secrets manager (a `vault`
+    plugin instance). `config_json` holds the plugin's saved config (with secret
+    fields packed by secrets_crypto); `configured` flips true once a connection
+    test passes."""
+    __tablename__ = "vault_connections"
+    id = Column(String(255), primary_key=True)
+    name = Column(String(255), nullable=False)
+    plugin = Column(String(255), nullable=False)
+    config_json = Column(Text, nullable=False, default="{}")
+    configured = Column(Boolean, nullable=False, default=False)
+    last_poll_at = Column(String(255))
+    created_at = Column(String(255), nullable=False)
+
+
+class CanarySecret(Base):
+    """A canary secret planted in a secrets manager via a VaultConnection.
+    `state`: pending -> planted -> triggered. `value` is the fake credential
+    written at `path`; a read of it (seen in the manager's audit log) fires."""
+    __tablename__ = "canary_secrets"
+    id = Column(String(255), primary_key=True)
+    vault_connection_id = Column(
+        String(255),
+        ForeignKey("vault_connections.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    template = Column(String(255), nullable=False)
+    path = Column(String(255), nullable=False)
+    value = Column(Text, nullable=False)
+    state = Column(String(255), nullable=False, default="pending")
+    created_at = Column(String(255), nullable=False)
+    last_accessed_at = Column(String(255))
+    __table_args__ = (
+        Index("ix_canary_vault_conn", "vault_connection_id"),
+    )
+
+
 # ── engine + session ────────────────────────────────────────────────────────
 # Created lazily on first use rather than at import time, so a THUMPER_DB / dotenv
 # override applied after this module is imported (CLI, tests) still takes effect.

--- a/server/thumper/migrations/versions/vault_tables_v1.py
+++ b/server/thumper/migrations/versions/vault_tables_v1.py
@@ -1,0 +1,51 @@
+"""Add vault_connections and canary_secrets tables for secrets-manager integrations.
+
+Revision ID: vault_tables_v1
+Revises: endpoint_ephemeral_v1
+Create Date: 2026-07-20
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "vault_tables_v1"
+down_revision: Union[str, None] = "endpoint_ephemeral_v1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "vault_connections",
+        sa.Column("id", sa.String(255), primary_key=True),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("plugin", sa.String(255), nullable=False),
+        sa.Column("config_json", sa.Text(), nullable=False, server_default="{}"),
+        sa.Column("configured", sa.Boolean(), nullable=False,
+                  server_default=sa.false()),
+        sa.Column("last_poll_at", sa.String(255), nullable=True),
+        sa.Column("created_at", sa.String(255), nullable=False),
+    )
+    op.create_table(
+        "canary_secrets",
+        sa.Column("id", sa.String(255), primary_key=True),
+        sa.Column("vault_connection_id", sa.String(255),
+                  sa.ForeignKey("vault_connections.id", ondelete="CASCADE"),
+                  nullable=False),
+        sa.Column("template", sa.String(255), nullable=False),
+        sa.Column("path", sa.String(255), nullable=False),
+        sa.Column("value", sa.Text(), nullable=False),
+        sa.Column("state", sa.String(255), nullable=False,
+                  server_default="pending"),
+        sa.Column("created_at", sa.String(255), nullable=False),
+        sa.Column("last_accessed_at", sa.String(255), nullable=True),
+    )
+    op.create_index("ix_canary_vault_conn", "canary_secrets",
+                    ["vault_connection_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_canary_vault_conn", table_name="canary_secrets")
+    op.drop_table("canary_secrets")
+    op.drop_table("vault_connections")

--- a/server/thumper/models.py
+++ b/server/thumper/models.py
@@ -181,3 +181,43 @@ class TokenPreviewOut(BaseModel):
 # Agent-facing endpoints (/enroll, /agent/*, /trigger) speak a plain-text
 # protocol (key=value / tab-separated), not JSON, so the Bash agent needs no
 # JSON parser - see api/routes.py. They therefore have no Pydantic schemas here.
+
+
+# ── vault (secrets-manager) connections & canary secrets ─────────────────────
+class CreateVaultConnectionIn(BaseModel):
+    name: str
+    plugin: str
+    config: dict
+
+
+class UpdateVaultConnectionIn(BaseModel):
+    name: str
+    config: dict
+
+
+class VaultConnectionOut(BaseModel):
+    id: str
+    name: str
+    plugin: str
+    configured: bool
+    config: dict
+    last_poll_at: Optional[str] = None
+    created_at: str
+
+
+class CreateCanarySecretIn(BaseModel):
+    vault_connection_id: str
+    template: str
+    path: str
+
+
+class CanarySecretOut(BaseModel):
+    id: str
+    vault_connection_id: str
+    vault_connection_name: str
+    template: str
+    template_name: str
+    path: str
+    state: str
+    created_at: str
+    last_accessed_at: Optional[str] = None

--- a/server/thumper/plugins/base.py
+++ b/server/thumper/plugins/base.py
@@ -1,17 +1,19 @@
 """The plugin contract. Community plugins import from here.
 
-A plugin is a DIRECTORY under plugins/{deploy,alert}/<name>/ containing:
+A plugin is a DIRECTORY under plugins/{deploy,alert,vault}/<name>/ containing:
   - manifest.yaml : name, kind, display_name, version, author, description,
                     and config_schema (fields: string | secret | boolean) that
                     the UI renders into a config form automatically.
-  - plugin.py     : defines a class named `Plugin` subclassing DeployPlugin or
-                    AlertPlugin. It is constructed with the saved config dict.
+  - plugin.py     : defines a class named `Plugin` subclassing DeployPlugin,
+                    AlertPlugin, or VaultPlugin. It is constructed with the saved
+                    config dict.
 
 The contract is intentionally minimal so it can grow without breaking plugins:
 the `path` and HMAC `callback_url`/`hmac_secret` travel INSIDE the Token object,
 not as separate arguments.
 """
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 
 from pydantic import BaseModel
 
@@ -74,3 +76,46 @@ class AlertPlugin(ABC):
             "endpoint_hostname": "thumper-server",
             "message": "Thumper test event - your integration is wired up correctly.",
         })
+
+
+@dataclass
+class AccessEvent:
+    """A detected read of a canary secret in a secrets manager."""
+    path: str
+    timestamp: str
+    accessor: str | None = None
+    source_ip: str | None = None
+    policy: str | None = None
+    extra: dict = field(default_factory=dict)
+
+
+class VaultPlugin(ABC):
+    """Connect to a secrets manager, plant/delete canary secrets, poll for reads.
+
+    A `vault` plugin plants realistic-but-fake secrets in a real secrets manager
+    (HashiCorp Vault, AWS Secrets Manager, ...) and polls that manager's audit log
+    to detect reads - a read of a canary is the signal, delivered through the same
+    alert pipeline as file-based tripwires."""
+
+    def __init__(self, config: dict):
+        self.config = config or {}
+
+    @abstractmethod
+    def connect(self) -> None:
+        """Authenticate and verify connectivity. Raise PluginError on failure."""
+
+    @abstractmethod
+    def plant(self, path: str, value: str, metadata: dict) -> None:
+        """Write a canary secret at the given path. Raise PluginError on failure."""
+
+    @abstractmethod
+    def delete(self, path: str) -> None:
+        """Remove a canary secret. Raise PluginError on failure."""
+
+    @abstractmethod
+    def poll(self, paths: list[str], since: str | None = None) -> list[AccessEvent]:
+        """Check audit logs for reads on the given paths since `since`."""
+
+    def test(self) -> None:
+        """Verify connectivity (default: calls connect)."""
+        self.connect()

--- a/server/thumper/plugins/loader.py
+++ b/server/thumper/plugins/loader.py
@@ -1,6 +1,6 @@
 """Discover and instantiate plugins from the filesystem.
 
-Drop a directory with a manifest.yaml + plugin.py into plugins/{deploy,alert}/
+Drop a directory with a manifest.yaml + plugin.py into plugins/{deploy,alert,vault}/
 and it shows up - no registration code, no imports to edit.
 
 Discovery and module loading are cached: the plugin set is fixed at process
@@ -14,7 +14,7 @@ import yaml
 
 from ..config import PLUGINS_DIR
 
-_KINDS = ("deploy", "alert")
+_KINDS = ("deploy", "alert", "vault")
 
 _manifest_cache: list[dict] | None = None
 _module_cache: dict[str, object] = {}

--- a/server/thumper/services/templates.py
+++ b/server/thumper/services/templates.py
@@ -1,0 +1,69 @@
+"""Load and serve canary secret templates from the templates/ directory.
+
+A template describes a realistic-looking (but fake) credential for a popular
+SaaS tool: its display name, category, the value format (prefix/length/charset),
+and suggested vault paths. `generate_value` mints a fresh fake credential from a
+template; the value authenticates to nothing - a read of it in a secrets manager
+is the signal.
+"""
+import secrets
+import string
+
+import yaml
+
+from ..config import REPO_ROOT
+
+_TEMPLATES_DIR = REPO_ROOT / "templates"
+_cache: list[dict] | None = None
+
+_CHARSETS = {
+    "alphanumeric": string.ascii_letters + string.digits,
+    "alphanumeric_dash": string.ascii_letters + string.digits + "-",
+    "alphanumeric_special": string.ascii_letters + string.digits + "-_",
+    "hex": string.hexdigits[:16],
+    "uppercase_alphanumeric": string.ascii_uppercase + string.digits,
+}
+
+
+def _load_all() -> list[dict]:
+    global _cache
+    if _cache is not None:
+        return _cache
+    templates: list[dict] = []
+    for path in sorted(_TEMPLATES_DIR.glob("*.yaml")):
+        with open(path) as f:
+            templates.append(yaml.safe_load(f))
+    templates.sort(key=lambda t: (t.get("category", ""), t.get("name", "")))
+    _cache = templates
+    return _cache
+
+
+def reset_cache() -> None:
+    """Drop the cached template list (mainly for tests)."""
+    global _cache
+    _cache = None
+
+
+def list_templates() -> list[dict]:
+    """Every parsed template, sorted by category then name."""
+    return _load_all()
+
+
+def get_template(slug: str) -> dict | None:
+    """Return the template with the given slug, or None."""
+    for t in _load_all():
+        if t["slug"] == slug:
+            return t
+    return None
+
+
+def generate_value(template: dict) -> str:
+    """Mint a fresh fake credential matching the template's format spec."""
+    fmt = template["format"]
+    prefix = fmt.get("prefix", "")
+    total_length = fmt["length"]
+    charset = _CHARSETS.get(fmt.get("charset", "alphanumeric"),
+                            _CHARSETS["alphanumeric"])
+    suffix_length = total_length - len(prefix)
+    suffix = "".join(secrets.choice(charset) for _ in range(suffix_length))
+    return prefix + suffix

--- a/server/thumper/store.py
+++ b/server/thumper/store.py
@@ -2,6 +2,7 @@
 the app deals in ORM model instances (attribute access: row.id, row.name, …).
 """
 import hmac
+import json
 import secrets
 from datetime import datetime, timezone
 from typing import Optional
@@ -11,7 +12,8 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from .db import (
-    Alert, Deployment, DeliveryAttempt, Endpoint, Integration, Tripwire,
+    Alert, CanarySecret, Deployment, DeliveryAttempt, Endpoint, Integration,
+    Tripwire, VaultConnection,
 )
 from .models import iso_now
 from .services.secrets_crypto import pack_config
@@ -432,3 +434,118 @@ def set_integration_test_result(db: Session, *, plugin: str, status: str,
         row.last_test_at = iso_now()
         row.last_test_error = error
         db.commit()
+
+
+# ── vault connections (secrets-manager instances) ────────────────────────────
+def create_vault_connection(db: Session, *, name: str, plugin: str,
+                            config: dict) -> VaultConnection:
+    row = VaultConnection(id=_id("vc"), name=name, plugin=plugin,
+                          config_json=json.dumps(config), configured=False,
+                          created_at=iso_now())
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def list_vault_connections(db: Session) -> list[VaultConnection]:
+    return db.query(VaultConnection).order_by(
+        VaultConnection.created_at.desc()).all()
+
+
+def get_vault_connection(db: Session, vid: str) -> Optional[VaultConnection]:
+    return db.query(VaultConnection).filter(VaultConnection.id == vid).first()
+
+
+def update_vault_connection(db: Session, vid: str, *, name: str,
+                            config: dict) -> Optional[VaultConnection]:
+    row = get_vault_connection(db, vid)
+    if row is None:
+        return None
+    row.name = name
+    row.config_json = json.dumps(config)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def delete_vault_connection(db: Session, vid: str) -> bool:
+    row = get_vault_connection(db, vid)
+    if row is None:
+        return False
+    # Explicit child delete: ondelete=CASCADE is a DB-level FK action and SQLite
+    # doesn't enforce it unless PRAGMA foreign_keys=ON, so don't rely on it.
+    db.query(CanarySecret).filter(
+        CanarySecret.vault_connection_id == vid).delete()
+    db.delete(row)
+    db.commit()
+    return True
+
+
+def set_vault_connection_test(db: Session, *, vid: str,
+                              configured: bool) -> None:
+    row = get_vault_connection(db, vid)
+    if row:
+        row.configured = configured
+        db.commit()
+
+
+def update_vault_last_poll(db: Session, vid: str) -> None:
+    db.query(VaultConnection).filter(VaultConnection.id == vid).update(
+        {VaultConnection.last_poll_at: iso_now()})
+    db.commit()
+
+
+# ── canary secrets (planted in a secrets manager) ────────────────────────────
+def create_canary_secret(db: Session, *, vault_connection_id: str,
+                         template: str, path: str, value: str) -> CanarySecret:
+    row = CanarySecret(id=_id("cs"), vault_connection_id=vault_connection_id,
+                       template=template, path=path, value=value,
+                       state="pending", created_at=iso_now())
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def list_canary_secrets(db: Session) -> list[CanarySecret]:
+    return db.query(CanarySecret).order_by(CanarySecret.created_at.desc()).all()
+
+
+def get_canary_secret(db: Session, csid: str) -> Optional[CanarySecret]:
+    return db.query(CanarySecret).filter(CanarySecret.id == csid).first()
+
+
+def list_canary_secrets_for_connection(db: Session,
+                                       vid: str) -> list[CanarySecret]:
+    return db.query(CanarySecret).filter(
+        CanarySecret.vault_connection_id == vid).all()
+
+
+def list_planted_canary_secrets_for_connection(
+        db: Session, vid: str) -> list[CanarySecret]:
+    return db.query(CanarySecret).filter(
+        CanarySecret.vault_connection_id == vid,
+        CanarySecret.state.in_(["planted", "triggered"])).all()
+
+
+def set_canary_secret_state(db: Session, csid: str, state: str) -> None:
+    db.query(CanarySecret).filter(CanarySecret.id == csid).update(
+        {CanarySecret.state: state})
+    db.commit()
+
+
+def mark_canary_secret_accessed(db: Session, csid: str) -> None:
+    db.query(CanarySecret).filter(CanarySecret.id == csid).update(
+        {CanarySecret.last_accessed_at: iso_now(),
+         CanarySecret.state: "triggered"})
+    db.commit()
+
+
+def delete_canary_secret(db: Session, csid: str) -> bool:
+    row = get_canary_secret(db, csid)
+    if row is None:
+        return False
+    db.delete(row)
+    db.commit()
+    return True

--- a/templates/adp.yaml
+++ b/templates/adp.yaml
@@ -1,0 +1,13 @@
+name: "ADP Client Secret"
+slug: adp
+category: "HR"
+format:
+  prefix: ""
+  length: 64
+  charset: alphanumeric
+suggested_paths:
+  - "production/adp/client_secret"
+  - "services/hr/adp_secret"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/asana.yaml
+++ b/templates/asana.yaml
@@ -1,0 +1,13 @@
+name: "Asana Personal Access Token"
+slug: asana
+category: "Project Management"
+format:
+  prefix: ""
+  length: 32
+  charset: alphanumeric
+suggested_paths:
+  - "production/asana/pat"
+  - "services/pm/asana_token"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/auth0.yaml
+++ b/templates/auth0.yaml
@@ -1,0 +1,13 @@
+name: "Auth0 Client Secret"
+slug: auth0
+category: "Identity"
+format:
+  prefix: ""
+  length: 64
+  charset: alphanumeric_special
+suggested_paths:
+  - "production/auth0/client_secret"
+  - "services/identity/auth0_secret"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/aws.yaml
+++ b/templates/aws.yaml
@@ -1,0 +1,13 @@
+name: "AWS Access Key"
+slug: aws
+category: "Cloud"
+format:
+  prefix: "AKIA"
+  length: 20
+  charset: uppercase_alphanumeric
+suggested_paths:
+  - "production/aws/access_key_id"
+  - "services/infra/aws_credentials"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/azure_client.yaml
+++ b/templates/azure_client.yaml
@@ -1,0 +1,13 @@
+name: "Azure Client Secret"
+slug: azure_client
+category: "Cloud"
+format:
+  prefix: ""
+  length: 40
+  charset: alphanumeric_special
+suggested_paths:
+  - "production/azure/client_secret"
+  - "services/infra/azure_credentials"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/bamboohr.yaml
+++ b/templates/bamboohr.yaml
@@ -1,0 +1,13 @@
+name: "BambooHR API Key"
+slug: bamboohr
+category: "HR"
+format:
+  prefix: ""
+  length: 40
+  charset: alphanumeric
+suggested_paths:
+  - "production/bamboohr/api_key"
+  - "services/hr/bamboohr_key"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/bitbucket.yaml
+++ b/templates/bitbucket.yaml
@@ -1,0 +1,13 @@
+name: "Bitbucket App Password"
+slug: bitbucket
+category: "R&D"
+format:
+  prefix: ""
+  length: 20
+  charset: alphanumeric
+suggested_paths:
+  - "production/bitbucket/app_password"
+  - "ci/bitbucket/access_token"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/brex.yaml
+++ b/templates/brex.yaml
@@ -1,0 +1,13 @@
+name: "Brex API Token"
+slug: brex
+category: Finance
+format:
+  prefix: ""
+  length: 64
+  charset: alphanumeric
+suggested_paths:
+  - "production/brex/api_token"
+  - "services/finance/brex_token"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/cloudflare.yaml
+++ b/templates/cloudflare.yaml
@@ -1,0 +1,13 @@
+name: "Cloudflare API Token"
+slug: cloudflare
+category: "Cloud"
+format:
+  prefix: ""
+  length: 40
+  charset: alphanumeric_special
+suggested_paths:
+  - "production/cloudflare/api_token"
+  - "services/infra/cloudflare_key"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/confluence.yaml
+++ b/templates/confluence.yaml
@@ -1,0 +1,13 @@
+name: "Confluence API Token"
+slug: confluence
+category: "Project Management"
+format:
+  prefix: ""
+  length: 24
+  charset: alphanumeric
+suggested_paths:
+  - "production/confluence/api_token"
+  - "services/pm/confluence_token"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/crowdstrike.yaml
+++ b/templates/crowdstrike.yaml
@@ -1,0 +1,13 @@
+name: "CrowdStrike API Secret"
+slug: crowdstrike
+category: "Identity"
+format:
+  prefix: ""
+  length: 40
+  charset: alphanumeric_special
+suggested_paths:
+  - "production/crowdstrike/api_secret"
+  - "services/identity/crowdstrike_secret"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/datadog.yaml
+++ b/templates/datadog.yaml
@@ -1,0 +1,13 @@
+name: "Datadog API Key"
+slug: datadog
+category: "R&D"
+format:
+  prefix: ""
+  length: 32
+  charset: hex
+suggested_paths:
+  - "production/datadog/api_key"
+  - "services/monitoring/datadog_key"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/docusign.yaml
+++ b/templates/docusign.yaml
@@ -1,0 +1,13 @@
+name: "DocuSign Integration Key"
+slug: docusign
+category: Legal
+format:
+  prefix: ""
+  length: 36
+  charset: hex
+suggested_paths:
+  - "production/docusign/integration_key"
+  - "services/legal/docusign_key"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/gcp.yaml
+++ b/templates/gcp.yaml
@@ -1,0 +1,13 @@
+name: "GCP Service Account Key"
+slug: gcp
+category: "Cloud"
+format:
+  prefix: ""
+  length: 40
+  charset: alphanumeric_special
+suggested_paths:
+  - "production/gcp/service_account_key"
+  - "services/infra/gcp_credentials"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/github.yaml
+++ b/templates/github.yaml
@@ -1,0 +1,13 @@
+name: "GitHub Personal Access Token"
+slug: github
+category: "R&D"
+format:
+  prefix: "ghp_"
+  length: 40
+  charset: alphanumeric
+suggested_paths:
+  - "production/github/pat"
+  - "ci/github/access_token"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/gitlab.yaml
+++ b/templates/gitlab.yaml
@@ -1,0 +1,13 @@
+name: "GitLab Personal Access Token"
+slug: gitlab
+category: "R&D"
+format:
+  prefix: "glpat-"
+  length: 26
+  charset: alphanumeric_dash
+suggested_paths:
+  - "production/gitlab/pat"
+  - "ci/gitlab/access_token"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/google_workspace.yaml
+++ b/templates/google_workspace.yaml
@@ -1,0 +1,13 @@
+name: "Google Workspace API Key"
+slug: google_workspace
+category: Collaboration
+format:
+  prefix: ""
+  length: 39
+  charset: alphanumeric_special
+suggested_paths:
+  - "production/google_workspace/api_key"
+  - "services/collaboration/google_key"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/hubspot.yaml
+++ b/templates/hubspot.yaml
@@ -1,0 +1,13 @@
+name: "HubSpot API Key"
+slug: hubspot
+category: "CRM"
+format:
+  prefix: ""
+  length: 36
+  charset: hex
+suggested_paths:
+  - "production/hubspot/api_key"
+  - "services/crm/hubspot_key"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/jira.yaml
+++ b/templates/jira.yaml
@@ -1,0 +1,13 @@
+name: "Jira API Token"
+slug: jira
+category: "Project Management"
+format:
+  prefix: ""
+  length: 24
+  charset: alphanumeric
+suggested_paths:
+  - "production/jira/api_token"
+  - "services/pm/jira_token"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/jumpcloud.yaml
+++ b/templates/jumpcloud.yaml
@@ -1,0 +1,13 @@
+name: "JumpCloud API Key"
+slug: jumpcloud
+category: "Identity"
+format:
+  prefix: ""
+  length: 40
+  charset: hex
+suggested_paths:
+  - "production/jumpcloud/api_key"
+  - "services/identity/jumpcloud_key"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/linear.yaml
+++ b/templates/linear.yaml
@@ -1,0 +1,13 @@
+name: "Linear API Key"
+slug: linear
+category: "Project Management"
+format:
+  prefix: "lin_api_"
+  length: 48
+  charset: alphanumeric
+suggested_paths:
+  - "production/linear/api_key"
+  - "services/pm/linear_key"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/mailchimp.yaml
+++ b/templates/mailchimp.yaml
@@ -1,0 +1,13 @@
+name: "Mailchimp API Key"
+slug: mailchimp
+category: Marketing
+format:
+  prefix: ""
+  length: 36
+  charset: alphanumeric_dash
+suggested_paths:
+  - "production/mailchimp/api_key"
+  - "services/email/mailchimp_key"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/mongodb.yaml
+++ b/templates/mongodb.yaml
@@ -1,0 +1,13 @@
+name: "MongoDB Atlas API Key"
+slug: mongodb
+category: "Cloud"
+format:
+  prefix: ""
+  length: 36
+  charset: hex
+suggested_paths:
+  - "production/mongodb/api_key"
+  - "services/data/mongodb_key"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/netsuite.yaml
+++ b/templates/netsuite.yaml
@@ -1,0 +1,13 @@
+name: "NetSuite Consumer Secret"
+slug: netsuite
+category: Finance
+format:
+  prefix: ""
+  length: 64
+  charset: alphanumeric
+suggested_paths:
+  - "production/netsuite/consumer_secret"
+  - "services/finance/netsuite_secret"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/newrelic.yaml
+++ b/templates/newrelic.yaml
@@ -1,0 +1,13 @@
+name: "New Relic API Key"
+slug: newrelic
+category: "R&D"
+format:
+  prefix: "NRAK-"
+  length: 32
+  charset: uppercase_alphanumeric
+suggested_paths:
+  - "production/newrelic/api_key"
+  - "services/monitoring/newrelic_key"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/notion.yaml
+++ b/templates/notion.yaml
@@ -1,0 +1,13 @@
+name: "Notion Integration Token"
+slug: notion
+category: "Project Management"
+format:
+  prefix: "secret_"
+  length: 50
+  charset: alphanumeric
+suggested_paths:
+  - "production/notion/integration_token"
+  - "services/pm/notion_secret"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/okta.yaml
+++ b/templates/okta.yaml
@@ -1,0 +1,13 @@
+name: "Okta API Token"
+slug: okta
+category: "Identity"
+format:
+  prefix: "00"
+  length: 42
+  charset: alphanumeric
+suggested_paths:
+  - "production/okta/api_token"
+  - "services/identity/okta_secret"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/pagerduty.yaml
+++ b/templates/pagerduty.yaml
@@ -1,0 +1,13 @@
+name: "PagerDuty API Key"
+slug: pagerduty
+category: "R&D"
+format:
+  prefix: ""
+  length: 20
+  charset: alphanumeric
+suggested_paths:
+  - "production/pagerduty/api_key"
+  - "services/oncall/pagerduty_key"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/plaid.yaml
+++ b/templates/plaid.yaml
@@ -1,0 +1,13 @@
+name: "Plaid Secret Key"
+slug: plaid
+category: Finance
+format:
+  prefix: ""
+  length: 30
+  charset: alphanumeric
+suggested_paths:
+  - "production/plaid/secret_key"
+  - "services/finance/plaid_secret"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/quickbooks.yaml
+++ b/templates/quickbooks.yaml
@@ -1,0 +1,13 @@
+name: "QuickBooks Client Secret"
+slug: quickbooks
+category: Finance
+format:
+  prefix: ""
+  length: 32
+  charset: alphanumeric
+suggested_paths:
+  - "production/quickbooks/client_secret"
+  - "services/finance/quickbooks_secret"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/rippling.yaml
+++ b/templates/rippling.yaml
@@ -1,0 +1,13 @@
+name: "Rippling API Key"
+slug: rippling
+category: "HR"
+format:
+  prefix: ""
+  length: 48
+  charset: alphanumeric
+suggested_paths:
+  - "production/rippling/api_key"
+  - "services/hr/rippling_key"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/salesforce.yaml
+++ b/templates/salesforce.yaml
@@ -1,0 +1,13 @@
+name: "Salesforce Connected App Secret"
+slug: salesforce
+category: "CRM"
+format:
+  prefix: ""
+  length: 64
+  charset: alphanumeric
+suggested_paths:
+  - "production/salesforce/client_secret"
+  - "services/crm/salesforce_secret"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/sendgrid.yaml
+++ b/templates/sendgrid.yaml
@@ -1,0 +1,13 @@
+name: "SendGrid API Key"
+slug: sendgrid
+category: Marketing
+format:
+  prefix: "SG."
+  length: 69
+  charset: alphanumeric_special
+suggested_paths:
+  - "production/sendgrid/api_key"
+  - "services/email/sendgrid_key"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/sentinelone.yaml
+++ b/templates/sentinelone.yaml
@@ -1,0 +1,13 @@
+name: "SentinelOne API Token"
+slug: sentinelone
+category: "Identity"
+format:
+  prefix: ""
+  length: 80
+  charset: alphanumeric
+suggested_paths:
+  - "production/sentinelone/api_token"
+  - "services/identity/sentinelone_token"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/sentry.yaml
+++ b/templates/sentry.yaml
@@ -1,0 +1,13 @@
+name: "Sentry Auth Token"
+slug: sentry
+category: "R&D"
+format:
+  prefix: "sntrys_"
+  length: 64
+  charset: alphanumeric
+suggested_paths:
+  - "production/sentry/auth_token"
+  - "services/monitoring/sentry_token"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/slack.yaml
+++ b/templates/slack.yaml
@@ -1,0 +1,13 @@
+name: "Slack Bot Token"
+slug: slack
+category: Collaboration
+format:
+  prefix: "xoxb-"
+  length: 72
+  charset: alphanumeric_dash
+suggested_paths:
+  - "production/slack/bot_token"
+  - "services/notifications/slack_token"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/snowflake.yaml
+++ b/templates/snowflake.yaml
@@ -1,0 +1,13 @@
+name: "Snowflake Account Key"
+slug: snowflake
+category: "Cloud"
+format:
+  prefix: ""
+  length: 64
+  charset: alphanumeric_special
+suggested_paths:
+  - "production/snowflake/account_key"
+  - "services/data/snowflake_secret"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/snyk.yaml
+++ b/templates/snyk.yaml
@@ -1,0 +1,13 @@
+name: "Snyk API Token"
+slug: snyk
+category: "R&D"
+format:
+  prefix: ""
+  length: 36
+  charset: hex
+suggested_paths:
+  - "production/snyk/api_token"
+  - "ci/snyk/auth_token"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/stripe.yaml
+++ b/templates/stripe.yaml
@@ -1,0 +1,13 @@
+name: "Stripe API Key"
+slug: stripe
+category: Finance
+format:
+  prefix: "sk_live_"
+  length: 48
+  charset: alphanumeric
+suggested_paths:
+  - "production/stripe/api_key"
+  - "services/payments/stripe_secret"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/teams.yaml
+++ b/templates/teams.yaml
@@ -1,0 +1,13 @@
+name: "Microsoft Teams Webhook"
+slug: teams
+category: Collaboration
+format:
+  prefix: ""
+  length: 64
+  charset: alphanumeric_special
+suggested_paths:
+  - "production/teams/webhook_url"
+  - "services/notifications/teams_webhook"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/terraform.yaml
+++ b/templates/terraform.yaml
@@ -1,0 +1,13 @@
+name: "Terraform Cloud Token"
+slug: terraform
+category: "Cloud"
+format:
+  prefix: ""
+  length: 14
+  charset: alphanumeric
+suggested_paths:
+  - "production/terraform/api_token"
+  - "services/infra/terraform_token"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/twilio.yaml
+++ b/templates/twilio.yaml
@@ -1,0 +1,13 @@
+name: "Twilio Auth Token"
+slug: twilio
+category: Marketing
+format:
+  prefix: ""
+  length: 32
+  charset: hex
+suggested_paths:
+  - "production/twilio/auth_token"
+  - "services/communications/twilio_token"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/workday.yaml
+++ b/templates/workday.yaml
@@ -1,0 +1,13 @@
+name: "Workday API Client Secret"
+slug: workday
+category: "HR"
+format:
+  prefix: ""
+  length: 64
+  charset: alphanumeric
+suggested_paths:
+  - "production/workday/client_secret"
+  - "services/hr/workday_secret"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/zendesk.yaml
+++ b/templates/zendesk.yaml
@@ -1,0 +1,13 @@
+name: "Zendesk API Token"
+slug: zendesk
+category: "CRM"
+format:
+  prefix: ""
+  length: 40
+  charset: alphanumeric
+suggested_paths:
+  - "production/zendesk/api_token"
+  - "services/crm/zendesk_token"
+metadata:
+  created_by: terraform
+  environment: production

--- a/templates/zoom.yaml
+++ b/templates/zoom.yaml
@@ -1,0 +1,13 @@
+name: "Zoom JWT Token"
+slug: zoom
+category: Collaboration
+format:
+  prefix: ""
+  length: 32
+  charset: alphanumeric
+suggested_paths:
+  - "production/zoom/jwt_token"
+  - "services/collaboration/zoom_secret"
+metadata:
+  created_by: terraform
+  environment: production

--- a/tests/test_aws_vault_plugin.py
+++ b/tests/test_aws_vault_plugin.py
@@ -1,0 +1,129 @@
+import importlib.util
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from thumper.plugins.base import AccessEvent, PluginError
+
+PLUGIN_FILE = (Path(__file__).resolve().parents[1]
+               / "plugins" / "vault" / "aws" / "plugin.py")
+
+
+def load_plugin_module():
+    spec = importlib.util.spec_from_file_location(
+        "thumper_plugin_aws_vault_test", PLUGIN_FILE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeSecretsManager:
+    def __init__(self):
+        self.created = []
+        self.deleted = []
+
+    def list_secrets(self, MaxResults=None):
+        return {"SecretList": []}
+
+    def create_secret(self, Name, SecretString, Description=None, Tags=None):
+        self.created.append({"Name": Name, "SecretString": SecretString,
+                             "Tags": Tags})
+
+    def delete_secret(self, SecretId, ForceDeleteWithoutRecovery=None):
+        self.deleted.append(SecretId)
+
+
+class FakePaginator:
+    def __init__(self, events):
+        self._events = events
+
+    def paginate(self, **kwargs):
+        return [{"Events": self._events}]
+
+
+class FakeCloudTrail:
+    def __init__(self, events=None):
+        self._events = events or []
+
+    def get_paginator(self, name):
+        return FakePaginator(self._events)
+
+
+class FakeSession:
+    def __init__(self, sm, ct, **kwargs):
+        self._sm, self._ct = sm, ct
+
+    def client(self, name):
+        return self._sm if name == "secretsmanager" else self._ct
+
+
+@pytest.fixture
+def module():
+    return load_plugin_module()
+
+
+def _connect(module, ct_events=None):
+    sm = FakeSecretsManager()
+    ct = FakeCloudTrail(ct_events)
+    plugin = module.Plugin({
+        "region": "us-east-1", "access_key_id": "AKIAFAKE",
+        "secret_access_key": "secret", "prefix": "",
+    })
+    module.boto3.Session = lambda **kw: FakeSession(sm, ct, **kw)
+    plugin.connect()
+    return plugin, sm, ct
+
+
+def test_connect_requires_region(module):
+    plugin = module.Plugin({"access_key_id": "a", "secret_access_key": "s"})
+    with pytest.raises(PluginError, match="region"):
+        plugin.connect()
+
+
+def test_connect_requires_keys(module):
+    plugin = module.Plugin({"region": "us-east-1"})
+    with pytest.raises(PluginError, match="access_key_id"):
+        plugin.connect()
+
+
+def test_plant_creates_secret(module):
+    plugin, sm, _ = _connect(module)
+    plugin.plant("production/stripe/key", "sk_live_fake",
+                 {"created_by": "terraform"})
+    assert len(sm.created) == 1
+    assert sm.created[0]["Name"] == "production/stripe/key"
+    assert sm.created[0]["SecretString"] == "sk_live_fake"
+    assert {"Key": "created_by", "Value": "terraform"} in sm.created[0]["Tags"]
+
+
+def test_delete_removes_secret(module):
+    plugin, sm, _ = _connect(module)
+    plugin.delete("production/stripe/key")
+    assert sm.deleted == ["production/stripe/key"]
+
+
+def test_poll_empty_when_no_events(module):
+    plugin, _, _ = _connect(module, ct_events=[])
+    assert plugin.poll(["production/stripe/key"]) == []
+
+
+def test_poll_parses_getsecretvalue_into_access_event(module):
+    ct_event = {
+        "EventTime": datetime(2026, 6, 22, 10, 0, tzinfo=timezone.utc),
+        "Username": "attacker",
+        "EventId": "evt-1",
+        "Resources": [{"ResourceType": "AWS::SecretsManager::Secret",
+                       "ResourceName": "production/stripe/key"}],
+        "CloudTrailEvent": '{"sourceIPAddress": "10.0.0.5", '
+                           '"requestParameters": {"secretId": "production/stripe/key"}}',
+    }
+    plugin, _, _ = _connect(module, ct_events=[ct_event])
+    events = plugin.poll(["production/stripe/key"])
+    assert len(events) == 1
+    ev = events[0]
+    assert isinstance(ev, AccessEvent)
+    assert ev.path == "production/stripe/key"
+    assert ev.accessor == "attacker"
+    assert ev.source_ip == "10.0.0.5"
+    assert ev.extra["event_id"] == "evt-1"

--- a/tests/test_hashicorp_plugin.py
+++ b/tests/test_hashicorp_plugin.py
@@ -1,0 +1,160 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from thumper.plugins.base import AccessEvent, PluginError
+
+PLUGIN_FILE = Path(__file__).resolve().parents[1] / "plugins" / "vault" / "hashicorp" / "plugin.py"
+
+
+def load_plugin_module():
+    spec = importlib.util.spec_from_file_location("thumper_plugin_hashicorp_test", PLUGIN_FILE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeKVv2:
+    def __init__(self):
+        self.created = []
+        self.deleted = []
+
+    def create_or_update_secret(self, path, secret, mount_point=None):
+        self.created.append({"path": path, "secret": secret, "mount_point": mount_point})
+
+    def delete_metadata_and_all_versions(self, path, mount_point=None):
+        self.deleted.append({"path": path, "mount_point": mount_point})
+
+
+class FakeAuditLogs:
+    def __init__(self, entries=None):
+        self.entries = entries or []
+
+    def list_enabled_audit_devices(self):
+        return {"data": {"file/": {"type": "file", "options": {"file_path": "/tmp/audit.log"}}}}
+
+
+class FakeAuth:
+    def __init__(self):
+        self.token = "s.faketoken"
+
+    class approle:
+        @staticmethod
+        def login(role_id, secret_id):
+            return {"auth": {"client_token": "s.faketoken"}}
+
+
+class FakeHvacClient:
+    def __init__(self, url=None, token=None, namespace=None):
+        self.url = url
+        self.token = token
+        self.namespace = namespace
+        self.secrets = type("secrets", (), {"kv": type("kv", (), {"v2": FakeKVv2()})()})()
+        self.sys = FakeAuditLogs()
+        self.auth = FakeAuth()
+        self._is_authenticated = True
+
+    def is_authenticated(self):
+        return self._is_authenticated
+
+
+@pytest.fixture
+def module(monkeypatch):
+    mod = load_plugin_module()
+    monkeypatch.setattr(mod, "hvac", type("hvac", (), {"Client": FakeHvacClient}))
+    return mod
+
+
+def test_connect_succeeds(module):
+    plugin = module.Plugin({
+        "url": "http://vault:8200",
+        "mount": "secret",
+        "role_id": "role123",
+        "secret_id": "secret456",
+    })
+    plugin.connect()
+    assert plugin._client is not None
+
+
+def test_connect_fails_without_url(module):
+    plugin = module.Plugin({"mount": "secret", "role_id": "r", "secret_id": "s"})
+    with pytest.raises(PluginError, match="url"):
+        plugin.connect()
+
+
+def test_plant_writes_secret(module):
+    plugin = module.Plugin({
+        "url": "http://vault:8200",
+        "mount": "secret",
+        "role_id": "r",
+        "secret_id": "s",
+    })
+    plugin.connect()
+    plugin.plant("production/stripe/key", "sk_live_fake", {"created_by": "terraform"})
+    kv = plugin._client.secrets.kv.v2
+    assert len(kv.created) == 1
+    assert kv.created[0]["path"] == "production/stripe/key"
+    assert kv.created[0]["secret"]["value"] == "sk_live_fake"
+    assert kv.created[0]["secret"]["created_by"] == "terraform"
+
+
+def test_delete_removes_secret(module):
+    plugin = module.Plugin({
+        "url": "http://vault:8200",
+        "mount": "secret",
+        "role_id": "r",
+        "secret_id": "s",
+    })
+    plugin.connect()
+    plugin.delete("production/stripe/key")
+    kv = plugin._client.secrets.kv.v2
+    assert len(kv.deleted) == 1
+    assert kv.deleted[0]["path"] == "production/stripe/key"
+
+
+def test_poll_returns_empty_when_no_reads(module, monkeypatch):
+    plugin = module.Plugin({
+        "url": "http://vault:8200",
+        "mount": "secret",
+        "role_id": "r",
+        "secret_id": "s",
+    })
+    plugin.connect()
+    monkeypatch.setattr(plugin, "_fetch_audit_entries", lambda: [])
+    events = plugin.poll(["production/stripe/key"])
+    assert events == []
+
+
+def test_poll_returns_access_events(module, monkeypatch):
+    plugin = module.Plugin({
+        "url": "http://vault:8200",
+        "mount": "secret",
+        "role_id": "r",
+        "secret_id": "s",
+    })
+    plugin.connect()
+    monkeypatch.setattr(plugin, "_fetch_audit_entries", lambda: [
+        {
+            "type": "response",
+            "time": "2026-06-22T10:00:00Z",
+            "request": {
+                "path": "secret/data/production/stripe/key",
+                "operation": "read",
+            },
+            "auth": {
+                "display_name": "approle-canary-reader",
+                "policies": ["default", "reader"],
+                "metadata": {"role_name": "canary-reader"},
+            },
+            "request_metadata": {
+                "remote_address": "10.0.0.5",
+            },
+        },
+    ])
+    events = plugin.poll(["production/stripe/key"])
+    assert len(events) == 1
+    assert isinstance(events[0], AccessEvent)
+    assert events[0].path == "production/stripe/key"
+    assert events[0].accessor == "approle-canary-reader"
+    assert events[0].source_ip == "10.0.0.5"

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,76 @@
+from thumper.services.templates import (
+    generate_value,
+    get_template,
+    list_templates,
+    reset_cache,
+)
+
+
+def setup_function():
+    reset_cache()
+
+
+def test_list_templates_returns_all():
+    templates = list_templates()
+    slugs = {t["slug"] for t in templates}
+    assert {"stripe", "github", "slack", "aws"} <= slugs
+    assert len(templates) >= 10
+
+
+def test_list_templates_sorted_by_category_then_name():
+    templates = list_templates()
+    categories = [t["category"] for t in templates]
+    assert categories == sorted(categories)
+
+
+def test_every_template_has_the_required_shape():
+    for t in list_templates():
+        assert t["slug"] and t["name"] and t["category"]
+        assert "prefix" in t["format"] or t["format"].get("prefix", "") == ""
+        assert isinstance(t["format"]["length"], int)
+        assert isinstance(t["suggested_paths"], list) and t["suggested_paths"]
+
+
+def test_get_template_by_slug():
+    t = get_template("stripe")
+    assert t is not None
+    assert t["name"] == "Stripe API Key"
+    assert t["category"] == "Finance"
+    assert "format" in t and "suggested_paths" in t
+
+
+def test_get_template_unknown_returns_none():
+    assert get_template("nonexistent") is None
+
+
+def test_generate_value_with_prefix_and_length():
+    t = get_template("stripe")
+    value = generate_value(t)
+    assert value.startswith("sk_live_")
+    assert len(value) == t["format"]["length"] == 48
+
+
+def test_generate_value_alphanumeric():
+    t = get_template("github")
+    value = generate_value(t)
+    assert value.startswith("ghp_")
+    assert value[len("ghp_"):].isalnum()
+
+
+def test_generate_value_hex():
+    t = get_template("datadog")
+    value = generate_value(t)
+    int(value, 16)  # hex charset -> parses as hex, must not raise
+
+
+def test_generate_value_uppercase():
+    t = get_template("aws")
+    value = generate_value(t)
+    assert value.startswith("AKIA")
+    suffix = value[len("AKIA"):]
+    assert suffix == suffix.upper() and suffix.isalnum()
+
+
+def test_generate_value_is_unique_each_call():
+    t = get_template("stripe")
+    assert generate_value(t) != generate_value(t)

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -1,5 +1,3 @@
-import json
-
 import pytest
 import yaml
 

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -1,0 +1,161 @@
+import json
+
+import pytest
+import yaml
+
+from thumper.plugins import loader
+from thumper import store
+
+
+@pytest.fixture(autouse=True)
+def _clear_plugin_cache():
+    loader.reset_cache()
+    yield
+    loader.reset_cache()
+
+
+@pytest.fixture
+def vault_plugin_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(loader, "PLUGINS_DIR", tmp_path)
+    vault_dir = tmp_path / "vault" / "hashicorp"
+    vault_dir.mkdir(parents=True)
+    (vault_dir / "manifest.yaml").write_text(yaml.dump({
+        "name": "hashicorp",
+        "kind": "vault",
+        "display_name": "HashiCorp Vault",
+        "version": "0.1.0",
+        "author": "test",
+        "description": "Test vault",
+        "config_schema": [
+            {"key": "url", "label": "Vault URL", "type": "string", "required": True},
+            {"key": "secret_id", "label": "Secret ID", "type": "secret", "required": True},
+        ],
+    }))
+    (vault_dir / "plugin.py").write_text(
+        "from thumper.plugins.base import VaultPlugin, PluginError\n"
+        "class Plugin(VaultPlugin):\n"
+        "    def connect(self):\n"
+        "        if not self.config.get('url'): raise PluginError('url required')\n"
+        "    def plant(self, path, value, metadata): pass\n"
+        "    def delete(self, path): pass\n"
+        "    def poll(self, paths): return []\n"
+    )
+    return vault_dir
+
+
+def test_create_vault_connection(client_db, vault_plugin_dir):
+    tc, db = client_db
+    resp = tc.post("/api/vault/connections", json={
+        "name": "Prod Vault", "plugin": "hashicorp",
+        "config": {"url": "http://vault:8200", "secret_id": "abc"},
+    })
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["name"] == "Prod Vault"
+    assert data["id"].startswith("vc_")
+    assert data["config"]["secret_id"] == "••••••••"
+
+
+def test_list_vault_connections(client_db, vault_plugin_dir):
+    tc, db = client_db
+    tc.post("/api/vault/connections", json={
+        "name": "A", "plugin": "hashicorp", "config": {"url": "http://a"}})
+    tc.post("/api/vault/connections", json={
+        "name": "B", "plugin": "hashicorp", "config": {"url": "http://b"}})
+    resp = tc.get("/api/vault/connections")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 2
+
+
+def test_update_vault_connection(client_db, vault_plugin_dir):
+    tc, db = client_db
+    create = tc.post("/api/vault/connections", json={
+        "name": "Old", "plugin": "hashicorp", "config": {"url": "http://old"}})
+    vid = create.json()["id"]
+    resp = tc.put(f"/api/vault/connections/{vid}", json={
+        "name": "New", "config": {"url": "http://new"}})
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "New"
+
+
+def test_delete_vault_connection(client_db, vault_plugin_dir):
+    tc, db = client_db
+    create = tc.post("/api/vault/connections", json={
+        "name": "Doomed", "plugin": "hashicorp", "config": {"url": "http://x"}})
+    vid = create.json()["id"]
+    resp = tc.delete(f"/api/vault/connections/{vid}")
+    assert resp.status_code == 200
+    assert tc.get("/api/vault/connections").json() == []
+
+
+def test_test_vault_connection(client_db, vault_plugin_dir):
+    tc, db = client_db
+    create = tc.post("/api/vault/connections", json={
+        "name": "Test", "plugin": "hashicorp",
+        "config": {"url": "http://vault:8200", "secret_id": "s"}})
+    vid = create.json()["id"]
+    resp = tc.post(f"/api/vault/connections/{vid}/test")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+
+
+def test_list_templates(client_db):
+    tc, db = client_db
+    resp = tc.get("/api/vault/templates")
+    assert resp.status_code == 200
+    templates = resp.json()
+    assert len(templates) >= 10
+    slugs = {t["slug"] for t in templates}
+    assert "stripe" in slugs
+
+
+def test_create_canary_secret(client_db, vault_plugin_dir):
+    tc, db = client_db
+    create = tc.post("/api/vault/connections", json={
+        "name": "Test", "plugin": "hashicorp",
+        "config": {"url": "http://vault:8200", "secret_id": "s"}})
+    vid = create.json()["id"]
+    # Mark as configured
+    store.set_vault_connection_test(db, vid=vid, configured=True)
+
+    resp = tc.post("/api/vault/secrets", json={
+        "vault_connection_id": vid,
+        "template": "stripe",
+        "path": "production/stripe/key",
+    })
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["template"] == "stripe"
+    assert data["state"] == "planted"
+
+
+def test_list_canary_secrets(client_db, vault_plugin_dir):
+    tc, db = client_db
+    create = tc.post("/api/vault/connections", json={
+        "name": "Test", "plugin": "hashicorp",
+        "config": {"url": "http://vault:8200", "secret_id": "s"}})
+    vid = create.json()["id"]
+    store.set_vault_connection_test(db, vid=vid, configured=True)
+    tc.post("/api/vault/secrets", json={
+        "vault_connection_id": vid, "template": "stripe",
+        "path": "production/stripe/key"})
+    resp = tc.get("/api/vault/secrets")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+
+def test_delete_canary_secret(client_db, vault_plugin_dir):
+    tc, db = client_db
+    create = tc.post("/api/vault/connections", json={
+        "name": "Test", "plugin": "hashicorp",
+        "config": {"url": "http://vault:8200", "secret_id": "s"}})
+    vid = create.json()["id"]
+    store.set_vault_connection_test(db, vid=vid, configured=True)
+    create_secret = tc.post("/api/vault/secrets", json={
+        "vault_connection_id": vid, "template": "stripe",
+        "path": "production/stripe/key"})
+    csid = create_secret.json()["id"]
+    resp = tc.delete(f"/api/vault/secrets/{csid}")
+    assert resp.status_code == 200
+    assert tc.get("/api/vault/secrets").json() == []

--- a/tests/test_vault_plugin_loader.py
+++ b/tests/test_vault_plugin_loader.py
@@ -1,0 +1,62 @@
+import pytest
+import yaml
+
+from thumper.plugins import loader
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    loader.reset_cache()
+    yield
+    loader.reset_cache()
+
+
+@pytest.fixture
+def vault_plugin_dir(tmp_path, monkeypatch):
+    """Create a minimal vault plugin under a temp PLUGINS_DIR."""
+    monkeypatch.setattr(loader, "PLUGINS_DIR", tmp_path)
+    vault_dir = tmp_path / "vault" / "fakevault"
+    vault_dir.mkdir(parents=True)
+    (vault_dir / "manifest.yaml").write_text(yaml.dump({
+        "name": "fakevault",
+        "kind": "vault",
+        "display_name": "Fake Vault",
+        "version": "0.1.0",
+        "author": "test",
+        "description": "A test vault plugin",
+        "config_schema": [
+            {"key": "url", "label": "Vault URL", "type": "string", "required": True},
+        ],
+    }))
+    (vault_dir / "plugin.py").write_text(
+        "from thumper.plugins.base import VaultPlugin\n"
+        "class Plugin(VaultPlugin):\n"
+        "    def connect(self): pass\n"
+        "    def plant(self, path, value, metadata): pass\n"
+        "    def delete(self, path): pass\n"
+        "    def poll(self, paths, since=None): return []\n"
+    )
+    return vault_dir
+
+
+def test_discover_finds_vault_plugin(vault_plugin_dir):
+    manifests = loader.discover_manifests()
+    names = [m["name"] for m in manifests]
+    assert "fakevault" in names
+
+
+def test_discovered_vault_manifest_has_kind(vault_plugin_dir):
+    manifests = loader.discover_manifests()
+    fake = next(m for m in manifests if m["name"] == "fakevault")
+    assert fake["kind"] == "vault"
+
+
+def test_load_vault_plugin(vault_plugin_dir):
+    plugin = loader.load_plugin("fakevault", {"url": "http://localhost:8200"})
+    for method in ("connect", "plant", "delete", "poll"):
+        assert hasattr(plugin, method)
+
+
+def test_vault_plugin_poll_returns_list(vault_plugin_dir):
+    plugin = loader.load_plugin("fakevault", {"url": "http://localhost:8200"})
+    assert plugin.poll(["/secret/test"]) == []

--- a/tests/test_vault_store.py
+++ b/tests/test_vault_store.py
@@ -1,0 +1,129 @@
+import json
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from thumper import store
+from thumper.db import Base
+
+
+@pytest.fixture
+def db():
+    engine = create_engine("sqlite://", echo=False,
+                           connect_args={"check_same_thread": False},
+                           poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+
+
+# ── vault connections ────────────────────────────────────────────────────────
+def test_create_vault_connection(db):
+    vc = store.create_vault_connection(
+        db, name="Production Vault", plugin="hashicorp",
+        config={"url": "http://vault:8200", "role_id": "abc"})
+    assert vc.id.startswith("vc_")
+    assert vc.name == "Production Vault"
+    assert vc.plugin == "hashicorp"
+    assert vc.configured is False
+    assert vc.created_at is not None
+    assert json.loads(vc.config_json) == {"url": "http://vault:8200", "role_id": "abc"}
+
+
+def test_list_vault_connections_newest_first(db):
+    a = store.create_vault_connection(db, name="A", plugin="hashicorp", config={})
+    b = store.create_vault_connection(db, name="B", plugin="hashicorp", config={})
+    ids = [c.id for c in store.list_vault_connections(db)]
+    assert set(ids) == {a.id, b.id}
+    assert len(ids) == 2
+
+
+def test_get_vault_connection(db):
+    vc = store.create_vault_connection(db, name="T", plugin="hashicorp", config={})
+    assert store.get_vault_connection(db, vc.id).id == vc.id
+    assert store.get_vault_connection(db, "vc_nope") is None
+
+
+def test_update_vault_connection(db):
+    vc = store.create_vault_connection(db, name="Old", plugin="hashicorp",
+                                       config={"url": "http://old"})
+    updated = store.update_vault_connection(db, vc.id, name="New",
+                                            config={"url": "http://new"})
+    assert updated.name == "New"
+    assert json.loads(updated.config_json)["url"] == "http://new"
+    assert store.update_vault_connection(db, "vc_nope", name="X", config={}) is None
+
+
+def test_set_vault_connection_test_flips_configured(db):
+    vc = store.create_vault_connection(db, name="T", plugin="hashicorp", config={})
+    store.set_vault_connection_test(db, vid=vc.id, configured=True)
+    assert store.get_vault_connection(db, vc.id).configured is True
+
+
+def test_update_vault_last_poll(db):
+    vc = store.create_vault_connection(db, name="T", plugin="hashicorp", config={})
+    assert store.get_vault_connection(db, vc.id).last_poll_at is None
+    store.update_vault_last_poll(db, vc.id)
+    assert store.get_vault_connection(db, vc.id).last_poll_at is not None
+
+
+def test_delete_vault_connection_cascades_canaries(db):
+    vc = store.create_vault_connection(db, name="T", plugin="hashicorp", config={})
+    store.create_canary_secret(db, vault_connection_id=vc.id, template="stripe",
+                               path="secret/stripe/key", value="sk_live_fake")
+    assert store.delete_vault_connection(db, vc.id) is True
+    assert store.list_canary_secrets_for_connection(db, vc.id) == []
+    assert store.delete_vault_connection(db, "vc_nope") is False
+
+
+# ── canary secrets ────────────────────────────────────────────────────────────
+def test_create_canary_secret(db):
+    vc = store.create_vault_connection(db, name="T", plugin="hashicorp", config={})
+    cs = store.create_canary_secret(db, vault_connection_id=vc.id,
+                                    template="stripe", path="secret/stripe/key",
+                                    value="sk_live_fake")
+    assert cs.id.startswith("cs_")
+    assert cs.state == "pending"
+    assert cs.last_accessed_at is None
+
+
+def test_set_canary_secret_state(db):
+    vc = store.create_vault_connection(db, name="T", plugin="hashicorp", config={})
+    cs = store.create_canary_secret(db, vault_connection_id=vc.id, template="s",
+                                    path="p", value="v")
+    store.set_canary_secret_state(db, cs.id, "planted")
+    assert store.get_canary_secret(db, cs.id).state == "planted"
+
+
+def test_mark_canary_secret_accessed_triggers(db):
+    vc = store.create_vault_connection(db, name="T", plugin="hashicorp", config={})
+    cs = store.create_canary_secret(db, vault_connection_id=vc.id, template="s",
+                                    path="p", value="v")
+    store.mark_canary_secret_accessed(db, cs.id)
+    row = store.get_canary_secret(db, cs.id)
+    assert row.state == "triggered"
+    assert row.last_accessed_at is not None
+
+
+def test_list_planted_canary_secrets_for_connection(db):
+    vc = store.create_vault_connection(db, name="T", plugin="hashicorp", config={})
+    pending = store.create_canary_secret(db, vault_connection_id=vc.id,
+                                         template="s", path="p1", value="v")
+    planted = store.create_canary_secret(db, vault_connection_id=vc.id,
+                                         template="s", path="p2", value="v")
+    store.set_canary_secret_state(db, planted.id, "planted")
+    ids = [c.id for c in store.list_planted_canary_secrets_for_connection(db, vc.id)]
+    assert planted.id in ids
+    assert pending.id not in ids
+
+
+def test_delete_canary_secret(db):
+    vc = store.create_vault_connection(db, name="T", plugin="hashicorp", config={})
+    cs = store.create_canary_secret(db, vault_connection_id=vc.id, template="s",
+                                    path="p", value="v")
+    assert store.delete_canary_secret(db, cs.id) is True
+    assert store.get_canary_secret(db, cs.id) is None
+    assert store.delete_canary_secret(db, "cs_nope") is False


### PR DESCRIPTION
**Task 5 of #255** (secret-manager honeytokens) — the management API. This is the first task that integrates the whole vault stack (framework + models + templates + plugins).

### New work (the single commit on top of the integration merges)
- **`api/vault_routes.py`** — mounted under the admin-gated `/api` router (→ `/api/vault/...`):
  - **connections**: list / create / update (config-merge so a masked secret survives an edit) / delete (best-effort unplant of live canaries first) / **test** (runs the plugin's `connect()` and flips `configured`).
  - **templates**: list the canary templates.
  - **secrets**: list / create (generate a value from the template, plant it via the plugin, track `pending → planted/failed`) / delete (unplant then remove).
- Pydantic models in `models.py`; `router.include_router(vault_router)` in `routes.py`.
- The `/secrets/{id}/access-logs` endpoint is **deferred to Task 6** (poller), which adds the access-log table it reads.

### ⚠️ Stacking note
This branch **carries the four dependency PRs** merged in for integration/testing — **#257** (framework), **#259** (models), **#260** (templates), **#261** (plugins). The routes are the **single commit on top** (reviewable in isolation via that commit). Once the base PRs merge, this rebases down to just the routes. Review order should be the base PRs first.

### Tests
`tests/test_vault_api.py` (ported) — 9 tests covering connection CRUD + test, template listing, and canary create/list/delete, with a faked plugin (no real hvac/boto3 calls) and masked-secret assertions. App imports cleanly; 19 existing API/route tests unaffected; ruff clean.

Part of #255.