### PR TITLE
feat(honeytoken): background usage poller (epic #256 Task 3)

### DIFF
--- a/server/thumper/config.py
+++ b/server/thumper/config.py
@@ -52,6 +52,10 @@ ALLOWED_ORIGINS = [o.strip() for o in os.environ.get(
 # the plugin *framework* - base classes + loader).
 PLUGINS_DIR = Path(os.environ.get("THUMPER_PLUGINS_DIR", str(REPO_ROOT / "plugins")))
 
+# Seconds between honeytoken-usage poll cycles (the background poller that checks
+# each configured SaaS platform's audit log for use of a planted honeytoken).
+HONEYTOKEN_POLL_INTERVAL = int(os.environ.get("THUMPER_HONEYTOKEN_POLL_INTERVAL", "60"))
+
 # Database URL (SQLAlchemy format). A bare filesystem path is mapped to SQLite.
 _db_raw = os.environ.get("THUMPER_DB", str(REPO_ROOT / "thumper.db"))
 DB_URL = _db_raw if "://" in _db_raw else f"sqlite:///{_db_raw}"

--- a/server/thumper/main.py
+++ b/server/thumper/main.py
@@ -18,6 +18,7 @@ from .config import (
     ALLOWED_ORIGINS, UI_DIST, base_url_fail_closed, insecure_base_url,
     insecure_default_tokens)
 from .db import init_db
+from .services.honeytoken_poller import start_poller as start_honeytoken_poller
 from .services.secrets_crypto import encryption_enabled
 
 logging.basicConfig(level=logging.INFO)
@@ -60,7 +61,13 @@ async def lifespan(app: FastAPI):
             "SECURITY: %s. Starting anyway because THUMPER_ALLOW_INSECURE_BASE_URL "
             "is set - use https:// (or a TLS-terminating proxy) in production.",
             detail)
-    yield
+    # Background poller: watches each configured SaaS platform's audit log for
+    # honeytoken use. Cancelled on shutdown so tests / reloads don't leak it.
+    honeytoken_poller = start_honeytoken_poller()
+    try:
+        yield
+    finally:
+        honeytoken_poller.cancel()
 
 
 app = FastAPI(title="Thumper", version=__version__, lifespan=lifespan)

--- a/server/thumper/services/honeytoken_poller.py
+++ b/server/thumper/services/honeytoken_poller.py
@@ -1,0 +1,113 @@
+"""Background poller: checks each SaaS platform's audit log for honeytoken use.
+
+A configured HoneytokenConnection knows how to poll its platform (via its
+plugin); a use of any active honeytoken becomes an alert. Runs on an interval so
+a use fires without operator action. Dedup is by the platform's own event id (see
+`store.record_honeytoken_usage`), so re-polling the same audit window is safe.
+"""
+import asyncio
+import json
+import logging
+
+from sqlalchemy.orm import Session
+
+from .. import store
+from ..config import HONEYTOKEN_POLL_INTERVAL
+from ..db import SessionLocal
+from ..models import iso_now
+from ..plugins.registry import load_plugin
+from .alerting import deliver_alert
+
+log = logging.getLogger("thumper.honeytoken_poller")
+
+
+def poll_once(db: Session) -> int:
+    """Run one poll cycle across all configured honeytoken connections. Returns
+    the number of newly-recorded usage events (already-seen events are skipped)."""
+    total = 0
+    for conn in store.list_honeytoken_connections(db):
+        if not conn.configured:
+            continue
+        config = json.loads(conn.config_json)
+        try:
+            plugin = load_plugin(conn.plugin, config)
+        except Exception as exc:
+            log.warning("Failed to load plugin for %s: %s", conn.name, exc)
+            continue
+        tokens = store.list_active_honeytokens_for_connection(db, conn.id)
+        if not tokens:
+            continue
+        token_id_map = {ht.token_id: ht for ht in tokens}
+        try:
+            events = plugin.poll_usage(list(token_id_map.keys()), since=conn.last_poll_at)
+        except Exception as exc:
+            log.warning("Poll failed for %s: %s", conn.name, exc)
+            continue
+        for event in events:
+            ht = token_id_map.get(event.token_id)
+            if ht is None:
+                continue
+            event_id = event.extra.get("event_id") if event.extra else None
+            logged = store.record_honeytoken_usage(
+                db, htid=ht.id, event_id=event_id, actor=event.actor,
+                source_ip=event.source_ip, action=event.action,
+                timestamp=event.timestamp or iso_now(),
+            )
+            if not logged:
+                continue  # already recorded this exact use - do not re-alert
+            store.mark_honeytoken_used(db, ht.id)
+            alert = store.create_alert(
+                db,
+                deployment_id=ht.id,
+                tripwire_id=ht.id,
+                endpoint_id=conn.id,
+                tripwire_name=f"{ht.name} ({conn.name})",
+                endpoint_hostname=conn.name,
+                token_type=ht.token_type,
+                timestamp=event.timestamp or iso_now(),
+                triggered_by=event.actor,
+                accessed_path=None,
+                event_type="honeytoken_usage",
+                os_user=event.actor,
+            )
+            deliver_alert({
+                "alert_id": alert.id,
+                "event_type": "honeytoken_usage",
+                "tripwire_name": alert.tripwire_name,
+                "endpoint_hostname": conn.name,
+                "platform": conn.plugin,
+                "token_name": ht.name,
+                "token_type": ht.token_type,
+                "actor": event.actor,
+                "source_ip": event.source_ip,
+                "action": event.action,
+                "timestamp": event.timestamp,
+                "message": (
+                    f"Honeytoken usage detected: {ht.name} on "
+                    f"{conn.name} ({conn.plugin}) by {event.actor}"
+                ),
+            })
+            total += 1
+        store.update_honeytoken_last_poll(db, conn.id)
+    return total
+
+
+async def _poll_loop() -> None:
+    """Async loop that calls poll_once on a regular interval."""
+    log.info("Honeytoken poller started (interval=%ds)", HONEYTOKEN_POLL_INTERVAL)
+    while True:
+        db = SessionLocal()
+        try:
+            count = poll_once(db)
+            if count:
+                log.info("Honeytoken poller detected %d usage event(s)", count)
+        except Exception:
+            log.exception("Honeytoken poller error")
+        finally:
+            db.close()
+        await asyncio.sleep(HONEYTOKEN_POLL_INTERVAL)
+
+
+def start_poller() -> asyncio.Task:
+    """Start the background poller as an asyncio task."""
+    return asyncio.create_task(_poll_loop())

--- a/tests/test_honeytoken_poller.py
+++ b/tests/test_honeytoken_poller.py
@@ -1,0 +1,135 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from thumper import store
+from thumper.db import Base
+from thumper.plugins.base import TokenUsageEvent
+from thumper.services import honeytoken_poller
+
+
+@pytest.fixture
+def db():
+    engine = create_engine("sqlite://", echo=False,
+                           connect_args={"check_same_thread": False},
+                           poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+
+
+class FakePlugin:
+    def __init__(self, events=None):
+        self._events = events or []
+
+    def connect(self):
+        pass
+
+    def poll_usage(self, token_ids, since=None):
+        return self._events
+
+
+def _active_token(db, conn, token_id="tok_1"):
+    ht = store.create_honeytoken(db, connection_id=conn.id, name="canary",
+                                 token_id=token_id, token_type="datadog_key",
+                                 metadata={})
+    store.set_honeytoken_state(db, ht.id, "active")
+    return ht
+
+
+def _conn(db):
+    conn = store.create_honeytoken_connection(db, name="Prod", plugin="datadog",
+                                              config={"api_key": "k"})
+    store.set_honeytoken_connection_test(db, hid=conn.id, configured=True)
+    return conn
+
+
+def test_poll_once_no_connections(db):
+    assert honeytoken_poller.poll_once(db) == 0
+
+
+def test_poll_once_no_active_tokens(db):
+    _conn(db)
+    assert honeytoken_poller.poll_once(db) == 0
+
+
+def test_poll_once_detects_usage(db, monkeypatch):
+    conn = _conn(db)
+    ht = _active_token(db, conn)
+    fake = FakePlugin(events=[
+        TokenUsageEvent(token_id="tok_1", timestamp="2026-07-21T10:00:00Z",
+                        actor="attacker", source_ip="10.0.0.5", action="query"),
+    ])
+    monkeypatch.setattr(honeytoken_poller, "load_plugin", lambda name, config: fake)
+    delivered = []
+    monkeypatch.setattr(honeytoken_poller, "deliver_alert", delivered.append)
+
+    assert honeytoken_poller.poll_once(db) == 1
+    db.expire_all()
+    assert store.get_honeytoken(db, ht.id).state == "triggered"
+    assert store.get_honeytoken(db, ht.id).last_used_at is not None
+    assert store.get_honeytoken_connection(db, conn.id).last_poll_at is not None
+    assert len(delivered) == 1
+    assert delivered[0]["event_type"] == "honeytoken_usage"
+    assert delivered[0]["actor"] == "attacker"
+    assert len(store.list_honeytoken_usage_logs(db, ht.id)) == 1
+
+
+def test_poll_once_dedupes_repeated_event(db, monkeypatch):
+    conn = _conn(db)
+    ht = _active_token(db, conn)
+    fake = FakePlugin(events=[
+        TokenUsageEvent(token_id="tok_1", timestamp="t", actor="a",
+                        extra={"event_id": "evt-1"}),
+    ])
+    monkeypatch.setattr(honeytoken_poller, "load_plugin", lambda name, config: fake)
+    delivered = []
+    monkeypatch.setattr(honeytoken_poller, "deliver_alert", delivered.append)
+
+    assert honeytoken_poller.poll_once(db) == 1
+    assert honeytoken_poller.poll_once(db) == 0   # same event again -> no re-alert
+    assert len(delivered) == 1
+    assert len(store.list_honeytoken_usage_logs(db, ht.id)) == 1
+
+
+def test_poll_once_skips_unconfigured(db, monkeypatch):
+    conn = store.create_honeytoken_connection(db, name="X", plugin="datadog", config={})
+    _active_token(db, conn)
+    fake = FakePlugin(events=[TokenUsageEvent(token_id="tok_1", timestamp="t")])
+    monkeypatch.setattr(honeytoken_poller, "load_plugin", lambda name, config: fake)
+    monkeypatch.setattr(honeytoken_poller, "deliver_alert", lambda e: None)
+    assert honeytoken_poller.poll_once(db) == 0
+
+
+def test_poll_once_continues_on_plugin_error(db, monkeypatch):
+    broken = store.create_honeytoken_connection(db, name="Broken", plugin="datadog",
+                                               config={"api_key": "bad"})
+    store.set_honeytoken_connection_test(db, hid=broken.id, configured=True)
+    good = _conn(db)
+    ht = _active_token(db, good)
+
+    def fake_load(name, config):
+        if config.get("api_key") == "bad":
+            raise RuntimeError("auth failed")
+        return FakePlugin(events=[TokenUsageEvent(token_id=ht.token_id, timestamp="t")])
+
+    monkeypatch.setattr(honeytoken_poller, "load_plugin", fake_load)
+    delivered = []
+    monkeypatch.setattr(honeytoken_poller, "deliver_alert", delivered.append)
+    assert honeytoken_poller.poll_once(db) == 1
+    assert len(delivered) == 1
+
+
+def test_poll_once_survives_poll_failure(db, monkeypatch):
+    conn = _conn(db)
+    _active_token(db, conn)
+
+    class Boom:
+        def poll_usage(self, token_ids, since=None):
+            raise RuntimeError("audit API down")
+
+    monkeypatch.setattr(honeytoken_poller, "load_plugin", lambda name, config: Boom())
+    monkeypatch.setattr(honeytoken_poller, "deliver_alert", lambda e: None)
+    assert honeytoken_poller.poll_once(db) == 0


### PR DESCRIPTION
## What

Task 3 of epic #256 — closes the honeytoken detection loop. On an interval the poller asks each configured platform's plugin to `poll_usage`, records each use of an active honeytoken, raises an alert, and fans it out via the existing alerting path. With Tasks 1–3 the feature works end-to-end server-side (a provider plugin makes it real).

- **`services/honeytoken_poller.py`** — `poll_once()` + an asyncio interval loop, started from the app `lifespan` and cancelled on shutdown (`try/finally`).
- **`config.py`** — `THUMPER_HONEYTOKEN_POLL_INTERVAL` (default 60s).
- **`main.py`** — wire `start_poller` into `lifespan`.

Dedup happens **before** alerting (`record_honeytoken_usage` returns `None` for an already-seen event id), so a use surfacing across overlapping poll windows alerts exactly once — `test_poll_once_dedupes_repeated_event`.

## Testing
7 poller tests (detect, dedup, skip-unconfigured, no-active-tokens, continue-on-plugin-error, survive-poll-failure); **full suite 400 passed, 1 skipped**; ruff clean.

## Stacked
Based on #266 (Task 2) → #265 (Task 1). Provider plugins + UI follow.

_Note: CI's macOS leg hit a known agent-shell timing flake (`test_heartbeat_success_is_logged`) unrelated to this server-only diff; re-running. ubuntu + lint + build all green._

🤖 Generated with [Claude Code](https://claude.com/claude-code)