### PR TITLE
feat(honeytoken): API routes for connections + tokens (epic #256 Task 2)

### DIFF
--- a/server/thumper/api/honeytoken_routes.py
+++ b/server/thumper/api/honeytoken_routes.py
@@ -1,0 +1,174 @@
+"""API routes for honeytoken connections and tokens (third-party SaaS canaries)."""
+import json
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from .. import store
+from ..db import get_db
+from ..models import (
+    CreateHoneytokenConnectionIn, CreateHoneytokenIn, HoneytokenConnectionOut,
+    HoneytokenOut, HoneytokenUsageLogOut, UpdateHoneytokenConnectionIn,
+)
+from ..plugins.registry import get_manifest, load_plugin
+from ..services.integrations import mask_config, merge_config
+
+log = logging.getLogger("thumper.honeytokens")
+
+honeytoken_router = APIRouter(prefix="/honeytokens", tags=["honeytokens"])
+
+
+def _connection_out(row, manifest) -> dict:
+    config = json.loads(row.config_json)
+    masked = mask_config(manifest, config) if manifest else config
+    return HoneytokenConnectionOut(
+        id=row.id, name=row.name, plugin=row.plugin,
+        configured=row.configured, config=masked,
+        last_poll_at=row.last_poll_at, created_at=row.created_at,
+    ).model_dump()
+
+
+def _token_out(row, connection_name: str = "") -> dict:
+    return HoneytokenOut(
+        id=row.id, connection_id=row.connection_id,
+        connection_name=connection_name, name=row.name,
+        token_id=row.token_id, token_type=row.token_type,
+        state=row.state, created_at=row.created_at,
+        last_used_at=row.last_used_at,
+    ).model_dump()
+
+
+# ── connections ──────────────────────────────────────────────────────────────
+
+@honeytoken_router.get("/connections")
+def list_connections(db: Session = Depends(get_db)):
+    return [_connection_out(row, get_manifest(row.plugin))
+            for row in store.list_honeytoken_connections(db)]
+
+
+@honeytoken_router.post("/connections")
+def create_connection(body: CreateHoneytokenConnectionIn,
+                      db: Session = Depends(get_db)):
+    manifest = get_manifest(body.plugin)
+    if manifest is None or manifest.get("kind") != "honeytoken":
+        raise HTTPException(400, f"Unknown honeytoken plugin: {body.plugin}")
+    row = store.create_honeytoken_connection(
+        db, name=body.name, plugin=body.plugin, config=body.config)
+    return _connection_out(row, manifest)
+
+
+@honeytoken_router.put("/connections/{hid}")
+def update_connection(hid: str, body: UpdateHoneytokenConnectionIn,
+                      db: Session = Depends(get_db)):
+    row = store.get_honeytoken_connection(db, hid)
+    if row is None:
+        raise HTTPException(404, "Honeytoken connection not found")
+    # merge_config keeps a masked/blank secret untouched (per mask_config).
+    merged = merge_config(json.loads(row.config_json), body.config)
+    updated = store.update_honeytoken_connection(db, hid, name=body.name, config=merged)
+    return _connection_out(updated, get_manifest(updated.plugin))
+
+
+@honeytoken_router.delete("/connections/{hid}")
+def delete_connection(hid: str, db: Session = Depends(get_db)):
+    row = store.get_honeytoken_connection(db, hid)
+    if row:
+        tokens = store.list_honeytokens_for_connection(db, hid)
+        if tokens:
+            # Best-effort: revoke live tokens on the platform before dropping the
+            # connection, so we don't leave real (if fake) credentials behind.
+            try:
+                plugin = load_plugin(row.plugin, json.loads(row.config_json))
+                for ht in tokens:
+                    if ht.state in ("active", "triggered"):
+                        try:
+                            plugin.revoke_token(ht.token_id)
+                        except Exception:
+                            log.warning("Failed to revoke honeytoken %s", ht.token_id)
+            except Exception:
+                log.warning("Failed to load plugin to revoke tokens for %s", hid)
+    if not store.delete_honeytoken_connection(db, hid):
+        raise HTTPException(404, "Honeytoken connection not found")
+    return {"status": "ok"}
+
+
+@honeytoken_router.post("/connections/{hid}/test")
+def test_connection(hid: str, db: Session = Depends(get_db)):
+    row = store.get_honeytoken_connection(db, hid)
+    if row is None:
+        raise HTTPException(404, "Honeytoken connection not found")
+    try:
+        plugin = load_plugin(row.plugin, json.loads(row.config_json))
+        plugin.test()
+        store.set_honeytoken_connection_test(db, hid=hid, configured=True)
+        return {"ok": True, "error": None}
+    except Exception as exc:
+        store.set_honeytoken_connection_test(db, hid=hid, configured=False)
+        return {"ok": False, "error": str(exc)}
+
+
+# ── tokens ───────────────────────────────────────────────────────────────────
+
+@honeytoken_router.get("/tokens")
+def list_tokens(db: Session = Depends(get_db)):
+    conn_map = {c.id: c.name for c in store.list_honeytoken_connections(db)}
+    return [_token_out(row, conn_map.get(row.connection_id, ""))
+            for row in store.list_honeytokens(db)]
+
+
+@honeytoken_router.post("/tokens")
+def create_token(body: CreateHoneytokenIn, db: Session = Depends(get_db)):
+    conn = store.get_honeytoken_connection(db, body.connection_id)
+    if conn is None:
+        raise HTTPException(404, "Honeytoken connection not found")
+    if not conn.configured:
+        raise HTTPException(400, "Connection not tested/configured yet")
+    try:
+        plugin = load_plugin(conn.plugin, json.loads(conn.config_json))
+        result = plugin.create_token(body.name, options=body.options or None)
+    except Exception as exc:
+        raise HTTPException(400, f"Failed to create token: {exc}") from exc
+    metadata = {k: v for k, v in result.items()
+                if k not in ("token_id", "token_type")}
+    ht = store.create_honeytoken(
+        db, connection_id=conn.id, name=body.name,
+        token_id=result["token_id"], token_type=result["token_type"],
+        metadata=metadata)
+    store.set_honeytoken_state(db, ht.id, "active")
+    db.expire_all()
+    out = _token_out(store.get_honeytoken(db, ht.id), conn.name)
+    out["metadata"] = metadata
+    return out
+
+
+@honeytoken_router.delete("/tokens/{htid}")
+def delete_token(htid: str, db: Session = Depends(get_db)):
+    ht = store.get_honeytoken(db, htid)
+    if ht is None:
+        raise HTTPException(404, "Honeytoken not found")
+    if ht.state in ("active", "triggered"):
+        conn = store.get_honeytoken_connection(db, ht.connection_id)
+        if conn:
+            try:
+                plugin = load_plugin(conn.plugin, json.loads(conn.config_json))
+                plugin.revoke_token(ht.token_id)
+            except Exception:
+                log.warning("Failed to revoke honeytoken %s on delete", ht.token_id)
+    store.delete_honeytoken(db, htid)
+    return {"status": "ok"}
+
+
+@honeytoken_router.get("/tokens/{htid}/usage")
+def list_usage_logs(htid: str, db: Session = Depends(get_db)):
+    ht = store.get_honeytoken(db, htid)
+    if ht is None:
+        raise HTTPException(404, "Honeytoken not found")
+    return [
+        HoneytokenUsageLogOut(
+            id=entry.id, event_id=entry.event_id, actor=entry.actor,
+            source_ip=entry.source_ip, action=entry.action,
+            timestamp=entry.timestamp,
+        ).model_dump()
+        for entry in store.list_honeytoken_usage_logs(db, htid)
+    ]

--- a/server/thumper/api/routes.py
+++ b/server/thumper/api/routes.py
@@ -43,6 +43,7 @@ from ..models import (
 )
 from ..plugins.base import PluginError
 from ..plugins.registry import get_manifest, load_plugin, public_manifests
+from .honeytoken_routes import honeytoken_router
 from ..services.alerting import deliver_alert
 from ..services.content import render_content
 from ..services.deploy import build_install, build_install_command, distribute
@@ -88,6 +89,10 @@ def require_admin(authorization: str = Header(default="")):
 # token - a route is public ONLY by explicitly opting onto agent_router.
 router = APIRouter(prefix="/api", dependencies=[Depends(require_admin)])
 agent_router = APIRouter(prefix="/api")
+
+# Honeytoken (third-party SaaS canary) endpoints, mounted under the admin router
+# so they inherit require_admin like every other management route.
+router.include_router(honeytoken_router)
 
 
 def _validate_bait_path(path: str) -> str:

--- a/server/thumper/models.py
+++ b/server/thumper/models.py
@@ -178,6 +178,55 @@ class TokenPreviewOut(BaseModel):
     content: str
 
 
+# ── honeytokens (third-party SaaS canaries) ─────────────────────────────────
+class CreateHoneytokenConnectionIn(BaseModel):
+    name: str
+    plugin: str
+    config: dict
+
+
+class UpdateHoneytokenConnectionIn(BaseModel):
+    name: str
+    config: dict
+
+
+class HoneytokenConnectionOut(BaseModel):
+    id: str
+    name: str
+    plugin: str
+    configured: bool
+    config: dict
+    last_poll_at: Optional[str] = None
+    created_at: str
+
+
+class CreateHoneytokenIn(BaseModel):
+    connection_id: str
+    name: str
+    options: dict = {}
+
+
+class HoneytokenOut(BaseModel):
+    id: str
+    connection_id: str
+    connection_name: str
+    name: str
+    token_id: str
+    token_type: str
+    state: str
+    created_at: str
+    last_used_at: Optional[str] = None
+
+
+class HoneytokenUsageLogOut(BaseModel):
+    id: str
+    event_id: Optional[str] = None
+    actor: Optional[str] = None
+    source_ip: Optional[str] = None
+    action: Optional[str] = None
+    timestamp: str
+
+
 # Agent-facing endpoints (/enroll, /agent/*, /trigger) speak a plain-text
 # protocol (key=value / tab-separated), not JSON, so the Bash agent needs no
 # JSON parser - see api/routes.py. They therefore have no Pydantic schemas here.

--- a/tests/test_honeytoken_api.py
+++ b/tests/test_honeytoken_api.py
@@ -1,0 +1,132 @@
+import pytest
+import yaml
+
+from thumper import store
+from thumper.plugins import loader
+
+
+@pytest.fixture(autouse=True)
+def _clear_plugin_cache():
+    loader.reset_cache()
+    yield
+    loader.reset_cache()
+
+
+@pytest.fixture
+def honeytoken_plugin_dir(tmp_path, monkeypatch):
+    """A fake honeytoken plugin so the API's create/test/revoke paths run without
+    reaching any real SaaS platform."""
+    monkeypatch.setattr(loader, "PLUGINS_DIR", tmp_path)
+    d = tmp_path / "honeytoken" / "datadog"
+    d.mkdir(parents=True)
+    d.joinpath("manifest.yaml").write_text(yaml.dump({
+        "name": "datadog",
+        "kind": "honeytoken",
+        "display_name": "Datadog",
+        "version": "0.1.0",
+        "author": "test",
+        "description": "Test Datadog honeytokens",
+        "config_schema": [
+            {"key": "api_key", "label": "API Key", "type": "secret", "required": True},
+            {"key": "app_key", "label": "App Key", "type": "secret", "required": True},
+        ],
+    }))
+    d.joinpath("plugin.py").write_text(
+        "from thumper.plugins.base import HoneytokenPlugin\n"
+        "class Plugin(HoneytokenPlugin):\n"
+        "    def connect(self):\n"
+        "        if not self.config.get('api_key'): raise ValueError('api_key required')\n"
+        "    def create_token(self, name, options=None):\n"
+        "        return {'token_id': 'ddog_key_1', 'token_type': 'datadog_api_key',\n"
+        "                'key_id': 'abc123'}\n"
+        "    def revoke_token(self, token_id): pass\n"
+        "    def poll_usage(self, token_ids, since=None): return []\n"
+    )
+    return d
+
+
+def _make_connection(tc, db, configured=True):
+    vid = tc.post("/api/honeytokens/connections", json={
+        "name": "Prod Datadog", "plugin": "datadog",
+        "config": {"api_key": "k", "app_key": "a"}}).json()["id"]
+    if configured:
+        store.set_honeytoken_connection_test(db, hid=vid, configured=True)
+    return vid
+
+
+def test_create_connection_masks_secrets(client_db, honeytoken_plugin_dir):
+    tc, db = client_db
+    resp = tc.post("/api/honeytokens/connections", json={
+        "name": "Prod", "plugin": "datadog",
+        "config": {"api_key": "supersecret", "app_key": "a"}})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"].startswith("htc_")
+    assert data["config"]["api_key"] == "••••••••"
+
+
+def test_create_connection_rejects_unknown_plugin(client_db, honeytoken_plugin_dir):
+    tc, db = client_db
+    resp = tc.post("/api/honeytokens/connections", json={
+        "name": "X", "plugin": "nope", "config": {}})
+    assert resp.status_code == 400
+
+
+def test_test_connection_sets_configured(client_db, honeytoken_plugin_dir):
+    tc, db = client_db
+    vid = _make_connection(tc, db, configured=False)
+    resp = tc.post(f"/api/honeytokens/connections/{vid}/test")
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+    assert store.get_honeytoken_connection(db, vid).configured is True
+
+
+def test_create_token_requires_configured_connection(client_db, honeytoken_plugin_dir):
+    tc, db = client_db
+    vid = _make_connection(tc, db, configured=False)
+    resp = tc.post("/api/honeytokens/tokens", json={
+        "connection_id": vid, "name": "canary"})
+    assert resp.status_code == 400
+
+
+def test_create_and_list_token(client_db, honeytoken_plugin_dir):
+    tc, db = client_db
+    vid = _make_connection(tc, db)
+    resp = tc.post("/api/honeytokens/tokens", json={
+        "connection_id": vid, "name": "canary-key"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["token_id"] == "ddog_key_1"
+    assert data["token_type"] == "datadog_api_key"
+    assert data["state"] == "active"
+    assert data["metadata"]["key_id"] == "abc123"
+    listing = tc.get("/api/honeytokens/tokens").json()
+    assert len(listing) == 1
+    assert listing[0]["connection_name"] == "Prod Datadog"
+
+
+def test_delete_token(client_db, honeytoken_plugin_dir):
+    tc, db = client_db
+    vid = _make_connection(tc, db)
+    htid = tc.post("/api/honeytokens/tokens", json={
+        "connection_id": vid, "name": "k"}).json()["id"]
+    assert tc.delete(f"/api/honeytokens/tokens/{htid}").status_code == 200
+    assert tc.get("/api/honeytokens/tokens").json() == []
+
+
+def test_usage_logs_endpoint(client_db, honeytoken_plugin_dir):
+    tc, db = client_db
+    vid = _make_connection(tc, db)
+    htid = tc.post("/api/honeytokens/tokens", json={
+        "connection_id": vid, "name": "k"}).json()["id"]
+    store.record_honeytoken_usage(db, htid=htid, event_id="e1", actor="mallory",
+                                  source_ip="10.0.0.9", action="query", timestamp="t")
+    logs = tc.get(f"/api/honeytokens/tokens/{htid}/usage").json()
+    assert len(logs) == 1
+    assert logs[0]["actor"] == "mallory"
+    assert logs[0]["source_ip"] == "10.0.0.9"
+
+
+def test_usage_logs_404_for_unknown_token(client_db):
+    tc, db = client_db
+    assert tc.get("/api/honeytokens/tokens/ht_nope/usage").status_code == 404


### PR DESCRIPTION
## What

Task 2 of epic #256 — the admin-gated honeytoken API, on top of the Task 1 foundation (#265). Mounted under `/api/honeytokens` so it inherits `require_admin` like every other management route.

- **`models.py`** — Create/Update/Out Pydantic models for connections, tokens, usage logs.
- **`api/honeytoken_routes.py`**
  - Connections: `GET/POST /connections`, `PUT/DELETE /connections/{id}`, `POST /connections/{id}/test`.
  - Tokens: `GET/POST /tokens`, `DELETE /tokens/{id}`, `GET /tokens/{id}/usage`.
  - `create_token` calls the plugin's `create_token` and persists the returned `token_id`/`token_type` (+ any extra keys as `metadata`); delete best-effort **revokes on the platform** first. Connection secrets are masked on output; `merge_config` keeps a blank secret untouched on edit.
- **`routes.py`** — include `honeytoken_router` on the admin router.

## Adaptations from the enterprise source
- Public `get_manifest(name)` / `load_plugin(name, config)` take no `kind` arg (dropped it); create explicitly rejects a plugin whose manifest `kind != "honeytoken"`.
- `delete_token`'s revoke is wrapped in try/except so a platform outage never blocks removing the local record.

## Testing
Fake honeytoken plugin (no real SaaS reached), 8 API tests: mask secrets, unknown-plugin reject, test→configured, create-needs-configured, create+list, delete, usage listing, usage 404. **Full suite: 393 passed, 1 skipped**; ruff clean.

## Stacked
Based on #265 (Task 1). Provider plugins (Datadog/Salesforce/AWS) + the usage poller + UI follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)