### PR TITLE
test(agent): steady-state 'ready' signal to kill the startup-timing flake class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Agent emits a steady-state `ready` signal (marker + `watcher ready` log) once its
+  watchers are up and atime baselines are captured, killing the startup-timing test
+  flake class; the ephemeral `ready` marker is now accurate in every mode.
 - Restarted dead endpoint sensor processes instead of leaving live-sync agents silently blind.
 - Removed stale dashboard copy that described the old macOS `fs_usage`/sudo-based tripwire sensor.
 - Rejected unknown or oversized config keys when saving an integration, instead of persisting them unvalidated.

--- a/agent/thumper_agent.sh
+++ b/agent/thumper_agent.sh
@@ -558,6 +558,7 @@ watch_inotify() {
     # silently-dark sensor looks exactly like "no one touched the bait", which is
     # the worst possible failure for a tripwire. -q already keeps normal startup
     # quiet, so only real errors reach the log here.
+    mark_ready   # inotify -m begins monitoring immediately; signal steady state
     inotifywait -m -q -e access --format '%w' -- "$@" | while read -r path; do
         idx=""
         j=1
@@ -612,6 +613,8 @@ atime_poll() {
         arm_atime "$p"                                  # arm so relatime bumps atime on a read
         eval "atime_$i=\$(read_atime \"\$p\")"
     done
+    mark_armed   # gen 1: initial baselines captured - reads are now detectable
+    mark_ready   # atime watcher is at steady state
     while true; do
         sleep "$POLL"
         # shellcheck disable=SC2086
@@ -622,6 +625,7 @@ atime_poll() {
                 fire "$i" "atime-change" "" "" "" "$p"
                 arm_atime "$p"                          # RE-ARM so the NEXT read is detectable too
                 eval "atime_$i=\$(read_atime \"\$p\")"
+                mark_armed   # gen++: this bait re-armed + re-baselined
             fi
         done
     done
@@ -636,6 +640,24 @@ watch_atime() { atime_poll "$(all_indices)"; }   # poll every bait (homogeneous 
 # blind ourselves between cycles.
 WATCH_PID=""
 WATCH_STARTED=""
+
+# Steady-state signal (#237): a watcher writes WATCH_READY_FILE and logs once it
+# is fully up - workers spawned AND (for atime) baselines captured. Tests wait on
+# this instead of racing the sub-second startup window with weak "armed?" gates.
+# Idempotent: a re-armed/reconciled watcher simply re-touches it.
+mark_ready() {
+    : > "${WATCH_READY_FILE:-/dev/null}" 2>/dev/null || true
+    log "watcher ready"
+}
+
+# atime-only: an "armed generation" bumped after EACH baseline (re)capture, so a
+# test can wait past a specific re-arm before simulating the next read (the
+# arm->baseline window is otherwise a race - see #235). One writer (the atime
+# poll subshell), so the plain counter is safe.
+mark_armed() {
+    ATIME_ARMED_GEN=$(( ${ATIME_ARMED_GEN:-0} + 1 ))
+    printf '%s' "$ATIME_ARMED_GEN" > "${ATIME_ARMED_FILE:-/dev/null}" 2>/dev/null || true
+}
 
 # Record sensor workers owned by the current supervisor. If that supervisor is
 # killed abruptly, its children are reparented and `pkill -P` can no longer find
@@ -762,6 +784,7 @@ watch_fifo() {  # supervisor: keep one serve_fifo alive per bait; restart any th
         i=$((i + 1))
     done
     update_fifo_worker_registry
+    mark_ready   # all FIFO writers spawned - steady state
     while :; do
         [ -e "${WATCH_STOP_FLAG:-/nonexistent}" ] && return 0
         i=1
@@ -830,6 +853,10 @@ watch_mixed() {
         write_watcher_workers $_worker_pids
     }
     update_mixed_worker_registry
+    # Steady state (#237): with atime companions, the backgrounded atime_poll marks
+    # ready after IT captures baselines (the last thing to come up, since the FIFO
+    # writers spawned above). With no atime baits, nothing else will - so mark here.
+    [ -z "$_atidx" ] && mark_ready
     # Supervise the FIFO writers, exactly like watch_fifo: a serve_fifo that dies
     # leaves its pipe on disk, so any reader's open() blocks forever and that bait
     # is silently blind until a full restart (Roee #160 N1). Re-check the stop flag
@@ -1042,6 +1069,8 @@ run() {
     BAITCACHE="$(dirname "$STATE_FILE")/bait"
     WATCH_STOP_FLAG="$(dirname "$STATE_FILE")/watcher.stopping"
     WATCH_WORKERS_FILE="$(dirname "$STATE_FILE")/watcher.workers"
+    WATCH_READY_FILE="$(dirname "$STATE_FILE")/ready"          # steady-state signal (#237)
+    ATIME_ARMED_FILE="$(dirname "$STATE_FILE")/atime_armed"    # atime re-arm generation (#237)
     mkdir -p "$(dirname "$STATE_FILE")"
     case "$SENSOR" in
         atime) FIFO_MODE=0; log "sensor: atime poll (regular-file bait, re-armable)" ;;
@@ -1067,6 +1096,9 @@ run() {
     # it. Never act on stale PIDs from an earlier boot/run: they may have been
     # reused by an unrelated process. Current-run supervisors recreate the file.
     rm -f "$WATCH_WORKERS_FILE"
+    # Clear any steady-state markers from a prior run so a test can't observe a
+    # stale "ready"/generation before THIS run's watcher actually comes up (#237).
+    rm -f "$WATCH_READY_FILE" "$ATIME_ARMED_FILE"
     remove_fifos
     resolve_target_user
 
@@ -1123,7 +1155,9 @@ run() {
     fi
 
     start_watcher
-    [ "$EPHEMERAL" = 1 ] && : > "$(dirname "$STATE_FILE")/ready" 2>/dev/null || true
+    # The steady-state `ready` marker is now written by the watcher itself, once
+    # workers are up and (for atime) baselines are captured - accurate in every
+    # mode, not just ephemeral, and no longer racing the sub-second startup (#237).
 
     # No live sync: behave as before - block on the watcher.
     if ! [ "$SYNC_INTERVAL" -gt 0 ] 2>/dev/null; then

--- a/tests/agent_ready.py
+++ b/tests/agent_ready.py
@@ -1,0 +1,42 @@
+"""Shared helpers for waiting on the agent's steady-state signal (#237).
+
+The agent writes a `ready` marker (and, for atime, bumps an `atime_armed`
+generation counter) once its watchers are up and baselines are captured. Tests
+wait on these instead of racing the sub-second startup window with weak "armed?"
+gates + ad-hoc sleeps.
+"""
+import time
+from pathlib import Path
+
+
+def wait_for(cond, timeout=12.0, interval=0.05):
+    """Poll `cond` until it returns truthy or `timeout` elapses. Returns bool."""
+    end = time.time() + timeout
+    while time.time() < end:
+        if cond():
+            return True
+        time.sleep(interval)
+    return False
+
+
+def wait_ready(state_dir, timeout=12.0):
+    """Block until the agent signals steady state: watchers up and, for atime,
+    baselines captured. `state_dir` is the dir holding the agent's --state-file
+    (the agent writes `ready` there)."""
+    ready = Path(state_dir) / "ready"
+    return wait_for(ready.exists, timeout)
+
+
+def atime_armed_gen(state_dir):
+    """The atime 'armed generation' - incremented after every (re)baseline. Wait
+    for it to ADVANCE before simulating the next atime read, so the bump can't
+    land in the arm->baseline window and be captured as the baseline (#235)."""
+    try:
+        return int((Path(state_dir) / "atime_armed").read_text())
+    except (FileNotFoundError, ValueError):
+        return 0
+
+
+def wait_atime_gen(state_dir, at_least, timeout=12.0):
+    """Block until the atime armed generation reaches `at_least`."""
+    return wait_for(lambda: atime_armed_gen(state_dir) >= at_least, timeout)

--- a/tests/test_agent_atime.py
+++ b/tests/test_agent_atime.py
@@ -15,6 +15,8 @@ import time
 from pathlib import Path
 import pytest
 
+from agent_ready import wait_atime_gen, wait_ready
+
 AGENT = Path(__file__).resolve().parents[1] / "agent" / "thumper_agent.sh"
 BAIT_BODY = "AKIA-BAIT\nsecret=shhh\n"
 ARMED_MAX = (
@@ -144,9 +146,11 @@ def test_atime_sensor_is_rearmable(server, tmp_path):
     Stub.bait_path = str(bait)
     p = _spawn(server, tmp_path)
     try:
-        assert _wait(lambda: bait.exists() and _atime(bait) < ARMED_MAX), (
-            "bait not planted+armed"
-        )
+        # Wait for the atime watcher's steady-state signal (baseline captured)
+        # rather than racing the arm->baseline window with a bare "armed?" gate.
+        # The signal is emitted only AFTER the initial baseline read (#237).
+        assert wait_ready(tmp_path), "agent did not reach steady state"
+        assert bait.exists() and _atime(bait) < ARMED_MAX, "bait not planted+armed"
         # simulate read #1: bump atime forward (what a real read does under relatime)
         os.utime(bait, (time.time(), os.stat(bait).st_mtime))
         assert _wait(lambda: _atime_hits() >= 1), "read #1 was not detected"
@@ -154,11 +158,11 @@ def test_atime_sensor_is_rearmable(server, tmp_path):
         assert _wait(lambda: _atime(bait) < ARMED_MAX), (
             "bait was not re-armed after detection"
         )
-        # Let the re-arm fully settle before the next read. The agent re-arms in two
-        # steps (touch atime->past, then re-read the baseline); bumping atime in that
-        # ms-wide window would be captured AS the new baseline and missed. A real
-        # reader doesn't race the re-arm, so the test shouldn't either (one poll cycle).
-        time.sleep(2)
+        # The agent re-arms in two steps (touch atime->past, then re-read the
+        # baseline); bumping atime in that window would be captured AS the new
+        # baseline and missed. Wait for the armed generation to advance to 2 (the
+        # re-baseline after read #1) instead of a blind sleep settle (#235/#237).
+        assert wait_atime_gen(tmp_path, 2), "atime baseline was not re-captured after read #1"
         # simulate read #2
         os.utime(bait, (time.time(), os.stat(bait).st_mtime))
         assert _wait(lambda: _atime_hits() >= 2), (

--- a/tests/test_agent_ephemeral.py
+++ b/tests/test_agent_ephemeral.py
@@ -22,6 +22,8 @@ from pathlib import Path
 
 import pytest
 
+from agent_ready import wait_ready
+
 AGENT = Path(__file__).resolve().parents[1] / "agent" / "thumper_agent.sh"
 BAIT_BODY = "BAIT-honeytoken-content"
 
@@ -183,7 +185,7 @@ def test_non_ephemeral_enroll_body_has_no_ephemeral_flag(stub):
     )
 
 
-def test_ephemeral_auto_decommissions_on_terminate(stub):
+def test_ephemeral_auto_decommissions_on_terminate(stub, tmp_path):
     """In watch mode, terminating an --ephemeral agent triggers self-destruct:
     it POSTs /api/agent/decommissioned before exiting."""
     proc = stub["start"](
@@ -203,6 +205,11 @@ def test_ephemeral_auto_decommissions_on_terminate(stub):
         lambda: any("/api/agent/deployments/" in p for p in _StubHandler.seen_paths),
         timeout=10,
     ), "agent never reported plant state (bait not planted yet)"
+
+    # Wait for the watcher to reach steady state before terminating, so SIGTERM
+    # can't race startup (a serve_fifo child still coming up would hold stdout open
+    # and hang the exit / drop the decommission) - #237.
+    assert wait_ready(tmp_path / "state"), "agent did not reach steady state"
 
     before = _StubHandler.decommission_count
 

--- a/tests/test_agent_live_sync.py
+++ b/tests/test_agent_live_sync.py
@@ -16,6 +16,8 @@ from pathlib import Path
 
 import pytest
 
+from agent_ready import wait_ready
+
 AGENT = Path(__file__).resolve().parents[1] / "agent" / "thumper_agent.sh"
 BAIT_BODY = "BAIT-honeytoken-content"
 REAL_SECRET = "REAL-SECRET-DO-NOT-DELETE"
@@ -136,7 +138,8 @@ def agent(tmp_path):
     _StubHandler.fail_content = set()
     try:
         yield {"set": set_deployments, "start": start, "reset_token": reset_token,
-               "keep": keep, "drop": drop, "add": add}
+               "keep": keep, "drop": drop, "add": add,
+               "state_dir": str(tmp_path / "state")}
     finally:
         for p in procs:
             _term_group(p)
@@ -166,6 +169,9 @@ def test_live_sync_plants_added_and_removes_dropped(agent):
     # Both initial baits planted.
     assert _wait_until(lambda: Path(keep).exists() and Path(drop).exists()), \
         "initial bait not planted"
+    # Wait for the first watcher to reach steady state before perturbing the set,
+    # so the reconcile isn't racing the agent's initial startup (#237).
+    assert wait_ready(agent["state_dir"]), "agent did not reach steady state"
 
     # Server set changes: drop -> add (keep stays).
     agent["set"]([{"id": "dep_keep", "path": keep}, {"id": "dep_add", "path": add}])

--- a/tests/test_agent_mixed.py
+++ b/tests/test_agent_mixed.py
@@ -16,6 +16,8 @@ import platform as _platform
 from pathlib import Path
 import pytest
 
+from agent_ready import wait_ready
+
 pytestmark = pytest.mark.skipif(
     _platform.system() != "Darwin", reason="pair includes a FIFO bait (macOS)"
 )
@@ -137,11 +139,13 @@ def test_mixed_sensors_plant_and_fire_together(server, tmp_path):
         assert _wait(lambda: fifo.exists() and stat.S_ISFIFO(fifo.stat().st_mode)), (
             "fifo-sensor bait was not planted as a named pipe"
         )
-        assert _wait(
-            lambda: (
-                atin.exists() and atin.is_file() and atin.stat().st_atime < ARMED_MAX
-            )
-        ), "atime-sensor bait was not planted as an armed regular file"
+        assert _wait(lambda: atin.exists() and atin.is_file()), (
+            "atime-sensor bait was not planted as a regular file"
+        )
+        # Wait for steady state - FIFO writers up AND the atime baseline captured -
+        # before simulating reads, so the atime bump can't race the baseline (#237).
+        assert wait_ready(tmp_path), "agent did not reach steady state"
+        assert atin.stat().st_atime < ARMED_MAX, "atime bait was not armed"
         # read the FIFO bait (blocks until the agent serves it) -> fires with pid
         threading.Thread(target=lambda: open(fifo).read(), daemon=True).start()
         # 'read' the atime bait -> fires (detection)


### PR DESCRIPTION
## What

Closes #237. A whole class of macOS flakes this cycle shared one root cause: a test acted **immediately after a weak readiness gate** (a bare "armed?" check), racing the agent's sub-second startup — e.g. simulating an atime read before `atime_poll` had captured its baseline, so the read was captured *as* the baseline and missed.

## Agent

Each watcher now emits a single unambiguous **steady-state signal** once it's fully up — workers spawned AND (for atime) baselines captured:
- **`mark_ready()`** — writes a `ready` marker + logs `watcher ready`, from `watch_fifo` / `watch_mixed` / `atime_poll` / `watch_inotify`. This also makes the **ephemeral `ready` marker accurate in every mode** (it was previously written in the main flow right after `start_watcher` returned — *before* the backgrounded watcher had armed, which is exactly the bug).
- **`mark_armed()`** — bumps an `atime_armed` generation after *each* baseline (re)capture, so a test can wait past a specific re-arm instead of a blind `sleep` (the arm→baseline window is a genuine race, #235).

## Tests

A shared helper (`tests/agent_ready.py`: `wait_ready` / `wait_atime_gen`) replaces the ad-hoc "armed?" gates + `sleep(2)` settles in the four flaky tests: atime rearm, mixed plant+fire, ephemeral terminate, live-sync reconcile.

## Verification

- `test_atime_sensor_is_rearmable`: **0/15** flaky before under local stress → **15/15** after.
- All four migrated tests: **10/10** stress rounds (40 runs) clean.
- Full suite **375 passed, 1 skipped**; ruff + shellcheck clean.
- Real-endpoint behavior unchanged — a real reader hits a steady-state agent, never this startup window.

This should end the recurring macOS flake that has repeatedly blocked merges this cycle (it forced re-runs on #268, #272, #258, and others).

🤖 Generated with [Claude Code](https://claude.com/claude-code)