### PR TITLE
feat(honeytoken): AWS provider plugin (epic #256 Task 6)

### DIFF
--- a/plugins/honeytoken/aws/manifest.yaml
+++ b/plugins/honeytoken/aws/manifest.yaml
@@ -1,0 +1,30 @@
+name: aws
+kind: honeytoken
+display_name: "AWS"
+version: "0.3.0"
+author: thumper-core
+description: >
+  Create AWS IAM access keys as honeytokens and monitor
+  CloudTrail for unauthorized usage.
+
+config_schema:
+  - key: access_key_id
+    label: "Access Key ID"
+    type: string
+    required: true
+    placeholder: "AKIA..."
+    help: "AWS access key ID with IAM and CloudTrail permissions."
+
+  - key: secret_access_key
+    label: "Secret Access Key"
+    type: secret
+    required: true
+    placeholder: ""
+    help: "Corresponding secret access key."
+
+  - key: region
+    label: "AWS Region"
+    type: string
+    required: true
+    placeholder: "us-east-1"
+    help: "Region for CloudTrail API calls."

--- a/plugins/honeytoken/aws/plugin.py
+++ b/plugins/honeytoken/aws/plugin.py
@@ -1,0 +1,130 @@
+"""AWS honeytoken plugin: create canary IAM access keys and detect use.
+
+Each canary is a dedicated IAM user (`thumper-canary-*`) with a deny-all inline
+policy, so the key can do nothing even if leaked - but any USE of it is recorded
+in CloudTrail, which poll_usage looks up by AccessKeyId.
+"""
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+
+import boto3
+from botocore.exceptions import ClientError
+
+from thumper.plugins.base import HoneytokenPlugin, PluginError, TokenUsageEvent
+
+log = logging.getLogger("thumper.plugin.aws")
+
+CANARY_PREFIX = "thumper-canary-"
+DENY_ALL_POLICY = json.dumps({
+    "Version": "2012-10-17",
+    "Statement": [{"Effect": "Deny", "Action": "*", "Resource": "*"}],
+})
+
+
+class Plugin(HoneytokenPlugin):
+    def __init__(self, config: dict):
+        super().__init__(config)
+        self._session = None
+
+    def _get_session(self):
+        if self._session is None:
+            self._session = boto3.Session(
+                aws_access_key_id=self.config["access_key_id"],
+                aws_secret_access_key=self.config["secret_access_key"],
+                region_name=self.config.get("region", "us-east-1"),
+            )
+        return self._session
+
+    def connect(self) -> None:
+        if not self.config.get("access_key_id") or not self.config.get("secret_access_key"):
+            raise PluginError("aws: access_key_id and secret_access_key are required")
+        try:
+            identity = self._get_session().client("sts").get_caller_identity()
+            log.info("AWS honeytoken connected as %s", identity.get("Arn"))
+        except ClientError as exc:
+            raise PluginError(f"AWS connection failed: {exc}") from exc
+
+    def create_token(self, name: str, options: dict | None = None) -> dict:
+        iam = self._get_session().client("iam")
+        username = f"{CANARY_PREFIX}{name.replace(' ', '-').lower()}"
+        try:
+            iam.create_user(UserName=username, Tags=[
+                {"Key": "thumper", "Value": "canary"},
+                {"Key": "canary-name", "Value": name},
+            ])
+        except ClientError as exc:
+            if exc.response["Error"]["Code"] != "EntityAlreadyExists":
+                raise PluginError(f"Failed to create IAM user: {exc}") from exc
+        try:
+            # Deny-all so a leaked canary key is inert; only its USE matters (logged
+            # in CloudTrail even when the call is denied).
+            iam.put_user_policy(UserName=username, PolicyName="thumper-deny-all",
+                                PolicyDocument=DENY_ALL_POLICY)
+            key = iam.create_access_key(UserName=username)["AccessKey"]
+        except ClientError as exc:
+            raise PluginError(f"Failed to provision canary key: {exc}") from exc
+        return {
+            "token_id": key["AccessKeyId"],
+            "token_type": "access_key",
+            "username": username,
+            "access_key_id": key["AccessKeyId"],
+            "secret_access_key": key["SecretAccessKey"],
+        }
+
+    def revoke_token(self, token_id: str) -> None:
+        iam = self._get_session().client("iam")
+        try:
+            for page in iam.get_paginator("list_users").paginate(PathPrefix="/"):
+                for user in page["Users"]:
+                    if not user["UserName"].startswith(CANARY_PREFIX):
+                        continue
+                    keys = iam.list_access_keys(UserName=user["UserName"])
+                    if any(km["AccessKeyId"] == token_id
+                           for km in keys["AccessKeyMetadata"]):
+                        self._cleanup_user(iam, user["UserName"])
+                        return
+        except ClientError as exc:
+            if "NoSuchEntity" not in str(exc):
+                raise PluginError(f"Failed to delete access key: {exc}") from exc
+
+    def _cleanup_user(self, iam, username: str) -> None:
+        """Remove a canary user's keys + inline policies, then the user itself.
+        (IAM refuses to delete a user that still has keys/policies attached.)"""
+        try:
+            for key in iam.list_access_keys(UserName=username).get("AccessKeyMetadata", []):
+                iam.delete_access_key(UserName=username, AccessKeyId=key["AccessKeyId"])
+            for policy in iam.list_user_policies(UserName=username).get("PolicyNames", []):
+                iam.delete_user_policy(UserName=username, PolicyName=policy)
+            iam.delete_user(UserName=username)
+        except ClientError:
+            log.warning("Partial cleanup of canary user %s", username)
+
+    def poll_usage(self, token_ids: list[str],
+                   since: str | None = None) -> list[TokenUsageEvent]:
+        ct = self._get_session().client("cloudtrail")
+        now = datetime.now(timezone.utc)
+        start = (datetime.fromisoformat(since) - timedelta(minutes=5)
+                 if since else now - timedelta(hours=1))
+        events: list[TokenUsageEvent] = []
+        for tid in token_ids:
+            try:
+                resp = ct.lookup_events(
+                    LookupAttributes=[{"AttributeKey": "AccessKeyId",
+                                       "AttributeValue": tid}],
+                    StartTime=start, EndTime=now, MaxResults=50,
+                )
+            except ClientError as exc:
+                log.warning("CloudTrail lookup failed for key %s: %s", tid, exc)
+                continue
+            for event in resp.get("Events", []):
+                resources = event.get("Resources") or []
+                events.append(TokenUsageEvent(
+                    token_id=tid,
+                    timestamp=event["EventTime"].isoformat(),
+                    actor=event.get("Username"),
+                    source_ip=resources[0].get("ResourceName") if resources else None,
+                    action=event.get("EventName"),
+                    extra={"event_id": event.get("EventId")},
+                ))
+        return events

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "alembic>=1.18.5",
   "cryptography>=49.0.0",
   "pyjwt>=2.8",
+  "boto3>=1.34",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_aws_honeytoken_plugin.py
+++ b/tests/test_aws_honeytoken_plugin.py
@@ -1,0 +1,155 @@
+"""AWS honeytoken plugin against a faked boto3 session (no real AWS calls)."""
+import importlib.util
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from botocore.exceptions import ClientError
+
+from thumper.plugins.base import PluginError
+
+PLUGIN_FILE = (Path(__file__).resolve().parents[1]
+               / "plugins" / "honeytoken" / "aws" / "plugin.py")
+
+
+def load_plugin_module():
+    spec = importlib.util.spec_from_file_location("thumper_plugin_aws_ht_test", PLUGIN_FILE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _client_error(code):
+    return ClientError({"Error": {"Code": code, "Message": code}}, "Op")
+
+
+class FakeIAM:
+    def __init__(self, create_user_error=None):
+        self.calls = []
+        self._create_user_error = create_user_error
+        self.deleted_users = []
+
+    def create_user(self, **kw):
+        self.calls.append(("create_user", kw))
+        if self._create_user_error:
+            raise self._create_user_error
+
+    def put_user_policy(self, **kw):
+        self.calls.append(("put_user_policy", kw))
+
+    def create_access_key(self, UserName):
+        self.calls.append(("create_access_key", UserName))
+        return {"AccessKey": {"AccessKeyId": "AKIACANARY", "SecretAccessKey": "secret"}}
+
+    def get_paginator(self, name):
+        class Pag:
+            def paginate(self, **kw):
+                return [{"Users": [{"UserName": "thumper-canary-c"},
+                                   {"UserName": "real-user"}]}]
+        return Pag()
+
+    def list_access_keys(self, UserName):
+        if UserName == "thumper-canary-c":
+            return {"AccessKeyMetadata": [{"AccessKeyId": "AKIACANARY"}]}
+        return {"AccessKeyMetadata": []}
+
+    def list_user_policies(self, UserName):
+        return {"PolicyNames": ["thumper-deny-all"]}
+
+    def delete_access_key(self, **kw):
+        self.calls.append(("delete_access_key", kw))
+
+    def delete_user_policy(self, **kw):
+        self.calls.append(("delete_user_policy", kw))
+
+    def delete_user(self, UserName):
+        self.deleted_users.append(UserName)
+
+
+class FakeCloudTrail:
+    def __init__(self, events):
+        self._events = events
+
+    def lookup_events(self, **kw):
+        return {"Events": self._events}
+
+
+class FakeSession:
+    def __init__(self, clients):
+        self._clients = clients
+
+    def client(self, name):
+        return self._clients[name]
+
+
+CONFIG = {"access_key_id": "AKIA", "secret_access_key": "s", "region": "us-east-1"}
+
+
+@pytest.fixture
+def module():
+    return load_plugin_module()
+
+
+def _with_session(module, monkeypatch, clients):
+    monkeypatch.setattr(module.boto3, "Session", lambda **kw: FakeSession(clients))
+
+
+def test_connect_requires_keys(module):
+    with pytest.raises(PluginError):
+        module.Plugin({"region": "us-east-1"}).connect()
+
+
+def test_connect_calls_sts(module, monkeypatch):
+    class STS:
+        def get_caller_identity(self):
+            return {"Arn": "arn:aws:iam::1:user/x"}
+    _with_session(module, monkeypatch, {"sts": STS()})
+    module.Plugin(CONFIG).connect()  # no raise
+
+
+def test_create_token_provisions_key_and_deny_all(module, monkeypatch):
+    iam = FakeIAM()
+    _with_session(module, monkeypatch, {"iam": iam})
+    result = module.Plugin(CONFIG).create_token("C")
+    assert result["token_id"] == "AKIACANARY"
+    assert result["username"] == "thumper-canary-c"
+    assert result["secret_access_key"] == "secret"
+    ops = [c[0] for c in iam.calls]
+    assert "put_user_policy" in ops  # deny-all attached
+    assert "create_access_key" in ops
+
+
+def test_create_token_tolerates_existing_user(module, monkeypatch):
+    iam = FakeIAM(create_user_error=_client_error("EntityAlreadyExists"))
+    _with_session(module, monkeypatch, {"iam": iam})
+    result = module.Plugin(CONFIG).create_token("C")  # does not raise
+    assert result["token_id"] == "AKIACANARY"
+
+
+def test_create_token_raises_on_other_error(module, monkeypatch):
+    iam = FakeIAM(create_user_error=_client_error("AccessDenied"))
+    _with_session(module, monkeypatch, {"iam": iam})
+    with pytest.raises(PluginError):
+        module.Plugin(CONFIG).create_token("C")
+
+
+def test_revoke_token_cleans_up_canary_user(module, monkeypatch):
+    iam = FakeIAM()
+    _with_session(module, monkeypatch, {"iam": iam})
+    module.Plugin(CONFIG).revoke_token("AKIACANARY")
+    assert "thumper-canary-c" in iam.deleted_users
+
+
+def test_poll_usage_maps_cloudtrail_events(module, monkeypatch):
+    ct = FakeCloudTrail(events=[{
+        "EventTime": datetime(2026, 7, 21, 10, 0, tzinfo=timezone.utc),
+        "EventId": "evt-1", "EventName": "GetCallerIdentity", "Username": "attacker",
+        "Resources": [{"ResourceName": "203.0.113.5"}],
+    }])
+    _with_session(module, monkeypatch, {"cloudtrail": ct})
+    events = module.Plugin(CONFIG).poll_usage(["AKIACANARY"])
+    assert len(events) == 1
+    assert events[0].token_id == "AKIACANARY"
+    assert events[0].action == "GetCallerIdentity"
+    assert events[0].actor == "attacker"
+    assert events[0].extra["event_id"] == "evt-1"


### PR DESCRIPTION
## What

Task 6 of epic #256 — the **last honeytoken provider**. Creates canary AWS IAM access keys and detects their use via CloudTrail.

- Each canary is a dedicated IAM user (`thumper-canary-*`) with a **deny-all inline policy**, so a leaked key is inert — but any *use* is still recorded in CloudTrail.
- **`create_token()`** — create user + deny-all policy + access key; tolerates an already-existing user (`EntityAlreadyExists`).
- **`revoke_token()`** — find the canary user owning the key and fully clean it up (keys → inline policies → user, the order IAM requires).
- **`poll_usage()`** — CloudTrail `lookup_events` by `AccessKeyId`; each event → a usage event keyed on the CloudTrail `EventId` for dedup.

## Adaptation
Straight `boto3` port (no `requests`). Adds **`boto3>=1.34`** to deps (CI installs via `pip install -e ".[dev]"`). Config: `access_key_id` (string), `secret_access_key` (secret), `region`.

## Testing
7 tests against a **faked boto3 session** (no real AWS): connect + missing-keys, create + deny-all attached, existing-user tolerance, other-error raises, revoke cleanup, CloudTrail event mapping. Loader discovers it as `honeytoken`. Full suite green (one unrelated agent-shell macOS flake, passed on isolated re-run); ruff clean.

## Stacked
Based on #269 (Task 5) → …. This completes the three providers; the UI (Task 7) + polish (Task 8) remain.

_Note: both this and the vault AWS plugin add `boto3` to deps — a trivial duplicate-line conflict when the second of the two stacks merges._

🤖 Generated with [Claude Code](https://claude.com/claude-code)