### PR TITLE
feat(honeytoken): Third Party SaaS UI — connections + honeytokens (epic #256 Task 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Third-party SaaS honeytokens: create fake credentials inside Datadog,
+  Salesforce, and AWS via their APIs, and detect use by polling each platform's
+  audit log — a new "Third Party SaaS" dashboard section (Connections +
+  Honeytokens tabs), a background usage poller, and the `honeytoken` plugin kind.
 - Docker registry credentials honeytoken type for `~/.docker/config.json`.
 - Added absolute local-time tooltips to relative timestamps in the dashboard UI.
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { NavLink, Route, Routes } from "react-router-dom";
 import {
+  Cloud,
   Crosshair,
   LayoutDashboard,
   MonitorDot,
@@ -16,6 +17,8 @@ import CreateTripwire from "./pages/CreateTripwire.tsx";
 import Endpoints from "./pages/Endpoints.tsx";
 import EndpointDetail from "./pages/EndpointDetail.tsx";
 import Integrations from "./pages/Integrations.tsx";
+import HoneytokenConnections from "./pages/HoneytokenConnections.tsx";
+import Honeytokens from "./pages/Honeytokens.tsx";
 import Settings from "./pages/Settings.tsx";
 import NotFound from "./pages/NotFound.tsx";
 import AdminGate from "./AdminGate.tsx";
@@ -89,6 +92,10 @@ function Sidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () => 
           <span className="nav-icon"><MonitorDot size={18} /></span>{" "}
           <span className="nav-label">Endpoints</span>
         </NavLink>
+        <NavLink to="/third-party" className={linkClass} title="Third Party SaaS">
+          <span className="nav-icon"><Cloud size={18} /></span>{" "}
+          <span className="nav-label">Third Party SaaS</span>
+        </NavLink>
         <NavLink to="/integrations" className={linkClass} title="Integrations">
           <span className="nav-icon"><Plug size={18} /></span>{" "}
           <span className="nav-label">Integrations</span>
@@ -121,6 +128,8 @@ export default function App() {
           <Route path="/tripwires/:id" element={<TripwireDetail />} />
           <Route path="/endpoints" element={<Endpoints />} />
           <Route path="/endpoints/:id" element={<EndpointDetail />} />
+          <Route path="/third-party" element={<HoneytokenConnections />} />
+          <Route path="/third-party/tokens" element={<Honeytokens />} />
           <Route path="/integrations" element={<Integrations />} />
           <Route path="/settings" element={<Settings />} />
           <Route path="*" element={<NotFound />} />

--- a/ui/src/api/honeytoken.test.ts
+++ b/ui/src/api/honeytoken.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { httpApi } from "./http.ts";
+import { clearAdminToken, setAdminToken } from "./auth.ts";
+
+describe("honeytoken API client", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    const values = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+      removeItem: (key: string) => values.delete(key),
+      clear: () => values.clear(),
+      key: (index: number) => Array.from(values.keys())[index] ?? null,
+      get length() {
+        return values.size;
+      },
+    } as Storage;
+    Object.defineProperty(globalThis, "localStorage", { value: storage, configurable: true });
+    Object.defineProperty(globalThis, "fetch", { value: fetchMock, configurable: true });
+    setAdminToken("admin-secret");
+  });
+
+  afterEach(() => {
+    clearAdminToken();
+    fetchMock.mockReset();
+  });
+
+  function ok(body: unknown) {
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 200, json: async () => body });
+  }
+
+  it("creates a connection with a JSON body", async () => {
+    ok({ id: "htc_1", name: "DD", plugin: "datadog", configured: false, config: {}, created_at: "t" });
+    await httpApi.createHoneytokenConnection({
+      name: "DD", plugin: "datadog", config: { api_key: "k" } });
+    expect(fetchMock).toHaveBeenCalledWith("/api/honeytokens/connections", expect.objectContaining({
+      method: "POST",
+      body: JSON.stringify({ name: "DD", plugin: "datadog", config: { api_key: "k" } }),
+    }));
+  });
+
+  it("tests a connection via POST to its /test path", async () => {
+    ok({ ok: true, error: null });
+    await expect(httpApi.testHoneytokenConnection("htc_9")).resolves.toEqual({ ok: true, error: null });
+    expect(fetchMock).toHaveBeenCalledWith("/api/honeytokens/connections/htc_9/test",
+      expect.objectContaining({ method: "POST" }));
+  });
+
+  it("creates a honeytoken with connection + name", async () => {
+    ok({ id: "ht_1", name: "canary", token_type: "api_key", state: "active" });
+    await httpApi.createHoneytoken({ connection_id: "htc_1", name: "canary" });
+    expect(fetchMock).toHaveBeenCalledWith("/api/honeytokens/tokens", expect.objectContaining({
+      method: "POST",
+      body: JSON.stringify({ connection_id: "htc_1", name: "canary" }),
+    }));
+  });
+
+  it("fetches usage logs for a token", async () => {
+    ok([{ id: "hul_1", event_id: "e1", actor: "mallory", source_ip: "10.0.0.1", action: "query", timestamp: "t" }]);
+    const logs = await httpApi.listHoneytokenUsage("ht_1");
+    expect(logs[0].actor).toBe("mallory");
+    expect(fetchMock).toHaveBeenCalledWith("/api/honeytokens/tokens/ht_1/usage",
+      expect.objectContaining({ headers: expect.objectContaining({ authorization: "Bearer admin-secret" }) }));
+  });
+
+  it("deletes a token via DELETE", async () => {
+    ok({ status: "ok" });
+    await httpApi.deleteHoneytoken("ht_1");
+    expect(fetchMock).toHaveBeenCalledWith("/api/honeytokens/tokens/ht_1",
+      expect.objectContaining({ method: "DELETE" }));
+  });
+});

