### PR TITLE
feat(honeytoken): Salesforce provider plugin (epic #256 Task 5)

### DIFF
--- a/plugins/honeytoken/salesforce/manifest.yaml
+++ b/plugins/honeytoken/salesforce/manifest.yaml
@@ -1,0 +1,35 @@
+name: salesforce
+kind: honeytoken
+display_name: "Salesforce"
+version: "0.2.0"
+author: thumper-core
+description: >
+  Create Salesforce Connected Apps as honeytokens and monitor OAuth token
+  usage and login history for unauthorized access. Authenticates via
+  OAuth 2.0 JWT Bearer flow.
+
+config_schema:
+  - key: instance_url
+    label: "Instance URL"
+    type: string
+    required: true
+    placeholder: "https://myorg.my.salesforce.com"
+    help: "Your Salesforce instance URL (e.g. https://myorg.my.salesforce.com)."
+
+  - key: consumer_key
+    label: "Connected App Consumer Key"
+    type: string
+    required: true
+    help: "Consumer Key (Client ID) from your Connected App in Salesforce."
+
+  - key: username
+    label: "Admin Username"
+    type: string
+    required: true
+    help: "Salesforce admin user authorized in the Connected App."
+
+  - key: private_key
+    label: "Private Key (PEM)"
+    type: secret
+    required: true
+    help: "RSA private key in PEM format used to sign the JWT assertion."

--- a/plugins/honeytoken/salesforce/plugin.py
+++ b/plugins/honeytoken/salesforce/plugin.py
@@ -1,0 +1,188 @@
+"""Salesforce honeytoken plugin: create a canary Connected App and detect use.
+
+Authenticates via the OAuth 2.0 JWT Bearer flow (RS256-signed assertion), creates
+a Connected App as the canary, and polls LoginHistory + OAuthToken for any use of
+it. Uses httpx (the thumper HTTP client) and PyJWT for the assertion.
+"""
+import logging
+import time
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import jwt
+
+from thumper.plugins.base import HoneytokenPlugin, PluginError, TokenUsageEvent
+
+log = logging.getLogger("thumper.plugin.salesforce")
+
+TOKEN_ENDPOINT = "/services/oauth2/token"
+API_VERSION = "v60.0"
+TIMEOUT = 15
+
+
+class Plugin(HoneytokenPlugin):
+    def __init__(self, config: dict):
+        super().__init__(config)
+        self._access_token: str | None = None
+        self._instance_url: str | None = None
+
+    def _jwt_assertion(self) -> str:
+        now = int(time.time())
+        instance_url = self.config["instance_url"].rstrip("/")
+        payload = {
+            "iss": self.config["consumer_key"],
+            "sub": self.config["username"],
+            "aud": instance_url,
+            "exp": now + 300,
+        }
+        return jwt.encode(payload, self.config["private_key"], algorithm="RS256")
+
+    def connect(self) -> None:
+        instance_url = self.config.get("instance_url", "").rstrip("/")
+        if not all([instance_url, self.config.get("consumer_key"),
+                    self.config.get("username"), self.config.get("private_key")]):
+            raise PluginError(
+                "salesforce: instance_url, consumer_key, username, and private_key "
+                "are required")
+        try:
+            resp = httpx.post(
+                f"{instance_url}{TOKEN_ENDPOINT}",
+                data={
+                    "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                    "assertion": self._jwt_assertion(),
+                },
+                timeout=TIMEOUT,
+            )
+        except httpx.HTTPError as exc:
+            raise PluginError(f"Salesforce connection failed: {exc}") from exc
+        if resp.status_code != 200:
+            ct = resp.headers.get("content-type", "")
+            body = resp.json() if ct.startswith("application/json") else {}
+            raise PluginError(
+                f"Salesforce JWT auth failed: {body.get('error_description', resp.text)}")
+        data = resp.json()
+        self._access_token = data["access_token"]
+        self._instance_url = data.get("instance_url", instance_url)
+
+    def _ensure_connected(self) -> None:
+        if self._access_token is None:
+            self.connect()
+
+    def _api(self, method: str, path: str, **kwargs) -> httpx.Response:
+        self._ensure_connected()
+        return httpx.request(
+            method, f"{self._instance_url}{path}",
+            headers={"Authorization": f"Bearer {self._access_token}"},
+            timeout=TIMEOUT, **kwargs)
+
+    def create_token(self, name: str, options: dict | None = None) -> dict:
+        app_name = f"Thumper_Canary_{name.replace(' ', '_')}"
+        resp = self._api(
+            "POST",
+            f"/services/data/{API_VERSION}/tooling/sobjects/ConnectedApplication",
+            json={
+                "FullName": app_name,
+                "Metadata": {
+                    "label": app_name,
+                    "contactEmail": self.config.get("username"),
+                    "oauthConfig": {
+                        "callbackUrl": "https://localhost/callback",
+                        "isAdminApproved": False,
+                        "scopes": ["Api", "RefreshToken"],
+                    },
+                },
+            },
+        )
+        if resp.status_code not in (200, 201):
+            raise PluginError(
+                f"Failed to create Connected App: {resp.status_code} {resp.text}")
+        app_id = resp.json().get("id", app_name)
+        # Resolve the durable record Id (the create response id may be the tooling
+        # object id); fall back to the create result if the lookup can't find it.
+        lookup = self._api(
+            "GET", f"/services/data/{API_VERSION}/tooling/query",
+            params={"q": f"SELECT Id, Name FROM ConnectedApplication "
+                         f"WHERE Name = '{app_name}' LIMIT 1"},
+        )
+        if lookup.status_code == 200:
+            records = lookup.json().get("records", [])
+            if records:
+                app_id = records[0]["Id"]
+        return {"token_id": app_id, "token_type": "connected_app", "app_name": app_name}
+
+    def revoke_token(self, token_id: str) -> None:
+        resp = self._api(
+            "DELETE",
+            f"/services/data/{API_VERSION}/tooling/sobjects/ConnectedApplication/{token_id}",
+        )
+        if resp.status_code not in (200, 204, 404):
+            raise PluginError(
+                f"Failed to delete Connected App: {resp.status_code} {resp.text}")
+
+    def poll_usage(self, token_ids: list[str],
+                   since: str | None = None) -> list[TokenUsageEvent]:
+        now = datetime.now(timezone.utc)
+        if since:
+            start = datetime.fromisoformat(since) - timedelta(minutes=10)
+        else:
+            start = now - timedelta(hours=1)
+        start_str = start.strftime("%Y-%m-%dT%H:%M:%SZ")
+        events: list[TokenUsageEvent] = []
+        for token_id in token_ids:
+            events.extend(self._login_history(token_id, start_str, now))
+            events.extend(self._oauth_usage(token_id, start_str, now))
+        return events
+
+    def _login_history(self, token_id, start_str, now) -> list[TokenUsageEvent]:
+        try:
+            resp = self._api(
+                "GET", f"/services/data/{API_VERSION}/query",
+                params={"q": (
+                    "SELECT Id, UserId, LoginTime, SourceIp, Application, LoginType "
+                    "FROM LoginHistory "
+                    f"WHERE LoginTime > {start_str} AND Application = '{token_id}' "
+                    "ORDER BY LoginTime DESC LIMIT 50"
+                )},
+            )
+        except httpx.HTTPError as exc:
+            log.warning("Salesforce LoginHistory query failed for %s: %s", token_id, exc)
+            return []
+        if resp.status_code != 200:
+            return []
+        return [
+            TokenUsageEvent(
+                token_id=token_id,
+                timestamp=r.get("LoginTime", now.isoformat()),
+                actor=r.get("UserId"), source_ip=r.get("SourceIp"),
+                action=r.get("LoginType", "login"),
+                extra={"event_id": r.get("Id")},
+            )
+            for r in resp.json().get("records", [])
+        ]
+
+    def _oauth_usage(self, token_id, start_str, now) -> list[TokenUsageEvent]:
+        try:
+            resp = self._api(
+                "GET", f"/services/data/{API_VERSION}/query",
+                params={"q": (
+                    "SELECT Id, AppName, LastUsedDate, UseCount, UserId "
+                    "FROM OAuthToken "
+                    f"WHERE AppName = '{token_id}' AND LastUsedDate > {start_str} "
+                    "LIMIT 50"
+                )},
+            )
+        except httpx.HTTPError as exc:
+            log.warning("Salesforce OAuthToken query failed for %s: %s", token_id, exc)
+            return []
+        if resp.status_code != 200:
+            return []
+        return [
+            TokenUsageEvent(
+                token_id=token_id,
+                timestamp=r.get("LastUsedDate", now.isoformat()),
+                actor=r.get("UserId"), source_ip=None,
+                action=f"oauth_usage (count: {r.get('UseCount', 0)})",
+                extra={"event_id": f"oauth_{r.get('Id')}"},
+            )
+            for r in resp.json().get("records", [])
+        ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "sqlalchemy>=2.0.51",
   "alembic>=1.18.5",
   "cryptography>=49.0.0",
+  "pyjwt>=2.8",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_salesforce_plugin.py
+++ b/tests/test_salesforce_plugin.py
@@ -1,0 +1,148 @@
+"""Salesforce honeytoken plugin against a faked httpx + jwt (no real org/key)."""
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from thumper.plugins.base import PluginError
+
+PLUGIN_FILE = (Path(__file__).resolve().parents[1]
+               / "plugins" / "honeytoken" / "salesforce" / "plugin.py")
+
+
+def load_plugin_module():
+    spec = importlib.util.spec_from_file_location("thumper_plugin_salesforce_test", PLUGIN_FILE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, payload=None, text="", content_type="application/json"):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+        self.text = text
+        self.headers = {"content-type": content_type}
+
+    def json(self):
+        return self._payload
+
+
+class FakeHttpx:
+    HTTPError = Exception
+
+    def __init__(self, routes):
+        self._routes = routes
+        self.calls = []
+
+    def _match(self, method, url):
+        for (m, frag), resp in self._routes.items():
+            if m == method and frag in url:
+                return resp
+        raise AssertionError(f"no fake route for {method} {url}")
+
+    def post(self, url, data=None, timeout=None):
+        self.calls.append(("POST", url, data))
+        return self._match("POST", url)
+
+    def request(self, method, url, headers=None, timeout=None, **kwargs):
+        self.calls.append((method, url, kwargs))
+        return self._match(method, url)
+
+
+CONFIG = {
+    "instance_url": "https://myorg.my.salesforce.com",
+    "consumer_key": "ck", "username": "admin@example.com", "private_key": "PEM",
+}
+
+TOKEN_OK = FakeResponse(200, payload={"access_token": "at", "instance_url": CONFIG["instance_url"]})
+
+
+@pytest.fixture
+def module(monkeypatch):
+    mod = load_plugin_module()
+    # Sign with a stub so tests need no real RSA key.
+    monkeypatch.setattr(mod.jwt, "encode", lambda payload, key, algorithm=None: "signed.jwt")
+    return mod
+
+
+def _install(module, monkeypatch, routes):
+    fake = FakeHttpx(routes)
+    monkeypatch.setattr(module, "httpx", fake)
+    return fake
+
+
+def test_connect_requires_all_config(module):
+    with pytest.raises(PluginError):
+        module.Plugin({"instance_url": "https://x"}).connect()
+
+
+def test_connect_obtains_access_token(module, monkeypatch):
+    _install(module, monkeypatch, {("POST", "/services/oauth2/token"): TOKEN_OK})
+    plugin = module.Plugin(CONFIG)
+    plugin.connect()
+    assert plugin._access_token == "at"
+
+
+def test_connect_raises_on_auth_failure(module, monkeypatch):
+    _install(module, monkeypatch, {
+        ("POST", "/services/oauth2/token"): FakeResponse(
+            400, payload={"error_description": "invalid_grant"}),
+    })
+    with pytest.raises(PluginError) as exc:
+        module.Plugin(CONFIG).connect()
+    assert "invalid_grant" in str(exc.value)
+
+
+def test_create_token_returns_connected_app_id(module, monkeypatch):
+    _install(module, monkeypatch, {
+        ("POST", "/services/oauth2/token"): TOKEN_OK,
+        ("POST", "/tooling/sobjects/ConnectedApplication"): FakeResponse(
+            201, payload={"id": "toolingId"}),
+        ("GET", "/tooling/query"): FakeResponse(
+            200, payload={"records": [{"Id": "0H4xx", "Name": "Thumper_Canary_c"}]}),
+    })
+    result = module.Plugin(CONFIG).create_token("c")
+    assert result["token_id"] == "0H4xx"
+    assert result["token_type"] == "connected_app"
+    assert result["app_name"] == "Thumper_Canary_c"
+
+
+def test_revoke_token_idempotent_on_404(module, monkeypatch):
+    _install(module, monkeypatch, {
+        ("POST", "/services/oauth2/token"): TOKEN_OK,
+        ("DELETE", "/tooling/sobjects/ConnectedApplication/"): FakeResponse(404),
+    })
+    module.Plugin(CONFIG).revoke_token("0H4xx")  # no raise
+
+
+def test_poll_usage_collects_login_and_oauth_events(module, monkeypatch):
+    login = FakeResponse(200, payload={"records": [{
+        "Id": "login-1", "UserId": "005xx", "LoginTime": "2026-07-21T10:00:00.000+0000",
+        "SourceIp": "10.0.0.9", "LoginType": "Application",
+    }]})
+    oauth = FakeResponse(200, payload={"records": [{
+        "Id": "oauth-1", "AppName": "app", "LastUsedDate": "2026-07-21T11:00:00.000+0000",
+        "UseCount": 3, "UserId": "005xx",
+    }]})
+
+    # /query serves LoginHistory first, then OAuthToken - route by call order.
+    seq = [login, oauth]
+
+    class Seq(FakeHttpx):
+        def request(self, method, url, headers=None, timeout=None, **kwargs):
+            self.calls.append((method, url))
+            if method == "POST":
+                return TOKEN_OK
+            return seq.pop(0)
+
+    fake = Seq({})
+    monkeypatch.setattr(module, "httpx", fake)
+    plugin = module.Plugin(CONFIG)
+    plugin._access_token = "at"
+    plugin._instance_url = CONFIG["instance_url"]
+    events = plugin.poll_usage(["app"])
+    assert len(events) == 2
+    assert events[0].source_ip == "10.0.0.9"
+    assert events[0].extra["event_id"] == "login-1"
+    assert events[1].extra["event_id"] == "oauth_oauth-1"


### PR DESCRIPTION
## What

Task 5 of epic #256 — second honeytoken provider: create a canary Salesforce **Connected App** and detect its use.

- Authenticates via the **OAuth 2.0 JWT Bearer flow** (RS256-signed assertion).
- **`create_token()`** — create a Connected App as the canary; resolves its durable record Id.
- **`revoke_token()`** — delete the Connected App (404 → already gone, idempotent).
- **`poll_usage()`** — queries **LoginHistory** (login attempts + source IP) *and* **OAuthToken** (token usage counts) for the canary app; each row becomes a usage event with a stable `event_id` for dedup.

## Adaptation
Ported from the enterprise plugin, rewritten on **`httpx`** (dropping `requests`) and adding **`pyjwt>=2.8`** to deps — `cryptography` (needed for RS256) is already a dependency, and CI installs via `pip install -e ".[dev]"`. Config: `instance_url`, `consumer_key`, `username` (strings), `private_key` (secret PEM).

## Testing
6 tests against faked `httpx` + `jwt` (no real org/key): connect success/failure, config validation, create→resolve-id, idempotent revoke, poll collecting both login + oauth events. Loader discovers it as `honeytoken`. **Full suite: 414 passed, 1 skipped**; ruff clean.

## Stacked
Based on #268 (Task 4) → #267 → …. AWS plugin (Task 6) next, then the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)