### PR TITLE
feat(honeytoken): Datadog provider plugin (epic #256 Task 4)

### DIFF
--- a/plugins/honeytoken/datadog/manifest.yaml
+++ b/plugins/honeytoken/datadog/manifest.yaml
@@ -1,0 +1,28 @@
+name: datadog
+kind: honeytoken
+display_name: "Datadog"
+version: "0.1.0"
+author: thumper-core
+description: >
+  Create Datadog API keys as honeytokens and monitor the audit trail
+  for unauthorized usage.
+
+config_schema:
+  - key: api_key
+    label: "Admin API Key"
+    type: secret
+    required: true
+    help: "A Datadog API key with admin permissions to create/delete keys."
+
+  - key: app_key
+    label: "Application Key"
+    type: secret
+    required: true
+    help: "A Datadog application key with admin scope."
+
+  - key: site
+    label: "Datadog Site"
+    type: string
+    required: true
+    placeholder: "datadoghq.com"
+    help: "Your Datadog site (e.g. datadoghq.com, datadoghq.eu, us5.datadoghq.com)."

--- a/plugins/honeytoken/datadog/plugin.py
+++ b/plugins/honeytoken/datadog/plugin.py
@@ -1,0 +1,105 @@
+"""Datadog honeytoken plugin: create Datadog API keys as canaries and detect use.
+
+Datadog's v2 API-keys endpoint reports `used_in_last_24_hours` / `date_last_used`
+per key, so poll_usage checks each canary key and emits an event when it has been
+used - no separate audit-log scrape needed. Uses httpx (the thumper HTTP client).
+"""
+import logging
+from datetime import datetime, timezone
+
+import httpx
+
+from thumper.plugins.base import HoneytokenPlugin, PluginError, TokenUsageEvent
+
+log = logging.getLogger("thumper.plugin.datadog")
+
+TIMEOUT = 10
+
+
+class Plugin(HoneytokenPlugin):
+    def __init__(self, config: dict):
+        super().__init__(config)
+        self._site = None
+        self._headers = None
+
+    def _base_url(self) -> str:
+        return f"https://api.{self._site}/api"
+
+    def connect(self) -> None:
+        site = self.config.get("site")
+        api_key = self.config.get("api_key")
+        app_key = self.config.get("app_key")
+        if not site:
+            raise PluginError("datadog: site is required")
+        if not api_key or not app_key:
+            raise PluginError("datadog: api_key and app_key are required")
+        self._site = site
+        self._headers = {
+            "DD-API-KEY": api_key,
+            "DD-APPLICATION-KEY": app_key,
+            "Content-Type": "application/json",
+        }
+        resp = httpx.get(f"{self._base_url()}/v1/validate",
+                         headers=self._headers, timeout=TIMEOUT)
+        if resp.status_code != 200:
+            raise PluginError(
+                f"Datadog authentication failed: {resp.status_code} {resp.text}")
+
+    def _ensure_connected(self) -> None:
+        if self._site is None:
+            self.connect()
+
+    def create_token(self, name: str, options: dict | None = None) -> dict:
+        self._ensure_connected()
+        resp = httpx.post(
+            f"{self._base_url()}/v2/api_keys",
+            headers=self._headers, timeout=TIMEOUT,
+            json={"data": {"type": "api_keys", "attributes": {"name": name}}},
+        )
+        if resp.status_code not in (200, 201):
+            raise PluginError(
+                f"Failed to create Datadog API key: {resp.status_code} {resp.text}")
+        data = resp.json()["data"]
+        return {
+            "token_id": data["id"],
+            "token_type": "api_key",
+            "key_name": data["attributes"]["name"],
+            "key_value": data["attributes"].get("key", ""),
+        }
+
+    def revoke_token(self, token_id: str) -> None:
+        self._ensure_connected()
+        resp = httpx.delete(f"{self._base_url()}/v2/api_keys/{token_id}",
+                            headers=self._headers, timeout=TIMEOUT)
+        # 404 = already gone; treat as success (idempotent revoke).
+        if resp.status_code not in (200, 204, 404):
+            raise PluginError(
+                f"Failed to delete Datadog API key: {resp.status_code} {resp.text}")
+
+    def poll_usage(self, token_ids: list[str],
+                   since: str | None = None) -> list[TokenUsageEvent]:
+        self._ensure_connected()
+        now = datetime.now(timezone.utc)
+        events: list[TokenUsageEvent] = []
+        for tid in token_ids:
+            try:
+                resp = httpx.get(f"{self._base_url()}/v2/api_keys/{tid}",
+                                 headers=self._headers, timeout=TIMEOUT)
+            except httpx.HTTPError as exc:
+                log.warning("Datadog poll error for key %s: %s", tid, exc)
+                continue
+            if resp.status_code != 200:
+                log.warning("Datadog key lookup failed for %s: %s", tid, resp.status_code)
+                continue
+            attrs = resp.json()["data"]["attributes"]
+            if attrs.get("used_in_last_24_hours"):
+                last_used = attrs.get("date_last_used") or now.isoformat()
+                # event_id keys off the last-used timestamp so each distinct use
+                # records once; the same reading across poll cycles dedups.
+                events.append(TokenUsageEvent(
+                    token_id=tid,
+                    timestamp=last_used,
+                    action="api_key_used",
+                    extra={"event_id": f"usage_{tid}_{last_used}"},
+                ))
+        return events

--- a/tests/test_datadog_plugin.py
+++ b/tests/test_datadog_plugin.py
@@ -1,0 +1,141 @@
+"""Datadog honeytoken plugin: create/revoke/poll against a faked httpx."""
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from thumper.plugins.base import PluginError
+
+PLUGIN_FILE = (Path(__file__).resolve().parents[1]
+               / "plugins" / "honeytoken" / "datadog" / "plugin.py")
+
+
+def load_plugin_module():
+    spec = importlib.util.spec_from_file_location("thumper_plugin_datadog_test", PLUGIN_FILE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+class FakeHttpx:
+    """Routes by (method, url-substring) to a queued FakeResponse, recording calls."""
+    HTTPError = Exception  # so `except module.httpx.HTTPError` works when swapped in
+
+    def __init__(self, routes):
+        self._routes = routes
+        self.calls = []
+
+    def _match(self, method, url):
+        for (m, frag), resp in self._routes.items():
+            if m == method and frag in url:
+                return resp
+        raise AssertionError(f"no fake route for {method} {url}")
+
+    def get(self, url, headers=None, timeout=None):
+        self.calls.append(("GET", url))
+        return self._match("GET", url)
+
+    def post(self, url, headers=None, timeout=None, json=None):
+        self.calls.append(("POST", url, json))
+        return self._match("POST", url)
+
+    def delete(self, url, headers=None, timeout=None):
+        self.calls.append(("DELETE", url))
+        return self._match("DELETE", url)
+
+
+CONFIG = {"site": "datadoghq.com", "api_key": "k", "app_key": "a"}
+
+
+@pytest.fixture
+def module():
+    return load_plugin_module()
+
+
+def _install(module, monkeypatch, routes):
+    fake = FakeHttpx(routes)
+    monkeypatch.setattr(module, "httpx", fake)
+    return fake
+
+
+def test_connect_requires_config(module):
+    with pytest.raises(PluginError):
+        module.Plugin({"site": "datadoghq.com"}).connect()  # missing keys
+
+
+def test_connect_validates(module, monkeypatch):
+    fake = _install(module, monkeypatch, {("GET", "/v1/validate"): FakeResponse(200)})
+    module.Plugin(CONFIG).connect()
+    assert fake.calls[0] == ("GET", "https://api.datadoghq.com/api/v1/validate")
+
+
+def test_connect_raises_on_auth_failure(module, monkeypatch):
+    _install(module, monkeypatch, {("GET", "/v1/validate"): FakeResponse(403, text="forbidden")})
+    with pytest.raises(PluginError):
+        module.Plugin(CONFIG).connect()
+
+
+def test_create_token_returns_id_and_metadata(module, monkeypatch):
+    _install(module, monkeypatch, {
+        ("GET", "/v1/validate"): FakeResponse(200),
+        ("POST", "/v2/api_keys"): FakeResponse(201, payload={"data": {
+            "id": "key-123",
+            "attributes": {"name": "canary", "key": "ddsecret"},
+        }}),
+    })
+    result = module.Plugin(CONFIG).create_token("canary")
+    assert result["token_id"] == "key-123"
+    assert result["token_type"] == "api_key"
+    assert result["key_value"] == "ddsecret"
+
+
+def test_create_token_raises_on_error(module, monkeypatch):
+    _install(module, monkeypatch, {
+        ("GET", "/v1/validate"): FakeResponse(200),
+        ("POST", "/v2/api_keys"): FakeResponse(400, text="bad"),
+    })
+    with pytest.raises(PluginError):
+        module.Plugin(CONFIG).create_token("canary")
+
+
+def test_revoke_token_treats_404_as_success(module, monkeypatch):
+    _install(module, monkeypatch, {
+        ("GET", "/v1/validate"): FakeResponse(200),
+        ("DELETE", "/v2/api_keys/"): FakeResponse(404),
+    })
+    module.Plugin(CONFIG).revoke_token("key-123")  # does not raise
+
+
+def test_poll_usage_emits_event_when_used(module, monkeypatch):
+    _install(module, monkeypatch, {
+        ("GET", "/v1/validate"): FakeResponse(200),
+        ("GET", "/v2/api_keys/key-1"): FakeResponse(200, payload={"data": {"attributes": {
+            "used_in_last_24_hours": True,
+            "date_last_used": "2026-07-21T10:00:00Z",
+        }}}),
+    })
+    events = module.Plugin(CONFIG).poll_usage(["key-1"])
+    assert len(events) == 1
+    assert events[0].token_id == "key-1"
+    assert events[0].timestamp == "2026-07-21T10:00:00Z"
+    assert events[0].extra["event_id"] == "usage_key-1_2026-07-21T10:00:00Z"
+
+
+def test_poll_usage_ignores_unused_keys(module, monkeypatch):
+    _install(module, monkeypatch, {
+        ("GET", "/v1/validate"): FakeResponse(200),
+        ("GET", "/v2/api_keys/key-1"): FakeResponse(200, payload={"data": {"attributes": {
+            "used_in_last_24_hours": False,
+        }}}),
+    })
+    assert module.Plugin(CONFIG).poll_usage(["key-1"]) == []


### PR DESCRIPTION
## What

Task 4 of epic #256 — the first honeytoken **provider**: create Datadog API keys as canaries and detect their use.

- **`connect()`** — `GET /api/v1/validate` to verify the admin API key + app key.
- **`create_token()`** — `POST /api/v2/api_keys`; returns the key id + value.
- **`revoke_token()`** — `DELETE /api/v2/api_keys/{id}` (404 treated as already-gone → idempotent).
- **`poll_usage()`** — Datadog reports `used_in_last_24_hours` / `date_last_used` per key, so we check each canary key directly (no separate audit-log scrape). `event_id` keys off the last-used timestamp so each distinct use records/alerts exactly once.

## Adaptation
Ported from the enterprise plugin but **rewritten on `httpx`** (the thumper HTTP client that every existing alert plugin uses) instead of `requests` — no new dependency. Config: `api_key`, `app_key` (secrets), `site`.

## Testing
8 tests against a faked `httpx` (connect/validate, missing config, auth failure, create, create-error, idempotent revoke, poll used/unused). Loader discovers it as a `honeytoken` kind. **Full suite: 408 passed, 1 skipped**; ruff clean. `plugins/` is already copied by the Dockerfile, so no build change.

## Stacked
Based on #267 (Task 3). Salesforce (Task 5) and AWS (Task 6) plugins, then UI, follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)