--- a/ui/src/api/http.ts
+++ b/ui/src/api/http.ts
@@ -8,6 +8,10 @@ import type {
   Deployment,
   Endpoint,
   EndpointDetail,
+  Honeytoken,
+  HoneytokenConnection,
+  HoneytokenConnectionTestResult,
+  HoneytokenUsageLog,
   InstallCommand,
   Integration,
   IntegrationTestResult,
@@ -121,6 +125,33 @@ export const httpApi = {
     }),
   resolveAllAlerts: () =>
     req<{ resolved: number }>("/alerts/resolve-all", { method: "POST" }),
+
+  // Honeytokens (third-party SaaS canaries)
+  listHoneytokenConnections: () => req<HoneytokenConnection[]>("/honeytokens/connections"),
+  createHoneytokenConnection: (input: {
+    name: string;
+    plugin: string;
+    config: Record<string, string | boolean>;
+  }) => req<HoneytokenConnection>("/honeytokens/connections",
+    { method: "POST", body: JSON.stringify(input) }),
+  updateHoneytokenConnection: (id: string, input: {
+    name: string;
+    config: Record<string, string | boolean>;
+  }) => req<HoneytokenConnection>(`/honeytokens/connections/${id}`,
+    { method: "PUT", body: JSON.stringify(input) }),
+  deleteHoneytokenConnection: (id: string) =>
+    req<{ status: string }>(`/honeytokens/connections/${id}`, { method: "DELETE" }),
+  testHoneytokenConnection: (id: string) =>
+    req<HoneytokenConnectionTestResult>(`/honeytokens/connections/${id}/test`,
+      { method: "POST" }),
+
+  listHoneytokens: () => req<Honeytoken[]>("/honeytokens/tokens"),
+  createHoneytoken: (input: { connection_id: string; name: string }) =>
+    req<Honeytoken>("/honeytokens/tokens", { method: "POST", body: JSON.stringify(input) }),
+  deleteHoneytoken: (id: string) =>
+    req<{ status: string }>(`/honeytokens/tokens/${id}`, { method: "DELETE" }),
+  listHoneytokenUsage: (id: string) =>
+    req<HoneytokenUsageLog[]>(`/honeytokens/tokens/${id}/usage`),
 
   // Plugins / integrations
   listManifests: () => req<PluginManifest[]>("/manifests"),

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -119,7 +119,7 @@ export interface ConfigField {
   generate?: boolean; // offer a "Generate" button (e.g. a signing secret you create yourself)
 }
 
