### PR TITLE
docs: fix the two dead links in the README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   The tokens authenticate to nothing. A <b><em>read</em></b> is the signal.
   </p>
   <p align="center">
-  <a href="https://jesta.ai/thumper">Website</a>
+  <a href="https://jesta.ai">Website</a>
   &nbsp;·&nbsp;
   <a href="https://docs.jesta.ai"><strong>Docs</strong></a>
   &nbsp;·&nbsp;

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <p align="center">
   <a href="https://jesta.ai/thumper">Website</a>
   &nbsp;·&nbsp;
-  <a href="https://jesta.ai/docs"><strong>Docs</strong></a>
+  <a href="https://docs.jesta.ai"><strong>Docs</strong></a>
   &nbsp;·&nbsp;
   <a href="docs/architecture.md">Get started »</a>
 </p>


### PR DESCRIPTION
Both links in the README header returned **404**. This fixes both.

```diff
-  <a href="https://jesta.ai/thumper">Website</a>
+  <a href="https://jesta.ai">Website</a>
   &nbsp;·&nbsp;
-  <a href="https://jesta.ai/docs"><strong>Docs</strong></a>
+  <a href="https://docs.jesta.ai"><strong>Docs</strong></a>
```

### Why they broke

- **Docs** — the docs moved off the `jesta.ai/docs` subpath onto their own subdomain, and the Cloudflare Worker that served the old path was deleted.
- **Website** — the landing site defines only `/`, `/blog`, and `/blog/:slug`, with a catch-all rendering `NotFound`. There is no `/thumper` route, so it fell through to the 404.

### Verified live

| URL | Before | After |
|---|---|---|
| `https://jesta.ai/thumper` → `https://jesta.ai` | 404 | **200** |
| `https://jesta.ai/docs` → `https://docs.jesta.ai` | 404 | **200** |

Every `jesta.ai` URL in the README now resolves. The remaining `docs/...` links (`docs/architecture.md`, `docs/plugins.md`) point at in-repo files and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)