### PR TITLE
feat(vault): Secret Managers UI — connections + canary secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Secret Managers UI: connect a vault (HashiCorp / AWS Secrets Manager), plant
+  canary secrets from a template, and view recorded reads — under a new sidebar
+  section with Connections and Canary Secrets tabs.
 - Background poller that watches each configured secrets manager's audit log for
   canary-secret reads and raises an alert, deduped by the manager's event id.
 - Docker registry credentials honeytoken type for `~/.docker/config.json`.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { NavLink, Route, Routes } from "react-router-dom";
 import {
   Crosshair,
+  KeyRound,
   LayoutDashboard,
   MonitorDot,
   PanelLeftClose,
@@ -16,6 +17,8 @@ import CreateTripwire from "./pages/CreateTripwire.tsx";
 import Endpoints from "./pages/Endpoints.tsx";
 import EndpointDetail from "./pages/EndpointDetail.tsx";
 import Integrations from "./pages/Integrations.tsx";
+import VaultConnections from "./pages/VaultConnections.tsx";
+import CanarySecrets from "./pages/CanarySecrets.tsx";
 import Settings from "./pages/Settings.tsx";
 import NotFound from "./pages/NotFound.tsx";
 import AdminGate from "./AdminGate.tsx";
@@ -89,6 +92,10 @@ function Sidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () => 
           <span className="nav-icon"><MonitorDot size={18} /></span>{" "}
           <span className="nav-label">Endpoints</span>
         </NavLink>
+        <NavLink to="/vault" className={linkClass} title="Secret Managers">
+          <span className="nav-icon"><KeyRound size={18} /></span>{" "}
+          <span className="nav-label">Secret Managers</span>
+        </NavLink>
         <NavLink to="/integrations" className={linkClass} title="Integrations">
           <span className="nav-icon"><Plug size={18} /></span>{" "}
           <span className="nav-label">Integrations</span>
@@ -121,6 +128,8 @@ export default function App() {
           <Route path="/tripwires/:id" element={<TripwireDetail />} />
           <Route path="/endpoints" element={<Endpoints />} />
           <Route path="/endpoints/:id" element={<EndpointDetail />} />
+          <Route path="/vault" element={<VaultConnections />} />
+          <Route path="/vault/secrets" element={<CanarySecrets />} />
           <Route path="/integrations" element={<Integrations />} />
           <Route path="/settings" element={<Settings />} />
           <Route path="*" element={<NotFound />} />

--- a/ui/src/api/http.ts
+++ b/ui/src/api/http.ts
@@ -3,6 +3,9 @@
 import type {
   Alert,
   AppSettings,
+  CanaryAccessLog,
+  CanarySecret,
+  CanaryTemplate,
   CredentialSource,
   DashboardStats,
   Deployment,
@@ -16,6 +19,8 @@ import type {
   TokenTypeInfo,
   Tripwire,
   TripwireDetail,
+  VaultConnection,
+  VaultConnectionTestResult,
   VersionInfo,
 } from "./types";
 
@@ -131,6 +136,34 @@ export const httpApi = {
     req<IntegrationTestResult>(`/integrations/${plugin}/test`, { method: "POST" }),
   deleteIntegration: (plugin: string) =>
     req<{ status: string }>(`/integrations/${plugin}`, { method: "DELETE" }),
+
+  // Vault / secret-manager canaries
+  listVaultConnections: () => req<VaultConnection[]>("/vault/connections"),
+  createVaultConnection: (input: {
+    name: string;
+    plugin: string;
+    config: Record<string, string | boolean>;
+  }) => req<VaultConnection>("/vault/connections", { method: "POST", body: JSON.stringify(input) }),
+  updateVaultConnection: (id: string, input: {
+    name: string;
+    config: Record<string, string | boolean>;
+  }) => req<VaultConnection>(`/vault/connections/${id}`, { method: "PUT", body: JSON.stringify(input) }),
+  deleteVaultConnection: (id: string) =>
+    req<{ status: string }>(`/vault/connections/${id}`, { method: "DELETE" }),
+  testVaultConnection: (id: string) =>
+    req<VaultConnectionTestResult>(`/vault/connections/${id}/test`, { method: "POST" }),
+
+  listCanaryTemplates: () => req<CanaryTemplate[]>("/vault/templates"),
+  listCanarySecrets: () => req<CanarySecret[]>("/vault/secrets"),
+  createCanarySecret: (input: {
+    vault_connection_id: string;
+    template: string;
+    path: string;
+  }) => req<CanarySecret>("/vault/secrets", { method: "POST", body: JSON.stringify(input) }),
+  deleteCanarySecret: (id: string) =>
+    req<{ status: string }>(`/vault/secrets/${id}`, { method: "DELETE" }),
+  listCanaryAccessLogs: (id: string) =>
+    req<CanaryAccessLog[]>(`/vault/secrets/${id}/access-logs`),
 
   // Token catalog + preview (generation lives on the server)
   getTokenTypes: () => req<TokenTypeInfo[]>("/token-types"),

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -119,7 +119,7 @@ export interface ConfigField {
   generate?: boolean; // offer a "Generate" button (e.g. a signing secret you create yourself)
 }
 
-export type PluginKind = "deploy" | "alert";
+export type PluginKind = "deploy" | "alert" | "vault";
 
 export interface PluginManifest {
   name: string;
@@ -145,6 +145,51 @@ export interface IntegrationTestResult {
   ok: boolean;
   error: string | null;
   tested_at: string;
+}
+
+// ── Vault / secret-manager canaries ──────────────────────────────────────────
+export type CanaryState = "pending" | "planted" | "failed" | "triggered";
+
+export interface VaultConnection {
+  id: string;
+  name: string;
+  plugin: string;
+  configured: boolean;
+  config: Record<string, string | boolean>;
+  last_poll_at?: string | null;
+  created_at: string;
+}
+
+export interface VaultConnectionTestResult {
+  ok: boolean;
+  error?: string | null;
+}
+
+export interface CanaryTemplate {
+  slug: string;
+  name: string;
+  category: string;
+  suggested_paths: string[];
+}
+
+export interface CanarySecret {
+  id: string;
+  vault_connection_id: string;
+  vault_connection_name: string;
+  template: string;
+  template_name: string;
+  path: string;
+  state: CanaryState;
+  created_at: string;
+  last_accessed_at?: string | null;
+}
+
+export interface CanaryAccessLog {
+  id: string;
+  event_id: string | null;
+  accessor: string | null;
+  source_ip: string | null;
+  timestamp: string;
 }
 
 export interface VersionInfo {

--- a/ui/src/api/vault.test.ts
+++ b/ui/src/api/vault.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { httpApi } from "./http.ts";
+import { clearAdminToken, setAdminToken } from "./auth.ts";
+
+describe("vault API client", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    const values = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+      removeItem: (key: string) => values.delete(key),
+      clear: () => values.clear(),
+      key: (index: number) => Array.from(values.keys())[index] ?? null,
+      get length() {
+        return values.size;
+      },
+    } as Storage;
+    Object.defineProperty(globalThis, "localStorage", { value: storage, configurable: true });
+    Object.defineProperty(globalThis, "fetch", { value: fetchMock, configurable: true });
+    setAdminToken("admin-secret");
+  });
+
+  afterEach(() => {
+    clearAdminToken();
+    fetchMock.mockReset();
+  });
+
+  function ok(body: unknown) {
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 200, json: async () => body });
+  }
+
+  it("creates a connection with a JSON body", async () => {
+    ok({ id: "vc_1", name: "Prod", plugin: "hashicorp", configured: false, config: {}, created_at: "t" });
+    await httpApi.createVaultConnection({ name: "Prod", plugin: "hashicorp", config: { url: "http://v" } });
+    expect(fetchMock).toHaveBeenCalledWith("/api/vault/connections", expect.objectContaining({
+      method: "POST",
+      body: JSON.stringify({ name: "Prod", plugin: "hashicorp", config: { url: "http://v" } }),
+    }));
+  });
+
+  it("tests a connection via POST to its /test path", async () => {
+    ok({ ok: true, error: null });
+    await expect(httpApi.testVaultConnection("vc_9")).resolves.toEqual({ ok: true, error: null });
+    expect(fetchMock).toHaveBeenCalledWith("/api/vault/connections/vc_9/test",
+      expect.objectContaining({ method: "POST" }));
+  });
+
+  it("plants a canary secret with the template and path", async () => {
+    ok({ id: "cs_1", template: "stripe", state: "planted" });
+    await httpApi.createCanarySecret({ vault_connection_id: "vc_1", template: "stripe", path: "prod/stripe" });
+    expect(fetchMock).toHaveBeenCalledWith("/api/vault/secrets", expect.objectContaining({
+      method: "POST",
+      body: JSON.stringify({ vault_connection_id: "vc_1", template: "stripe", path: "prod/stripe" }),
+    }));
+  });
+
+  it("fetches access logs for a secret", async () => {
+    ok([{ id: "cal_1", event_id: "e1", accessor: "mallory", source_ip: "10.0.0.1", timestamp: "t" }]);
+    const logs = await httpApi.listCanaryAccessLogs("cs_1");
+    expect(logs[0].accessor).toBe("mallory");
+    expect(fetchMock).toHaveBeenCalledWith("/api/vault/secrets/cs_1/access-logs",
+      expect.objectContaining({ headers: expect.objectContaining({ authorization: "Bearer admin-secret" }) }));
+  });
+
+  it("deletes a connection via DELETE", async () => {
+    ok({ status: "ok" });
+    await httpApi.deleteVaultConnection("vc_1");
+    expect(fetchMock).toHaveBeenCalledWith("/api/vault/connections/vc_1",
+      expect.objectContaining({ method: "DELETE" }));
+  });
+});