-export type PluginKind = "deploy" | "alert";
+export type PluginKind = "deploy" | "alert" | "honeytoken";
 
 export interface PluginManifest {
   name: string;
@@ -145,6 +145,46 @@ export interface IntegrationTestResult {
   ok: boolean;
   error: string | null;
   tested_at: string;
+}
+
+// ── Honeytokens (third-party SaaS canaries) ──────────────────────────────────
+export type HoneytokenState = "pending" | "active" | "failed" | "triggered";
+
+export interface HoneytokenConnection {
+  id: string;
+  name: string;
+  plugin: string;
+  configured: boolean;
+  config: Record<string, string | boolean>;
+  last_poll_at?: string | null;
+  created_at: string;
+}
+
+export interface HoneytokenConnectionTestResult {
+  ok: boolean;
+  error?: string | null;
+}
+
+export interface Honeytoken {
+  id: string;
+  connection_id: string;
+  connection_name: string;
+  name: string;
+  token_id: string;
+  token_type: string;
+  state: HoneytokenState;
+  created_at: string;
+  last_used_at?: string | null;
+  metadata?: Record<string, string>;
+}
+
+export interface HoneytokenUsageLog {
+  id: string;
+  event_id: string | null;
+  actor: string | null;
+  source_ip: string | null;
+  action: string | null;
+  timestamp: string;
 }
 
 export interface VersionInfo {

--- a/ui/src/pages/HoneytokenConnections.tsx
+++ b/ui/src/pages/HoneytokenConnections.tsx
@@ -1,0 +1,275 @@
+import { useEffect, useState } from "react";
+import { NavLink } from "react-router-dom";
+import type {
+  HoneytokenConnection,
+  HoneytokenConnectionTestResult,
+  PluginManifest,
+} from "../api";
+import { api } from "../api";
+import { TimeAgo, Topbar } from "../components/ui.tsx";
+import PageTitle from "../components/PageTitle.tsx";
+
+const PAGE_TITLE = "Third Party SaaS";
+
+// Shared tabs between the two honeytoken pages. Kept identical in Honeytokens.tsx.
+export function SaasTabs() {
+  const cls = ({ isActive }: { isActive: boolean }) => (isActive ? "active" : "");
+  return (
+    <nav className="nav-tabs">
+      <NavLink to="/third-party" end className={cls}>Connections</NavLink>
+      <NavLink to="/third-party/tokens" className={cls}>Honeytokens</NavLink>
+    </nav>
+  );
+}
+
+export default function HoneytokenConnections() {
+  const [connections, setConnections] = useState<HoneytokenConnection[]>([]);
+  const [manifests, setManifests] = useState<PluginManifest[]>([]);
+  const [adding, setAdding] = useState(false);
+  const [editing, setEditing] = useState<HoneytokenConnection | null>(null);
+  const [testing, setTesting] = useState<Record<string, boolean>>({});
+  const [results, setResults] = useState<Record<string, HoneytokenConnectionTestResult>>({});
+
+  const load = () =>
+    Promise.all([api.listHoneytokenConnections(), api.listManifests()]).then(([c, m]) => {
+      setConnections(c);
+      setManifests(m.filter((x) => x.kind === "honeytoken"));
+    });
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function test(id: string) {
+    setTesting((t) => ({ ...t, [id]: true }));
+    try {
+      const res = await api.testHoneytokenConnection(id);
+      setResults((r) => ({ ...r, [id]: res }));
+    } catch (e) {
+      setResults((r) => ({ ...r, [id]: { ok: false, error: (e as Error).message } }));
+    } finally {
+      setTesting((t) => ({ ...t, [id]: false }));
+      await load();
+    }
+  }
+
+  async function remove(c: HoneytokenConnection) {
+    if (!window.confirm(
+      `Remove "${c.name}"? Thumper best-effort revokes its live honeytokens on the ` +
+      `platform, then deletes them from Thumper.`
+    )) return;
+    await api.deleteHoneytokenConnection(c.id);
+    setResults((r) => {
+      const next = { ...r };
+      delete next[c.id];
+      return next;
+    });
+    await load();
+  }
+
+  const manifestOf = (plugin: string) => manifests.find((m) => m.name === plugin);
+
+  return (
+    <>
+      <PageTitle title={PAGE_TITLE} />
+      <Topbar
+        title={PAGE_TITLE}
+        action={
+          <button className="btn primary" disabled={manifests.length === 0} onClick={() => setAdding(true)}>
+            Add Platform
+          </button>
+        }
+      />
+      <div className="content">
+        <SaasTabs />
+        <p className="muted" style={{ marginTop: 12 }}>
+          Connect a SaaS platform (Datadog, Salesforce, AWS) so Thumper can create
+          fake credentials in it and watch its audit log for use. Plugins are
+          auto-loaded from <span className="path">/plugins/honeytoken</span>.
+        </p>
+
+        {connections.length === 0 ? (
+          <div className="card">
+            <div className="empty">
+              No platforms connected yet. Click <strong>Add Platform</strong> to connect one.
+            </div>
+          </div>
+        ) : (
+          <div className="card">
+            {connections.map((c) => {
+              const m = manifestOf(c.plugin);
+              const res = results[c.id];
+              return (
+                <div className="integration-row" key={c.id}>
+                  <div>
+                    <div className="row" style={{ gap: 8 }}>
+                      <strong>{c.name}</strong>
+                      {c.configured ? (
+                        <span className="badge deployed"><span className="dot" /> configured</span>
+                      ) : (
+                        <span className="badge pending"><span className="dot" /> not tested</span>
+                      )}
+                      {c.last_poll_at && (
+                        <span className="muted">· last poll <TimeAgo iso={c.last_poll_at} /></span>
+                      )}
+                    </div>
+                    <div className="muted" style={{ marginTop: 4 }}>{m?.display_name ?? c.plugin}</div>
+                    <div className="path" style={{ marginTop: 6 }}>
+                      {Object.entries(c.config).map(([k, v]) => `${k}=${v}`).join("  ") || "—"}
+                    </div>
+                    {res && (
+                      <div className={res.ok ? "muted" : "danger-text"} style={{ marginTop: 6 }}>
+                        {res.ok ? "✓ Connected" : `✗ ${res.error}`}
+                      </div>
+                    )}
+                  </div>
+                  <div className="row" style={{ gap: 8 }}>
+                    <button className="btn" disabled={testing[c.id]} onClick={() => test(c.id)}>
+                      {testing[c.id] ? "Testing…" : "Test"}
+                    </button>
+                    <button className="btn" onClick={() => setEditing(c)}>Edit</button>
+                    <button className="btn danger" onClick={() => remove(c)}>Remove</button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {adding && (
+        <ConnectionModal
+          manifests={manifests}
+          onClose={() => setAdding(false)}
+          onSaved={async () => { setAdding(false); await load(); }}
+        />
+      )}
+      {editing && (
+        <ConnectionModal
+          manifests={manifests}
+          current={editing}
+          onClose={() => setEditing(null)}
+          onSaved={async () => { setEditing(null); await load(); }}
+        />
+      )}
+    </>
+  );
+}
+
+function ConnectionModal({
+  manifests,
+  current,
+  onClose,
+  onSaved,
+}: {
+  manifests: PluginManifest[];
+  current?: HoneytokenConnection;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [plugin, setPlugin] = useState(current?.plugin ?? manifests[0]?.name ?? "");
+  const [name, setName] = useState(current?.name ?? "");
+  const manifest = manifests.find((m) => m.name === plugin);
+
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [revealed, setRevealed] = useState<Record<string, boolean>>({});
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const init: Record<string, string> = {};
+    for (const f of manifest?.config_schema ?? []) {
+      const v = current?.config?.[f.key];
+      if (f.type !== "secret" && v != null) init[f.key] = String(v);
+    }
+    setValues(init);
+  }, [plugin, manifest, current]);
+
+  const isSet = (f: PluginManifest["config_schema"][number]) =>
+    Boolean(values[f.key]?.trim()) || Boolean(current?.config?.[f.key]);
+  const missingRequired =
+    !name.trim() || (manifest?.config_schema ?? []).some((f) => f.required && !isSet(f));
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    try {
+      if (current) {
+        await api.updateHoneytokenConnection(current.id, { name: name.trim(), config: values });
+      } else {
+        await api.createHoneytokenConnection({ name: name.trim(), plugin, config: values });
+      }
+      onSaved();
+    } catch (e) {
+      setError((e as Error).message);
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="card modal-card" style={{ width: 480 }} onClick={(e) => e.stopPropagation()}>
+        <div className="card-head">
+          <h2>{current ? "Edit" : "Add"} platform</h2>
+          <span className="type-tag">honeytoken</span>
+        </div>
+
+        <div className="field">
+          <label><span>Name</span><span className="field-tag required">Required</span></label>
+          <input type="text" placeholder="e.g. Production Datadog"
+                 value={name} onChange={(e) => setName(e.target.value)} />
+        </div>
+
+        {!current && (
+          <div className="field">
+            <label><span>Platform</span><span className="field-tag required">Required</span></label>
+            <select value={plugin} onChange={(e) => setPlugin(e.target.value)}>
+              {manifests.map((m) => <option key={m.name} value={m.name}>{m.display_name}</option>)}
+            </select>
+          </div>
+        )}
+
+        {(manifest?.config_schema ?? []).map((f) => {
+          const secretKept = f.type === "secret" && Boolean(current?.config?.[f.key]);
+          return (
+            <div className="field" key={f.key}>
+              <label>
+                <span>{f.label}</span>
+                <span className={`field-tag ${f.required ? "required" : "optional"}`}>
+                  {f.required ? "Required" : "Optional"}
+                </span>
+              </label>
+              <input
+                type={f.type === "secret" && !revealed[f.key] ? "password" : "text"}
+                placeholder={secretKept ? "•••••• - leave blank to keep current" : f.placeholder}
+                value={values[f.key] ?? ""}
+                onChange={(e) => setValues({ ...values, [f.key]: e.target.value })}
+              />
+              {f.type === "secret" && values[f.key] && (
+                <div className="row field-actions">
+                  <button type="button" className="btn small"
+                          onClick={() => setRevealed((r) => ({ ...r, [f.key]: !r[f.key] }))}>
+                    {revealed[f.key] ? "Hide" : "Show"}
+                  </button>
+                </div>
+              )}
+              {f.help && <div className="help">{f.help}</div>}
+            </div>
+          );
+        })}
+
+        {error && <div className="danger-text" style={{ marginTop: 6 }}>{error}</div>}
+
+        <div className="row" style={{ marginTop: 6 }}>
+          <button className="btn primary" disabled={saving || missingRequired} onClick={save}>
+            {saving ? "Saving…" : "Save"}
+          </button>
+          <button className="btn" onClick={onClose}>Cancel</button>
+        </div>
+        <p className="help" style={{ marginTop: 10 }}>
+          After saving, click <strong>Test</strong> to verify the connection before
+          creating honeytokens.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/Honeytokens.tsx
+++ b/ui/src/pages/Honeytokens.tsx
@@ -1,0 +1,242 @@
+import { useEffect, useState } from "react";
+import type {
+  Honeytoken,
+  HoneytokenConnection,
+  HoneytokenUsageLog,
+} from "../api";
+import { api } from "../api";
+import { TimeAgo, Topbar } from "../components/ui.tsx";
+import PageTitle from "../components/PageTitle.tsx";
+import { SaasTabs } from "./HoneytokenConnections.tsx";
+
+const PAGE_TITLE = "Honeytokens";
+
+// honeytoken state -> the reused integration badge class. A use makes state
+// "triggered", which is an ALERT, so it borrows the red styling.
+const BADGE: Record<Honeytoken["state"], string> = {
+  pending: "pending",
+  active: "deployed",
+  failed: "failed",
+  triggered: "triggered",
+};
+
+export default function Honeytokens() {
+  const [tokens, setTokens] = useState<Honeytoken[]>([]);
+  const [connections, setConnections] = useState<HoneytokenConnection[]>([]);
+  const [creating, setCreating] = useState(false);
+  const [usageFor, setUsageFor] = useState<Honeytoken | null>(null);
+
+  const load = () =>
+    Promise.all([api.listHoneytokens(), api.listHoneytokenConnections()]).then(([t, c]) => {
+      setTokens(t);
+      setConnections(c);
+    });
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function remove(t: Honeytoken) {
+    if (!window.confirm(
+      `Delete "${t.name}"? Thumper revokes it on the platform too.`
+    )) return;
+    await api.deleteHoneytoken(t.id);
+    await load();
+  }
+
+  const usable = connections.filter((c) => c.configured);
+
+  return (
+    <>
+      <PageTitle title={PAGE_TITLE} />
+      <Topbar
+        title={PAGE_TITLE}
+        action={
+          <button
+            className="btn primary"
+            disabled={usable.length === 0}
+            title={usable.length === 0 ? "Connect and test a platform first" : ""}
+            onClick={() => setCreating(true)}
+          >
+            Create Honeytoken
+          </button>
+        }
+      />
+      <div className="content">
+        <SaasTabs />
+        <p className="muted" style={{ marginTop: 12 }}>
+          Fake credentials created inside your SaaS platforms. Thumper polls each
+          platform's audit log and raises an alert the moment one is used.
+        </p>
+
+        {tokens.length === 0 ? (
+          <div className="card">
+            <div className="empty">
+              No honeytokens yet.
+              {usable.length === 0
+                ? " Connect and test a platform first."
+                : " Click Create Honeytoken to create one."}
+            </div>
+          </div>
+        ) : (
+          <div className="card">
+            <table>
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Platform</th>
+                  <th>Type</th>
+                  <th>State</th>
+                  <th>Last used</th>
+                  <th />
+                </tr>
+              </thead>
+              <tbody>
+                {tokens.map((t) => (
+                  <tr key={t.id}>
+                    <td>{t.name}</td>
+                    <td>{t.connection_name}</td>
+                    <td className="path">{t.token_type}</td>
+                    <td><span className={`badge ${BADGE[t.state]}`}><span className="dot" />{t.state}</span></td>
+                    <td className="muted">
+                      {t.last_used_at ? <TimeAgo iso={t.last_used_at} /> : "—"}
+                    </td>
+                    <td>
+                      <div className="row" style={{ gap: 8, justifyContent: "flex-end" }}>
+                        <button className="btn small" onClick={() => setUsageFor(t)}>Usage</button>
+                        <button className="btn small danger" onClick={() => remove(t)}>Delete</button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {creating && (
+        <CreateModal
+          connections={usable}
+          onClose={() => setCreating(false)}
+          onCreated={async () => { setCreating(false); await load(); }}
+        />
+      )}
+      {usageFor && <UsageModal token={usageFor} onClose={() => setUsageFor(null)} />}
+    </>
+  );
+}
+
+function CreateModal({
+  connections,
+  onClose,
+  onCreated,
+}: {
+  connections: HoneytokenConnection[];
+  onClose: () => void;
+  onCreated: () => void;
+}) {
+  const [connId, setConnId] = useState(connections[0]?.id ?? "");
+  const [name, setName] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const missing = !connId || !name.trim();
+
+  async function create() {
+    setSaving(true);
+    setError(null);
+    try {
+      await api.createHoneytoken({ connection_id: connId, name: name.trim() });
+      onCreated();
+    } catch (e) {
+      setError((e as Error).message);
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="card modal-card" style={{ width: 480 }} onClick={(e) => e.stopPropagation()}>
+        <div className="card-head">
+          <h2>Create honeytoken</h2>
+          <span className="type-tag">honeytoken</span>
+        </div>
+
+        <div className="field">
+          <label><span>Platform</span></label>
+          <select value={connId} onChange={(e) => setConnId(e.target.value)}>
+            {connections.map((c) => <option key={c.id} value={c.id}>{c.name}</option>)}
+          </select>
+        </div>
+
+        <div className="field">
+          <label><span>Name</span><span className="field-tag required">Required</span></label>
+          <input
+            type="text"
+            placeholder="a recognizable label, e.g. finance-api-key"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <div className="help">
+            The real fake credential is created on the platform; its use is what fires.
+          </div>
+        </div>
+
+        {error && <div className="danger-text" style={{ marginTop: 6 }}>{error}</div>}
+
+        <div className="row" style={{ marginTop: 6 }}>
+          <button className="btn primary" disabled={saving || missing} onClick={create}>
+            {saving ? "Creating…" : "Create"}
+          </button>
+          <button className="btn" onClick={onClose}>Cancel</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function UsageModal({ token, onClose }: { token: Honeytoken; onClose: () => void }) {
+  const [logs, setLogs] = useState<HoneytokenUsageLog[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    api.listHoneytokenUsage(token.id).then(setLogs).catch((e) => setError((e as Error).message));
+  }, [token.id]);
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="card modal-card" style={{ width: 560 }} onClick={(e) => e.stopPropagation()}>
+        <div className="card-head">
+          <h2>Usage of {token.name}</h2>
+          <span className="type-tag">{token.connection_name}</span>
+        </div>
+        {error ? (
+          <div className="danger-text">{error}</div>
+        ) : logs === null ? (
+          <div className="empty">Loading…</div>
+        ) : logs.length === 0 ? (
+          <div className="empty">No use recorded yet. A use here fires an alert.</div>
+        ) : (
+          <table>
+            <thead>
+              <tr><th>When</th><th>Actor</th><th>Action</th><th>Source IP</th></tr>
+            </thead>
+            <tbody>
+              {logs.map((l) => (
+                <tr key={l.id}>
+                  <td className="muted"><TimeAgo iso={l.timestamp} /></td>
+                  <td>{l.actor ?? "—"}</td>
+                  <td>{l.action ?? "—"}</td>
+                  <td className="path">{l.source_ip ?? "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+        <div className="row" style={{ marginTop: 6 }}>
+          <button className="btn" onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/styles/app.css
+++ b/ui/src/styles/app.css
@@ -74,6 +74,15 @@ a { color: inherit; text-decoration: none; }
 .chip:hover { color: var(--text); border-color: var(--accent); }
 .chip.active { background: var(--accent-dim); color: var(--text); border-color: var(--accent); }
 
+/* horizontal page tabs (e.g. Third Party SaaS: Connections | Honeytokens) */
+.nav-tabs { display: flex; gap: 4px; border-bottom: 1px solid var(--border); }
+.nav-tabs a {
+  padding: 8px 14px; font-size: 13px; font-weight: 600; color: var(--text-faint);
+  border-bottom: 2px solid transparent; margin-bottom: -1px; text-decoration: none;
+}
+.nav-tabs a:hover { color: var(--text); }
+.nav-tabs a.active { color: var(--accent); border-bottom-color: var(--accent); }
+
 /* install command + distribute result */
 .copyfield {
   display: flex; align-items: center; gap: 10px;


### PR DESCRIPTION
## What

Task 7 of epic #256 — the operator-facing UI. Makes the honeytoken feature usable end-to-end via a new **Third Party SaaS** sidebar section with two tabbed pages.

### `HoneytokenConnections` (`/third-party`)
List / add / edit / **test** / remove platform connections. The add/edit modal renders each honeytoken plugin's `config_schema` — masked secret fields, leave-blank-to-keep on edit. A connection shows `configured` once its test passes.

### `Honeytokens` (`/third-party/tokens`)
- Table of created honeytokens: name, platform, type, **state** badge, last used.
- **Create** modal: pick a configured platform + a name (the real fake credential is created on the platform).
- **Usage** modal: recorded usage-log entries (`GET /honeytokens/tokens/{id}/usage`).

## Approach
Built against the public-thumper UI conventions — same shape as the vault UI (Integrations config-form pattern, shared `Topbar`/`Modal`/`TimeAgo`, existing badge/table CSS) — **not** ported from the cockpit-entangled enterprise pages.

## Details
- `httpApi` honeytoken connection + token methods; honeytoken types; `"honeytoken"` added to `PluginKind`.
- New `.nav-tabs` CSS for the horizontal page tabs.
- `honeytoken.test.ts` covers the new API methods (path/method/body + auth header).

## Testing
`tsc -b && vite build` clean; **22 vitest tests pass** (5 new). No Python changed.

## Stacked
Based on #275 (Task 6) → … the full honeytoken stack. Only Task 8 (provider logos + polish) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)