--- a/ui/src/pages/CanarySecrets.tsx
+++ b/ui/src/pages/CanarySecrets.tsx
@@ -1,0 +1,274 @@
+import { useEffect, useState } from "react";
+import type {
+  CanaryAccessLog,
+  CanarySecret,
+  CanaryTemplate,
+  VaultConnection,
+} from "../api";
+import { api } from "../api";
+import { TimeAgo, Topbar } from "../components/ui.tsx";
+import PageTitle from "../components/PageTitle.tsx";
+import { VaultTabs } from "./VaultConnections.tsx";
+
+const PAGE_TITLE = "Canary Secrets";
+
+// canary state -> the reused integration badge class. A read makes state
+// "triggered", which is an ALERT, so it borrows the red "failed" styling.
+const BADGE: Record<CanarySecret["state"], string> = {
+  pending: "pending",
+  planted: "deployed",
+  failed: "failed",
+  triggered: "triggered",
+};
+
+export default function CanarySecrets() {
+  const [secrets, setSecrets] = useState<CanarySecret[]>([]);
+  const [connections, setConnections] = useState<VaultConnection[]>([]);
+  const [planting, setPlanting] = useState(false);
+  const [logsFor, setLogsFor] = useState<CanarySecret | null>(null);
+
+  const load = () =>
+    Promise.all([api.listCanarySecrets(), api.listVaultConnections()]).then(([s, c]) => {
+      setSecrets(s);
+      setConnections(c);
+    });
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function remove(s: CanarySecret) {
+    if (!window.confirm(
+      `Delete "${s.path}"? Thumper removes it from the secrets manager too.`
+    )) return;
+    await api.deleteCanarySecret(s.id);
+    await load();
+  }
+
+  // Only configured connections can hold a planted canary.
+  const usable = connections.filter((c) => c.configured);
+
+  return (
+    <>
+      <PageTitle title={PAGE_TITLE} />
+      <Topbar
+        title={PAGE_TITLE}
+        action={
+          <button
+            className="btn primary"
+            disabled={usable.length === 0}
+            title={usable.length === 0 ? "Connect and test a secret manager first" : ""}
+            onClick={() => setPlanting(true)}
+          >
+            Plant Canary
+          </button>
+        }
+      />
+      <div className="content">
+        <VaultTabs />
+        <p className="muted" style={{ marginTop: 12 }}>
+          Fake credentials planted in your secrets managers. Thumper polls each manager's
+          audit log and raises an alert the moment one is read.
+        </p>
+
+        {secrets.length === 0 ? (
+          <div className="card">
+            <div className="empty">
+              No canary secrets planted yet.
+              {usable.length === 0
+                ? " Connect and test a secret manager first."
+                : " Click Plant Canary to plant one."}
+            </div>
+          </div>
+        ) : (
+          <div className="card">
+            <table>
+              <thead>
+                <tr>
+                  <th>Template</th>
+                  <th>Secret manager</th>
+                  <th>Path</th>
+                  <th>State</th>
+                  <th>Last read</th>
+                  <th />
+                </tr>
+              </thead>
+              <tbody>
+                {secrets.map((s) => (
+                  <tr key={s.id}>
+                    <td>{s.template_name}</td>
+                    <td>{s.vault_connection_name}</td>
+                    <td className="path">{s.path}</td>
+                    <td><span className={`badge ${BADGE[s.state]}`}><span className="dot" />{s.state}</span></td>
+                    <td className="muted">
+                      {s.last_accessed_at ? <TimeAgo iso={s.last_accessed_at} /> : "—"}
+                    </td>
+                    <td>
+                      <div className="row" style={{ gap: 8, justifyContent: "flex-end" }}>
+                        <button className="btn small" onClick={() => setLogsFor(s)}>Reads</button>
+                        <button className="btn small danger" onClick={() => remove(s)}>Delete</button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {planting && (
+        <PlantModal
+          connections={usable}
+          onClose={() => setPlanting(false)}
+          onPlanted={async () => {
+            setPlanting(false);
+            await load();
+          }}
+        />
+      )}
+      {logsFor && <AccessLogModal secret={logsFor} onClose={() => setLogsFor(null)} />}
+    </>
+  );
+}
+
+function PlantModal({
+  connections,
+  onClose,
+  onPlanted,
+}: {
+  connections: VaultConnection[];
+  onClose: () => void;
+  onPlanted: () => void;
+}) {
+  const [templates, setTemplates] = useState<CanaryTemplate[]>([]);
+  const [connId, setConnId] = useState(connections[0]?.id ?? "");
+  const [template, setTemplate] = useState("");
+  const [path, setPath] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    api.listCanaryTemplates().then((t) => {
+      setTemplates(t);
+      if (t[0]) setTemplate(t[0].slug);
+    });
+  }, []);
+
+  const chosen = templates.find((t) => t.slug === template);
+  const missing = !connId || !template || !path.trim();
+
+  async function plant() {
+    setSaving(true);
+    setError(null);
+    try {
+      await api.createCanarySecret({ vault_connection_id: connId, template, path: path.trim() });
+      onPlanted();
+    } catch (e) {
+      setError((e as Error).message);
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="card modal-card" style={{ width: 480 }} onClick={(e) => e.stopPropagation()}>
+        <div className="card-head">
+          <h2>Plant canary secret</h2>
+          <span className="type-tag">vault</span>
+        </div>
+
+        <div className="field">
+          <label><span>Secret manager</span></label>
+          <select value={connId} onChange={(e) => setConnId(e.target.value)}>
+            {connections.map((c) => <option key={c.id} value={c.id}>{c.name}</option>)}
+          </select>
+        </div>
+
+        <div className="field">
+          <label><span>Template</span></label>
+          <select value={template} onChange={(e) => setTemplate(e.target.value)}>
+            {templates.map((t) => (
+              <option key={t.slug} value={t.slug}>{t.name} · {t.category}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="field">
+          <label><span>Path</span><span className="field-tag required">Required</span></label>
+          <input
+            type="text"
+            placeholder="where to store it in the manager, e.g. production/stripe/key"
+            value={path}
+            onChange={(e) => setPath(e.target.value)}
+          />
+          {chosen && chosen.suggested_paths.length > 0 && (
+            <div className="row field-actions" style={{ flexWrap: "wrap" }}>
+              {chosen.suggested_paths.map((p) => (
+                <button type="button" key={p} className="btn small" onClick={() => setPath(p)}>
+                  {p}
+                </button>
+              ))}
+            </div>
+          )}
+          <div className="help">
+            A realistic-looking fake value is generated for you and written at this path.
+          </div>
+        </div>
+
+        {error && <div className="danger-text" style={{ marginTop: 6 }}>{error}</div>}
+
+        <div className="row" style={{ marginTop: 6 }}>
+          <button className="btn primary" disabled={saving || missing} onClick={plant}>
+            {saving ? "Planting…" : "Plant"}
+          </button>
+          <button className="btn" onClick={onClose}>Cancel</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AccessLogModal({ secret, onClose }: { secret: CanarySecret; onClose: () => void }) {
+  const [logs, setLogs] = useState<CanaryAccessLog[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    api.listCanaryAccessLogs(secret.id).then(setLogs).catch((e) => setError((e as Error).message));
+  }, [secret.id]);
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="card modal-card" style={{ width: 560 }} onClick={(e) => e.stopPropagation()}>
+        <div className="card-head">
+          <h2>Reads of {secret.template_name}</h2>
+          <span className="type-tag">{secret.path}</span>
+        </div>
+        {error ? (
+          <div className="danger-text">{error}</div>
+        ) : logs === null ? (
+          <div className="empty">Loading…</div>
+        ) : logs.length === 0 ? (
+          <div className="empty">No reads recorded yet. A read here fires an alert.</div>
+        ) : (
+          <table>
+            <thead>
+              <tr><th>When</th><th>Accessor</th><th>Source IP</th></tr>
+            </thead>
+            <tbody>
+              {logs.map((l) => (
+                <tr key={l.id}>
+                  <td className="muted"><TimeAgo iso={l.timestamp} /></td>
+                  <td>{l.accessor ?? "—"}</td>
+                  <td className="path">{l.source_ip ?? "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+        <div className="row" style={{ marginTop: 6 }}>
+          <button className="btn" onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/VaultConnections.tsx
+++ b/ui/src/pages/VaultConnections.tsx
@@ -1,0 +1,302 @@
+import { useEffect, useState } from "react";
+import { NavLink } from "react-router-dom";
+import type {
+  PluginManifest,
+  VaultConnection,
+  VaultConnectionTestResult,
+} from "../api";
+import { api } from "../api";
+import { TimeAgo, Topbar } from "../components/ui.tsx";
+import PageTitle from "../components/PageTitle.tsx";
+
+const PAGE_TITLE = "Secret Managers";
+
+// Shared tabs between the two vault pages. Kept identical in CanarySecrets.tsx.
+export function VaultTabs() {
+  const cls = ({ isActive }: { isActive: boolean }) => (isActive ? "active" : "");
+  return (
+    <nav className="nav-tabs">
+      <NavLink to="/vault" end className={cls}>Connections</NavLink>
+      <NavLink to="/vault/secrets" className={cls}>Canary Secrets</NavLink>
+    </nav>
+  );
+}
+
+export default function VaultConnections() {
+  const [connections, setConnections] = useState<VaultConnection[]>([]);
+  const [manifests, setManifests] = useState<PluginManifest[]>([]);
+  const [adding, setAdding] = useState(false);
+  const [editing, setEditing] = useState<VaultConnection | null>(null);
+  const [testing, setTesting] = useState<Record<string, boolean>>({});
+  const [results, setResults] = useState<Record<string, VaultConnectionTestResult>>({});
+
+  const load = () =>
+    Promise.all([api.listVaultConnections(), api.listManifests()]).then(([c, m]) => {
+      setConnections(c);
+      setManifests(m.filter((x) => x.kind === "vault"));
+    });
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function test(id: string) {
+    setTesting((t) => ({ ...t, [id]: true }));
+    try {
+      const res = await api.testVaultConnection(id);
+      setResults((r) => ({ ...r, [id]: res }));
+    } catch (e) {
+      setResults((r) => ({ ...r, [id]: { ok: false, error: (e as Error).message } }));
+    } finally {
+      setTesting((t) => ({ ...t, [id]: false }));
+      await load(); // refresh the persisted "configured" badge
+    }
+  }
+
+  async function remove(c: VaultConnection) {
+    if (!window.confirm(
+      `Remove "${c.name}"? Its canary secrets are deleted from Thumper (they are ` +
+      `NOT removed from the secrets manager - delete those first if you want them gone).`
+    )) return;
+    await api.deleteVaultConnection(c.id);
+    setResults((r) => {
+      const next = { ...r };
+      delete next[c.id];
+      return next;
+    });
+    await load();
+  }
+
+  const manifestOf = (plugin: string) => manifests.find((m) => m.name === plugin);
+
+  return (
+    <>
+      <PageTitle title={PAGE_TITLE} />
+      <Topbar
+        title={PAGE_TITLE}
+        action={
+          <button className="btn primary" disabled={manifests.length === 0} onClick={() => setAdding(true)}>
+            Add Secret Manager
+          </button>
+        }
+      />
+      <div className="content">
+        <VaultTabs />
+        <p className="muted" style={{ marginTop: 12 }}>
+          Connect a secrets manager (HashiCorp Vault, AWS Secrets Manager) so Thumper
+          can plant canary secrets in it and watch its audit log for reads. Plugins are
+          auto-loaded from <span className="path">/plugins/vault</span>.
+        </p>
+
+        {connections.length === 0 ? (
+          <div className="card">
+            <div className="empty">
+              No secret managers connected yet. Click <strong>Add Secret Manager</strong> to
+              connect one.
+            </div>
+          </div>
+        ) : (
+          <div className="card">
+            {connections.map((c) => {
+              const m = manifestOf(c.plugin);
+              const res = results[c.id];
+              return (
+                <div className="integration-row" key={c.id}>
+                  <div>
+                    <div className="row" style={{ gap: 8 }}>
+                      <strong>{c.name}</strong>
+                      {c.configured ? (
+                        <span className="badge deployed"><span className="dot" /> configured</span>
+                      ) : (
+                        <span className="badge pending"><span className="dot" /> not tested</span>
+                      )}
+                      {c.last_poll_at && (
+                        <span className="muted">· last poll <TimeAgo iso={c.last_poll_at} /></span>
+                      )}
+                    </div>
+                    <div className="muted" style={{ marginTop: 4 }}>
+                      {m?.display_name ?? c.plugin}
+                    </div>
+                    <div className="path" style={{ marginTop: 6 }}>
+                      {Object.entries(c.config).map(([k, v]) => `${k}=${v}`).join("  ") || "—"}
+                    </div>
+                    {res && (
+                      <div className={res.ok ? "muted" : "danger-text"} style={{ marginTop: 6 }}>
+                        {res.ok ? "✓ Connected" : `✗ ${res.error}`}
+                      </div>
+                    )}
+                  </div>
+                  <div className="row" style={{ gap: 8 }}>
+                    <button className="btn" disabled={testing[c.id]} onClick={() => test(c.id)}>
+                      {testing[c.id] ? "Testing…" : "Test"}
+                    </button>
+                    <button className="btn" onClick={() => setEditing(c)}>Edit</button>
+                    <button className="btn danger" onClick={() => remove(c)}>Remove</button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {adding && (
+        <ConnectionModal
+          manifests={manifests}
+          onClose={() => setAdding(false)}
+          onSaved={async () => {
+            setAdding(false);
+            await load();
+          }}
+        />
+      )}
+      {editing && (
+        <ConnectionModal
+          manifests={manifests}
+          current={editing}
+          onClose={() => setEditing(null)}
+          onSaved={async () => {
+            setEditing(null);
+            await load();
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+function ConnectionModal({
+  manifests,
+  current,
+  onClose,
+  onSaved,
+}: {
+  manifests: PluginManifest[];
+  current?: VaultConnection;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  // Editing keeps the plugin fixed; adding lets you pick one.
+  const [plugin, setPlugin] = useState(current?.plugin ?? manifests[0]?.name ?? "");
+  const [name, setName] = useState(current?.name ?? "");
+  const manifest = manifests.find((m) => m.name === plugin);
+
+  // Pre-fill non-secret fields from the saved config; secrets stay blank (masked
+  // server-side) and a blank secret is left untouched on save (merge_config).
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [revealed, setRevealed] = useState<Record<string, boolean>>({});
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const init: Record<string, string> = {};
+    for (const f of manifest?.config_schema ?? []) {
+      const v = current?.config?.[f.key];
+      if (f.type !== "secret" && v != null) init[f.key] = String(v);
+    }
+    setValues(init);
+  }, [plugin, manifest, current]);
+
+  const isSet = (f: PluginManifest["config_schema"][number]) =>
+    Boolean(values[f.key]?.trim()) || Boolean(current?.config?.[f.key]);
+  const missingRequired =
+    !name.trim() || (manifest?.config_schema ?? []).some((f) => f.required && !isSet(f));
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    try {
+      if (current) {
+        await api.updateVaultConnection(current.id, { name: name.trim(), config: values });
+      } else {
+        await api.createVaultConnection({ name: name.trim(), plugin, config: values });
+      }
+      onSaved();
+    } catch (e) {
+      setError((e as Error).message);
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="card modal-card" style={{ width: 480 }} onClick={(e) => e.stopPropagation()}>
+        <div className="card-head">
+          <h2>{current ? "Edit" : "Add"} secret manager</h2>
+          <span className="type-tag">vault</span>
+        </div>
+
+        <div className="field">
+          <label>
+            <span>Name</span>
+            <span className="field-tag required">Required</span>
+          </label>
+          <input
+            type="text"
+            placeholder="e.g. Production Vault"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </div>
+
+        {!current && (
+          <div className="field">
+            <label>
+              <span>Plugin</span>
+              <span className="field-tag required">Required</span>
+            </label>
+            <select value={plugin} onChange={(e) => setPlugin(e.target.value)}>
+              {manifests.map((m) => (
+                <option key={m.name} value={m.name}>{m.display_name}</option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        {(manifest?.config_schema ?? []).map((f) => {
+          const secretKept = f.type === "secret" && Boolean(current?.config?.[f.key]);
+          return (
+            <div className="field" key={f.key}>
+              <label>
+                <span>{f.label}</span>
+                <span className={`field-tag ${f.required ? "required" : "optional"}`}>
+                  {f.required ? "Required" : "Optional"}
+                </span>
+              </label>
+              <input
+                type={f.type === "secret" && !revealed[f.key] ? "password" : "text"}
+                placeholder={secretKept ? "•••••• - leave blank to keep current" : f.placeholder}
+                value={values[f.key] ?? ""}
+                onChange={(e) => setValues({ ...values, [f.key]: e.target.value })}
+              />
+              {f.type === "secret" && values[f.key] && (
+                <div className="row field-actions">
+                  <button
+                    type="button"
+                    className="btn small"
+                    onClick={() => setRevealed((r) => ({ ...r, [f.key]: !r[f.key] }))}
+                  >
+                    {revealed[f.key] ? "Hide" : "Show"}
+                  </button>
+                </div>
+              )}
+              {f.help && <div className="help">{f.help}</div>}
+            </div>
+          );
+        })}
+
+        {error && <div className="danger-text" style={{ marginTop: 6 }}>{error}</div>}
+
+        <div className="row" style={{ marginTop: 6 }}>
+          <button className="btn primary" disabled={saving || missingRequired} onClick={save}>
+            {saving ? "Saving…" : "Save"}
+          </button>
+          <button className="btn" onClick={onClose}>Cancel</button>
+        </div>
+        <p className="help" style={{ marginTop: 10 }}>
+          After saving, click <strong>Test</strong> to verify the connection before planting
+          canary secrets.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/styles/app.css
+++ b/ui/src/styles/app.css
@@ -74,6 +74,15 @@ a { color: inherit; text-decoration: none; }
 .chip:hover { color: var(--text); border-color: var(--accent); }
 .chip.active { background: var(--accent-dim); color: var(--text); border-color: var(--accent); }
 
+/* horizontal page tabs (e.g. Secret Managers: Connections | Canary Secrets) */
+.nav-tabs { display: flex; gap: 4px; border-bottom: 1px solid var(--border); }
+.nav-tabs a {
+  padding: 8px 14px; font-size: 13px; font-weight: 600; color: var(--text-faint);
+  border-bottom: 2px solid transparent; margin-bottom: -1px; text-decoration: none;
+}
+.nav-tabs a:hover { color: var(--text); }
+.nav-tabs a.active { color: var(--accent); border-bottom-color: var(--accent); }
+
 /* install command + distribute result */
 .copyfield {
   display: flex; align-items: center; gap: 10px;


### PR DESCRIPTION
## What

The operator-facing UI for the vault feature (Task 7, epic #255) — a new **Secret Managers** sidebar section with two tabbed pages, wired to the API from #262/#263.

### `VaultConnections` (`/vault`)
List / add / edit / **test** / remove secret-manager connections. The add/edit modal renders each vault plugin's `config_schema` — masked secret fields, `leave-blank-to-keep` on edit — mirroring the existing Integrations config form. A connection shows `configured` once its test passes.

### `CanarySecrets` (`/vault/secrets`)
- Table of planted canaries: template, manager, path, **state** badge, last read.
- **Plant** modal: pick a configured connection + template + path (the template's `suggested_paths` render as one-click fills; a fake value is generated server-side).
- **Reads** modal: recorded access-log entries (`GET /vault/secrets/{id}/access-logs`).

## Approach

Built **fresh against public-thumper UI conventions** (the `Integrations.tsx` config-form pattern, `Topbar`/`Modal`/`TimeAgo`, the existing badge/table classes) rather than ported from the enterprise pages — those are 850+ lines entangled with the excluded cockpit subsystem.

## Details
- `httpApi` vault + canary methods; vault types; `"vault"` added to `PluginKind` so `/manifests` vault entries type-check (verified `public_manifests()` returns both plugins as `kind: "vault"`).
- New `.nav-tabs` CSS for the horizontal page tabs.
- `vault.test.ts` covers the new API methods (request path/method/body + auth header).

## Testing
`tsc -b && vite build` clean; **22 vitest tests pass** (5 new). No Python changed.

## Stacked
Based on #263 → #262 → #261 → #260 → #259 → #257. Merge those first; this rebases to just the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)